### PR TITLE
Use stdint.h instead of private definition

### DIFF
--- a/rpmsg/remote_device.c
+++ b/rpmsg/remote_device.c
@@ -484,16 +484,16 @@ void rpmsg_rdev_set_status(struct virtio_device *dev, unsigned char status) {
 
 }
 
-unsigned long rpmsg_rdev_get_feature(struct virtio_device *dev) {
+uint32_t rpmsg_rdev_get_feature(struct virtio_device *dev) {
     return dev->features;
 }
 
-void rpmsg_rdev_set_feature(struct virtio_device *dev, unsigned long feature) {
+void rpmsg_rdev_set_feature(struct virtio_device *dev, uint32_t feature) {
     dev->features |= feature;
 }
 
-unsigned long rpmsg_rdev_negotiate_feature(struct virtio_device *dev,
-                unsigned long features) {
+uint32_t rpmsg_rdev_negotiate_feature(struct virtio_device *dev,
+                uint32_t features) {
     return 0;
 }
 /*
@@ -501,11 +501,11 @@ unsigned long rpmsg_rdev_negotiate_feature(struct virtio_device *dev,
  * configuration region. This region is encoded in the same endian as
  * the guest.
  */
-void rpmsg_rdev_read_config(struct virtio_device *dev, unsigned long offset,
+void rpmsg_rdev_read_config(struct virtio_device *dev, uint32_t offset,
                 void *dst, int length) {
     return;
 }
-void rpmsg_rdev_write_config(struct virtio_device *dev, unsigned long offset,
+void rpmsg_rdev_write_config(struct virtio_device *dev, uint32_t offset,
                 void *src, int length) {
     return;
 }

--- a/rpmsg/rpmsg.c
+++ b/rpmsg/rpmsg.c
@@ -139,7 +139,7 @@ int rpmsg_send_offchannel_raw(struct rpmsg_channel *rp_chnl, unsigned long src,
     int status = RPMSG_SUCCESS;
     unsigned short idx;
     int tick_count = 0;
-    int buff_len;
+    unsigned long buff_len;
 
     if (!rp_chnl) {
         return RPMSG_ERR_PARAM;

--- a/rpmsg/rpmsg_core.c
+++ b/rpmsg/rpmsg_core.c
@@ -304,7 +304,7 @@ void rpmsg_send_ns_message(struct remote_device *rdev,
     struct rpmsg_hdr *rp_hdr;
     struct rpmsg_ns_msg *ns_msg;
     unsigned short idx;
-    int len;
+    unsigned long len;
 
     env_lock_mutex(rdev->lock);
 
@@ -402,19 +402,18 @@ void rpmsg_return_buffer(struct remote_device *rdev, void *buffer,
  *
  * return - pointer to buffer.
  */
-void *rpmsg_get_tx_buffer(struct remote_device *rdev, int *len,
+void *rpmsg_get_tx_buffer(struct remote_device *rdev, unsigned long *len,
                 unsigned short *idx) {
     void *data;
 
     if (rdev->role == RPMSG_REMOTE) {
-        data = virtqueue_get_buffer(rdev->tvq, (unsigned long *) len);
+        data = virtqueue_get_buffer(rdev->tvq, (uint32_t *)len);
         if (data == RPMSG_NULL) {
             data = sh_mem_get_buffer(rdev->mem_pool);
             *len = RPMSG_BUFFER_SIZE;
         }
     } else {
-        data = virtqueue_get_available_buffer(rdev->tvq, idx,
-                        (unsigned long *) len);
+        data = virtqueue_get_available_buffer(rdev->tvq, idx, (uint32_t *)len);
     }
     return ((void *) env_map_vatopa(data));
 }
@@ -436,9 +435,9 @@ void *rpmsg_get_rx_buffer(struct remote_device *rdev, unsigned long *len,
 
     void *data;
     if (rdev->role == RPMSG_REMOTE) {
-        data = virtqueue_get_buffer(rdev->rvq, len);
+        data = virtqueue_get_buffer(rdev->rvq, (uint32_t *)len);
     } else {
-        data = virtqueue_get_available_buffer(rdev->rvq, idx, len);
+        data = virtqueue_get_available_buffer(rdev->rvq, idx, (uint32_t *)len);
     }
     return ((void *) env_map_vatopa(data));
 }

--- a/rpmsg/rpmsg_core.h
+++ b/rpmsg/rpmsg_core.h
@@ -136,7 +136,7 @@ int rpmsg_enqueue_buffer(struct remote_device *rdev, void *buffer,
                 unsigned long len, unsigned short idx);
 void rpmsg_return_buffer(struct remote_device *rdev, void *buffer,
                 unsigned long len, unsigned short idx);
-void *rpmsg_get_tx_buffer(struct remote_device *rdev, int *len,
+void *rpmsg_get_tx_buffer(struct remote_device *rdev, unsigned long *len,
                 unsigned short *idx);
 void rpmsg_free_buffer(struct remote_device *rdev, void *buffer);
 void rpmsg_free_channel(struct rpmsg_channel* rp_chnl);
@@ -170,20 +170,20 @@ unsigned char rpmsg_rdev_get_status(struct virtio_device *dev);
 
 void rpmsg_rdev_set_status(struct virtio_device *dev, unsigned char status);
 
-unsigned long rpmsg_rdev_get_feature(struct virtio_device *dev);
+uint32_t rpmsg_rdev_get_feature(struct virtio_device *dev);
 
-void rpmsg_rdev_set_feature(struct virtio_device *dev, unsigned long feature);
+void rpmsg_rdev_set_feature(struct virtio_device *dev, uint32_t feature);
 
-unsigned long rpmsg_rdev_negotiate_feature(struct virtio_device *dev,
-                unsigned long features);
+uint32_t rpmsg_rdev_negotiate_feature(struct virtio_device *dev,
+                uint32_t features);
 /*
  * Read/write a variable amount from the device specific (ie, network)
  * configuration region. This region is encoded in the same endian as
  * the guest.
  */
-void rpmsg_rdev_read_config(struct virtio_device *dev, unsigned long offset,
+void rpmsg_rdev_read_config(struct virtio_device *dev, uint32_t offset,
                 void *dst, int length);
-void rpmsg_rdev_write_config(struct virtio_device *dev, unsigned long offset,
+void rpmsg_rdev_write_config(struct virtio_device *dev, uint32_t offset,
                 void *src, int length);
 void rpmsg_rdev_reset(struct virtio_device *dev);
 

--- a/virtio/virtqueue.c
+++ b/virtio/virtqueue.c
@@ -195,7 +195,7 @@ int virtqueue_add_buffer(struct virtqueue *vq, struct llist *buffer,
  * @return                      - Function status
  */
 int virtqueue_add_single_buffer(struct virtqueue *vq, void *cookie,
-        void *buffer_addr, uint_t len, int writable, boolean has_next) {
+        void *buffer_addr, uint32_t len, int writable, boolean has_next) {
 
     struct vq_desc_extra *dxp;
     struct vring_desc *dp;
@@ -353,7 +353,7 @@ void *virtqueue_get_available_buffer(struct virtqueue *vq, uint16_t *avail_idx,
  * @return                       - Function status
  */
 int virtqueue_add_consumed_buffer(struct virtqueue *vq, uint16_t head_idx,
-        uint_t len) {
+        uint32_t len) {
 
     struct vring_used_elem *used_desc = VQ_NULL;
     uint16_t used_idx;

--- a/virtio/virtqueue.h
+++ b/virtio/virtqueue.h
@@ -29,15 +29,8 @@
  * $FreeBSD$
  */
 
-typedef         unsigned int                        uint_t;
-typedef         signed char                         int8_t;
-typedef         unsigned char                       uint8_t;
+#include <stdint.h>
 typedef         uint8_t                             boolean;
-typedef         signed short                        int16_t;
-typedef         unsigned short                      uint16_t;
-typedef         unsigned long                       uint32_t;
-typedef         unsigned long long                  uint64_t;
-typedef         signed long long                    int64_t;
 
 #include "virtio_ring.h"
 #include "../porting/env/env.h"
@@ -206,7 +199,7 @@ int virtqueue_add_buffer(struct virtqueue *vq, struct llist *buffer,
         int readable, int writable, void *cookie);
 
 int virtqueue_add_single_buffer(struct virtqueue *vq, void *cookie,
-        void* buffer_addr, uint_t len, int writable, boolean has_next);
+        void* buffer_addr, uint32_t len, int writable, boolean has_next);
 
 void *virtqueue_get_buffer(struct virtqueue *vq, uint32_t *len);
 
@@ -214,7 +207,7 @@ void *virtqueue_get_available_buffer(struct virtqueue *vq, uint16_t *avail_idx,
         uint32_t *len);
 
 int virtqueue_add_consumed_buffer(struct virtqueue *vq, uint16_t head_idx,
-        uint_t len);
+        uint32_t len);
 
 void virtqueue_disable_cb(struct virtqueue *vq);
 


### PR DESCRIPTION
This patch helps to avoid duplicated type definition issue when the
application uses stdint.h.
At the same time, buffer length type is uniformed.

Signed-off-by: Feng Wei <wei.feng@freescale.com>