### PR TITLE
Fixed cast to (void *) preventing error free compilation with g++

### DIFF
--- a/lib/include/openamp/virtio_ring.h
+++ b/lib/include/openamp/virtio_ring.h
@@ -142,7 +142,7 @@ vring_init(struct vring *vr, unsigned int num, uint8_t * p, unsigned long align)
 	vr->num = num;
 	vr->desc = (struct vring_desc *)p;
 	vr->avail = (struct vring_avail *)(p + num * sizeof(struct vring_desc));
-	vr->used = (void *)
+	vr->used = (struct vring_used *)
 	    (((unsigned long)&vr->avail->ring[num] + align - 1) & ~(align - 1));
 }
 


### PR DESCRIPTION
While compilling OpenAMP with a c++ compiler, I encountered an Error originating from the original (void *) cast.