### PR TITLE
Compile Zynq A9 path changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The OpenAMP library will be generated to `build/usr/local/lib` directory, header
 ```
 $ mkdir build
 $ cd build/
-$ cmake ../open-amp -DCMAKE_TOOLCHAIN_FILE=zynq7_generic -DWITH_OBSOLETE=on -DWITH_APPS=ON
+$ cmake ../../open-amp -DCMAKE_TOOLCHAIN_FILE=zynq7_generic -DWITH_OBSOLETE=on -DWITH_APPS=ON
 $ make DESTDIR=$(pwd) install
 ```
 


### PR DESCRIPTION
The source directory is not correctly mapped in compiling.
it is
cmake ../../open-amp -DCMAKE_TOOLCHAIN_FILE=zynq7_generic -DWITH_OBSOLETE=on -DWITH_APPS=ON