### PR TITLE
zynq7: replace direct reg access by Xilinx funcs

### DIFF
--- a/lib/include/openamp/machine/zynq7/machine.h
+++ b/lib/include/openamp/machine/zynq7/machine.h
@@ -34,4 +34,91 @@
 
 #include "openamp/machine/machine_common.h"
 
+/* Define bit values for the architecture's status register / machine state register /
+ etc that are used to enable and disable interrupts for the given architecture. */
+#define         ARM_AR_INTERRUPTS_DISABLE_BITS         0x000000C0
+#define         ARM_AR_INTERRUPTS_ENABLE_BITS          0x00000000
+
+/* This macro reads the current program status register (CPSR - all fields) */
+#define         ARM_AR_CPSR_CXSF_READ(cpsr_cxsf_ptr)                                   \
+                {                                                                      \
+                    asm volatile("    MRS     %0, CPSR"                                \
+                                     : "=r" (*(cpsr_cxsf_ptr))                         \
+                                     : /* No inputs */ );                              \
+                }
+
+/* This macro writes the current program status register (CPSR - all fields) */
+#define         ARM_AR_CPSR_CXSF_WRITE(cpsr_cxsf_value)                                \
+                {                                                                      \
+                    asm volatile("    MSR     CPSR_cxsf, %0"                           \
+                                     : /* No outputs */                                \
+                                     : "r" (cpsr_cxsf_value) );                        \
+                }
+
+/* This macro sets the interrupt related bits in the status register / control
+ register to the specified value. */
+#define         ARM_AR_INT_BITS_SET(set_bits)                                 	 \
+                {                                                              	 \
+                    int     tmp_val;                                           	 \
+                                                                                 \
+                    ARM_AR_CPSR_CXSF_READ(&tmp_val);                       		 \
+                    tmp_val &= ~ARM_AR_INTERRUPTS_DISABLE_BITS;                  \
+                    tmp_val |= set_bits;                                         \
+                    ARM_AR_CPSR_CXSF_WRITE(tmp_val);                             \
+                }
+
+/* This macro gets the interrupt related bits from the status register / control
+ register. */
+#define         ARM_AR_INT_BITS_GET(get_bits_ptr)                              \
+                {                                                               \
+                    int     tmp_val;                                            \
+                                                                                \
+                    ARM_AR_CPSR_CXSF_READ(&tmp_val);                       \
+                    tmp_val &= ARM_AR_INTERRUPTS_DISABLE_BITS;                 \
+                    *get_bits_ptr = tmp_val;                                    \
+                }
+
+/* Macro used to make a 32-bit value with the specified bit set */
+#define             ESAL_GE_MEM_32BIT_SET(bit_num)      (1UL<<(bit_num))
+
+/* Macro used to make a 32-bit value with the specified bit clear */
+#define             ESAL_GE_MEM_32BIT_CLEAR(bit_num)    ~(1UL<<(bit_num))
+
+/* Translation table is 16K in size */
+#define     ARM_AR_MEM_TTB_SIZE                    16*1024
+
+/* Each TTB descriptor covers a 1MB region */
+#define     ARM_AR_MEM_TTB_SECT_SIZE               1024*1024
+
+/* Mask off lower bits of addr */
+#define     ARM_AR_MEM_TTB_SECT_SIZE_MASK          (~(ARM_AR_MEM_TTB_SECT_SIZE-1UL))
+
+/* Define shift to convert memory address to index of translation table entry (descriptor).
+ Shift 20 bits (for a 1MB section) - 2 bits (for a 4 byte TTB descriptor) */
+#define     ARM_AR_MEM_TTB_SECT_TO_DESC_SHIFT      (20-2)
+
+/* Define domain access values */
+#define     ARM_AR_MEM_DOMAIN_D0_MANAGER_ACCESS    0x3
+
+#define     ARM_AR_MEM_TTB_DESC_BACKWARDS          ESAL_GE_MEM_32BIT_SET(4)
+#define     ARM_AR_MEM_TTB_DESC_AP_MANAGER        (ESAL_GE_MEM_32BIT_SET(10)        |          \
+                                                    ESAL_GE_MEM_32BIT_SET(11))
+#define     ARM_AR_MEM_TTB_DESC_SECT               ESAL_GE_MEM_32BIT_SET(1)
+
+/* Define translation table descriptor bits */
+#define     ARM_AR_MEM_TTB_DESC_B                  ESAL_GE_MEM_32BIT_SET(2)
+#define     ARM_AR_MEM_TTB_DESC_C                  ESAL_GE_MEM_32BIT_SET(3)
+#define     ARM_AR_MEM_TTB_DESC_TEX                ESAL_GE_MEM_32BIT_SET(12)
+#define     ARM_AR_MEM_TTB_DESC_S                  ESAL_GE_MEM_32BIT_SET(16)
+
+/* Define all access  (manager access permission / not cachable / not bufferd)  */
+#define     ARM_AR_MEM_TTB_DESC_ALL_ACCESS         (ARM_AR_MEM_TTB_DESC_AP_MANAGER |          \
+                                                     ARM_AR_MEM_TTB_DESC_SECT)
+
+typedef enum {
+    NOCACHE,
+    WRITEBACK,
+    WRITETHROUGH
+} CACHE_TYPE;
+
 #endif				/* _MACHINE_H */

