### PR TITLE
Fixing potential RPMsg bug: rpmsg_endpoint structure is not cleared when...

### DIFF
--- a/rpmsg/rpmsg_core.c
+++ b/rpmsg/rpmsg_core.c
@@ -216,6 +216,7 @@ struct rpmsg_endpoint *_create_endpoint(struct remote_device *rdev,
     if (!rp_ept) {
         return RPMSG_NULL ;
     }
+    env_memset(rp_ept, 0x00, sizeof(struct rpmsg_endpoint));
 
     node = env_allocate_memory(sizeof(struct llist));
     if (!node) {


### PR DESCRIPTION
... dynamically created

- this causes the hardfault @line 570 when rp_chnl is not a null pointer (writing to undefined dereferenced address)