### PR TITLE
Irq rework

### DIFF
--- a/cmake/platforms/zynqmp_linux.cmake
+++ b/cmake/platforms/zynqmp_linux.cmake
@@ -1,7 +1,7 @@
 set (CMAKE_SYSTEM_PROCESSOR "arm64")
 set (CROSS_PREFIX           "aarch64-linux-gnu-")
-set (MACHINE                "zynqmp_a53" CACHE STRING "")
+set (MACHINE                "zynqmp" CACHE STRING "")
 
-include (cross-linux-gcc)
+include (cross_linux_gcc)
 
 # vim: expandtab:ts=2:sw=2:smartindent

--- a/cmake/platforms/zynqmp_r5_generic.cmake
+++ b/cmake/platforms/zynqmp_r5_generic.cmake
@@ -1,7 +1,9 @@
 set (CMAKE_SYSTEM_PROCESSOR "arm" CACHE STRING "")
 set (MACHINE                "zynqmp_r5" CACHE STRING "")
 set (CROSS_PREFIX           "armr5-none-eabi-" CACHE STRING "")
-set (CMAKE_C_FLAGS          "-mfloat-abi=soft -mcpu=cortex-r5" CACHE STRING "")
+
+# Xilinx SDK version earlier than 2017.2 use mfloat-abi=soft by default to generat libxil
+set (CMAKE_C_FLAGS          "-mfloat-abi=hard -mfpu=vfpv3-d16 -mcpu=cortex-r5" CACHE STRING "")
 
 include (cross_generic_gcc)
 

--- a/lib/remoteproc/drivers/linux_remoteproc.c
+++ b/lib/remoteproc/drivers/linux_remoteproc.c
@@ -358,7 +358,7 @@ static void _release(struct hil_proc *proc)
 			ipi = (struct vring_ipi_info *)vring->intr_info.data;
 			if (ipi) {
 				if (ipi->fd >= 0) {
-					metal_irq_register(ipi->fd, 0, NULL,
+					metal_irq_unregister(ipi->fd, 0, NULL,
 						vring);
 					close(ipi->fd);
 				}

--- a/lib/remoteproc/drivers/zynqmp_remoteproc_r5.c
+++ b/lib/remoteproc/drivers/zynqmp_remoteproc_r5.c
@@ -187,7 +187,6 @@ static int _initialize(struct hil_proc *proc)
 	struct proc_intr *intr_info;
 	struct ipi_info *ipi;
 	unsigned int ipi_intr_status;
-	int i;
 
 	if (!proc)
 		return -1;
@@ -234,7 +233,6 @@ error:
 
 static void _release(struct hil_proc *proc)
 {
-	int i;
 	struct proc_intr *intr_info;
 	struct ipi_info *ipi;
 


### PR DESCRIPTION
 -update to match libmetal IRQ API change
 -fix some typo in toolchain file
 -remove unused variables
 -change r5-generic toolchain file to use hard fp to match default latest Xilinx SDK setting