--- a/lib/system/generic/machine/zynq7/machine_system.c
+++ b/lib/system/generic/machine/zynq7/machine_system.c
@@ -28,12 +28,15 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <stdio.h>
-#include <string.h>
-#include "baremetal.h"
+#include "machine.h"
 #include "machine_system.h"
 #include "openamp/env.h"
 #include "openamp/hil.h"
+#include "xscugic.h"
+#include "xil_cache_l.h"
+#include "xil_mmu.h"
+
+
 
 static inline unsigned int get_cpu_id_arm(void)
 {
@@ -52,100 +55,33 @@ static inline unsigned int get_cpu_id_arm(void)
 int platform_interrupt_enable(unsigned int vector_id, unsigned int polarity,
 			      unsigned int priority)
 {
-	unsigned long reg_offset;
 	unsigned long bit_shift;
 	unsigned long temp32 = 0;
-	unsigned long targ_cpu;
 
-	temp32 = get_cpu_id_arm();
+	(void)polarity;
 
 	/* Determine the necessary bit shift in this target / priority register
-	   for this interrupt vector ID */
+	  for this interrupt vector ID */
 	bit_shift = ((vector_id) % 4) * 8;
 
-	/* Build a target value based on the bit shift calculated above and the CPU core
-	   that this code is executing on */
-	targ_cpu = (1 << temp32) << bit_shift;
-
-	/* Determine the Global interrupt controller target / priority register
-	   offset for this interrupt vector ID
-	   NOTE:  Each target / priority register supports 4 interrupts */
-	reg_offset = ((vector_id) / 4) * 4;
-
 	/* Read-modify-write the priority register for this interrupt */
-	temp32 = MEM_READ32(INT_GIC_DIST_BASE + INT_GIC_DIST_PRI + reg_offset);
+	temp32 = XScuGic_ReadReg(XPAR_SCUGIC_0_DIST_BASEADDR, XSCUGIC_PRIORITY_OFFSET_CALC(vector_id));
 
 	/* Set new priority. */
 	temp32 |= (priority << (bit_shift + 4));
-	MEM_WRITE32(INT_GIC_DIST_BASE + INT_GIC_DIST_PRI + reg_offset, temp32);
-
-	/* Read-modify-write the target register for this interrupt to allow this
-	   cpu to accept this interrupt */
-	temp32 =
-	    MEM_READ32(INT_GIC_DIST_BASE + INT_GIC_DIST_TARGET + reg_offset);
-	temp32 |= targ_cpu;
-	MEM_WRITE32(INT_GIC_DIST_BASE + INT_GIC_DIST_TARGET + reg_offset,
-		    temp32);
-
-	/* Determine the Global interrupt controller enable set register offset
-	   for this vector ID
-	   NOTE:  There are 32 interrupts in each enable set register */
-	reg_offset = (vector_id / 32) * 4;
+	XScuGic_WriteReg(XPAR_SCUGIC_0_DIST_BASEADDR, XSCUGIC_PRIORITY_OFFSET_CALC(vector_id), temp32);
 
 	/* Write to the appropriate bit in the enable set register for this
-	   vector ID to enable the interrupt */
+	 vector ID to enable the interrupt */
 
-	temp32 = (1UL << (vector_id - (reg_offset * 0x08)));
-	MEM_WRITE32(INT_GIC_DIST_BASE + INT_GIC_DIST_ENABLE_SET + reg_offset,
-		    temp32);
-
+	XScuGic_EnableIntr(XPAR_SCUGIC_0_DIST_BASEADDR, vector_id);
 	/* Return the vector ID */
 	return (vector_id);
 }
 
 int platform_interrupt_disable(unsigned int vector_id)
 {
-	unsigned long reg_offset;
-	unsigned long bit_shift;
-	unsigned long temp32 = 0;
-	unsigned long targ_cpu;
-
-	temp32 = get_cpu_id_arm();
-
-	/* Determine the Global interrupt controller enable set register offset
-	   for this vector ID
-	   NOTE:  There are 32 interrupts in each enable set register */
-	reg_offset = (vector_id / 32) * 4;
-
-	/* Write to the appropriate bit in the enable clear register for this
-	   vector ID to disable the interrupt */
-
-	MEM_WRITE32(INT_GIC_DIST_BASE + INT_GIC_DIST_ENABLE_CLEAR + reg_offset,
-		    (1UL << (vector_id - (reg_offset * 0x08))));
-
-	/* Determine the Global interrupt controller target register offset for
-	   this interrupt vector ID
-	   NOTE:  Each target register supports 4 interrupts */
-	reg_offset = (vector_id / 4) * 4;
-
-	/* Determine the necessary bit shift in this target register for this
-	   vector ID */
-	bit_shift = (vector_id % 4) * 8;
-
-	/* Build a value based on the bit shift calculated above and the CPU core
-	   that this code is executing on */
-	targ_cpu = (1 << temp32) << bit_shift;
-
-	/* Read-modify-write the target register for this interrupt and remove this cpu from
-	   accepting this interrupt */
-	temp32 =
-	    MEM_READ32(INT_GIC_DIST_BASE + INT_GIC_DIST_TARGET + reg_offset);
-	temp32 &= ~targ_cpu;
-
-	MEM_WRITE32(INT_GIC_DIST_BASE + INT_GIC_DIST_TARGET + reg_offset,
-		    temp32);
-
-	/* Return the vector ID */
+	XScuGic_DisableIntr(XPAR_SCUGIC_0_DIST_BASEADDR, vector_id);
 	return (vector_id);
 }
 
@@ -164,6 +100,60 @@ void disable_global_interrupts()
 		ARM_AR_INT_BITS_SET(ARM_AR_INTERRUPTS_DISABLE_BITS);
 		old_value = value;
 	}
