### PR TITLE
Avoid using zero length arrays in sh_mem_pool structure

### DIFF
--- a/lib/common/sh_mem.c
+++ b/lib/common/sh_mem.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Mentor Graphics Corporation
  * All rights reserved.
+ * Copyright (c) 2016 NXP Semiconductor, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -131,10 +132,10 @@ void *sh_mem_get_buffer(struct sh_mem_pool *pool)
 		 * Find the first 0 bit in the buffers bitmap. The 0th bit
 		 * represents a free buffer.
 		 */
-		bit_idx = get_first_zero_bit(pool->bitmap[idx]);
+		bit_idx = get_first_zero_bit(*(unsigned long*)SH_MEM_POOL_LOCATE_BITMAP(pool,idx));
 		if (bit_idx < 32) {
 			/* Set bit to mark it as consumed. */
-			pool->bitmap[idx] |= (1 << bit_idx);
+			*(unsigned long*)(SH_MEM_POOL_LOCATE_BITMAP(pool,idx)) |= (1 << bit_idx);
 			buff = (char *)pool->start_addr +
 			    pool->buff_size * (idx * BITMAP_WORD_SIZE +
 					       bit_idx);
@@ -175,7 +176,7 @@ void sh_mem_free_buffer(void *buff, struct sh_mem_pool *pool)
 	/* Translate the buffer index to bitmap index. */
 	bmp_idx = buff_idx / BITMAP_WORD_SIZE;
 	bit_idx = buff_idx % BITMAP_WORD_SIZE;
-	bitmask = &pool->bitmap[bmp_idx];
+	bitmask = (unsigned long*)(SH_MEM_POOL_LOCATE_BITMAP(pool, bmp_idx));
 
 	/* Mark the buffer as free */
 	*bitmask ^= (1 << bit_idx);

--- a/lib/include/openamp/sh_mem.h
+++ b/lib/include/openamp/sh_mem.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Mentor Graphics Corporation
  * All rights reserved.
+ * Copyright (c) 2016 NXP Semiconductor, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -52,6 +53,10 @@
 #define WORD_SIZE                sizeof(unsigned long)
 #define WORD_ALIGN(a)            (((a) & (WORD_SIZE-1)) != 0)? \
                                  (((a) & (~(WORD_SIZE-1))) + 4):(a)
+#define SH_MEM_POOL_LOCATE_BITMAP(pool,idx) ((unsigned char *) pool \
+                                             + sizeof(struct sh_mem_pool) \
+                                             + (BITMAP_WORD_SIZE * idx))
+
 /*
  * This structure represents a  shared memory pool.
  *
@@ -62,7 +67,6 @@
  * @total_buffs     - total number of buffers in shared memory region
  * @used_buffs      - number of used buffers
  * @bmp_size        - size of bitmap array
- * @bitmap          - array to keep record of free and used blocks
  *
  */
 
@@ -74,7 +78,6 @@ struct sh_mem_pool {
 	int total_buffs;
 	int used_buffs;
 	int bmp_size;
-	unsigned long bitmap[0];
 };
 
 /* APIs */


### PR DESCRIPTION
This is another step how to avoid using zero length arrays in structures, as discussed in https://github.com/OpenAMP/open-amp/pull/9 (flexible array members are not allowed in C++).

bitmap member of the sh_mem_pool struct has been removed and each time the pointer to the bitmap is necessary in the code it is calculated using the SH_MEM_POOL_LOCATE_BITMAP macro