+}
+
+/***********************************************************************
+ *
+ *
+ * arm_ar_map_mem_region
+ *
+ *
+ * This function sets-up the region of memory based on the given
+ * attributes
+ *
+ * @param vrt_addr       - virtual address of region
+ * @param phy_addr       - physical address of region
+ * @parma size           - size of region
+ * @param is_mem_mapped  - memory mapped or not
+ * @param cache_type     - cache type of region
+ *
+ *
+ *   OUTPUTS
+ *
+ *       None
+ *
+ ***********************************************************************/
+void arm_ar_map_mem_region(unsigned int vrt_addr, unsigned int phy_addr,
+			   unsigned int size, int is_mem_mapped,
+			   CACHE_TYPE cache_type)
+{
+	unsigned int ttb_value;
+	phy_addr &= ARM_AR_MEM_TTB_SECT_SIZE_MASK;
+	vrt_addr &= ARM_AR_MEM_TTB_SECT_SIZE_MASK;
+	ttb_value = ARM_AR_MEM_TTB_DESC_ALL_ACCESS;
+
+	(void)size;
+
+	if (!is_mem_mapped) {
+
+		/* Set cache related bits in translation table entry.
+		 NOTE: Default is uncached instruction and data. */
+		if (cache_type == WRITEBACK) {
+			/* Update translation table entry value */
+			ttb_value |= (ARM_AR_MEM_TTB_DESC_B | ARM_AR_MEM_TTB_DESC_C);
+		} else if (cache_type == WRITETHROUGH) {
+			/* Update translation table entry value */
+			ttb_value |= ARM_AR_MEM_TTB_DESC_C;
+		}
+		/* In case of un-cached memory, set TEX 0 bit to set memory
+		 attribute to normal. */
+		else if (cache_type == NOCACHE) {
+			ttb_value |= ARM_AR_MEM_TTB_DESC_TEX;
+		}
+	}
+
+	Xil_SetTlbAttributes(phy_addr,ttb_value);
+
 }
 
 void platform_map_mem_region(unsigned int vrt_addr, unsigned int phy_addr,
@@ -188,14 +178,14 @@ void platform_map_mem_region(unsigned int vrt_addr, unsigned int phy_addr,
 			      cache_type);
 }
 
-void platform_cache_all_flush_invalidate()
+void platform_cache_all_flush_invalidate(void)
 {
-	ARM_AR_MEM_DCACHE_ALL_OP(1);
+	Xil_L1DCacheFlush();
 }
 
-void platform_cache_disable()
+void platform_cache_disable(void)
 {
-	ARM_AR_MEM_CACHE_DISABLE();
+	Xil_L1DCacheDisable();
 }
 
 unsigned long platform_vatopa(void *addr)
@@ -214,5 +204,3 @@ void platform_isr(int vect_id, void * data)
     (void)vect_id;
     hil_isr(((struct proc_vring *)data));
 }
-
-


### PR DESCRIPTION
zynq7: replace GIC and Cache register level access function by Xilinx library function calls
Also remove the reference to the obsolete directory due to 
  #include "baremetal.h" 
and requires the following external includes, associated to external Xilinx libs to be found: 
  #include "xscugic.h", 
  #include "xil_cache_l.h"
  #include "xil_mmu.h"
