### PR TITLE
Enable  to build OpenAMP library for Zephyr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,7 @@ list (APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/cmake/modules"
   "${CMAKE_SOURCE_DIR}/cmake/platforms")
 
-project (open_amp)
-enable_language(C ASM)
+project (open_amp C)
 
 include (CheckIncludeFiles)
 include (CheckCSourceCompiles)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ list (APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/cmake/modules"
   "${CMAKE_SOURCE_DIR}/cmake/platforms")
 
+include (syscheck)
 project (open_amp C)
 
 include (CheckIncludeFiles)

--- a/cmake/depends.cmake
+++ b/cmake/depends.cmake
@@ -7,11 +7,17 @@ endif (WITH_LIBMETAL_FIND)
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   check_include_files (stdatomic.h HAVE_STDATOMIC_H)
-
+  check_include_files (fcntl.h HAVE_FCNTL_H)
 else ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   set (_saved_cmake_required_flags ${CMAKE_REQUIRED_FLAGS})
   set (CMAKE_REQUIRED_FLAGS "-c")
   check_include_files (stdatomic.h HAVE_STDATOMIC_H)
+  check_include_files (fcntl.h HAVE_FCNTL_H)
   set (CMAKE_REQUIRED_FLAGS ${_saved_cmake_required_flags})
 endif ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+
+if (NOT HAVE_FCNTL_H)
+  unset (WITH_PROXY CACHE)
+endif (NOT HAVE_FCNTL_H)
+
 # vim: expandtab:ts=2:sw=2:smartindent

--- a/cmake/syscheck.cmake
+++ b/cmake/syscheck.cmake
@@ -1,0 +1,12 @@
+# use "Generic" as CMAKE_SYSTEM_NAME
+
+if (WITH_ZEPHYR)
+  set (CMAKE_SYSTEM_NAME "Generic"        CACHE STRING "")
+  string (TOLOWER "Zephyr"                PROJECT_SYSTEM)
+  string (TOUPPER "Zephyr"                PROJECT_SYSTEM_UPPER)
+  set(IS_TEST 1)
+  include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+  if (CONFIG_CPU_CORTEX_M)
+    set (MACHINE "cortexm" CACHE STRING "")
+  endif (CONFIG_CPU_CORTEX_M)
+endif (WITH_ZEPHYR)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -33,26 +33,32 @@ set_property (SOURCE ${_sources}
   APPEND_STRING PROPERTY COMPILE_FLAGS " ${_ecflags}")
 
 # Build a shared library if so configured.
-if (WITH_SHARED_LIB)
-  set (_lib ${OPENAMP_LIB}-shared)
-  add_library (${_lib} SHARED ${_sources})
-  target_link_libraries (${_lib} ${_deps})
-  install (TARGETS ${_lib} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  set_target_properties (${_lib} PROPERTIES
-    OUTPUT_NAME       "${OPENAMP_LIB}"
-    VERSION           "${PROJECT_VER}"
-    SOVERSION         "${PROJECT_VER_MAJOR}"
-  )
-endif (WITH_SHARED_LIB)
+if (WITH_ZEPHYR)
+  zephyr_library_named(${OPENAMP_LIB})
+  add_dependencies(${OPENAMP_LIB} offsets_h)
+  target_sources (${OPENAMP_LIB} PRIVATE ${_sources})
+else (WITH_ZEPHYR)
+  if (WITH_SHARED_LIB)
+    set (_lib ${OPENAMP_LIB}-shared)
+    add_library (${_lib} SHARED ${_sources})
+    target_link_libraries (${_lib} ${_deps})
+    install (TARGETS ${_lib} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    set_target_properties (${_lib} PROPERTIES
+      OUTPUT_NAME       "${OPENAMP_LIB}"
+      VERSION           "${PROJECT_VER}"
+      SOVERSION         "${PROJECT_VER_MAJOR}"
+    )
+  endif (WITH_SHARED_LIB)
 
-if (WITH_STATIC_LIB)
-  set (_lib ${OPENAMP_LIB}-static)
-  add_library (${_lib} STATIC ${_sources})
-  install (TARGETS ${_lib} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  set_target_properties (${_lib} PROPERTIES
-    OUTPUT_NAME       "${OPENAMP_LIB}"
-  )
-endif (WITH_STATIC_LIB)
+  if (WITH_STATIC_LIB)
+    set (_lib ${OPENAMP_LIB}-static)
+    add_library (${_lib} STATIC ${_sources})
+    install (TARGETS ${_lib} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    set_target_properties (${_lib} PROPERTIES
+      OUTPUT_NAME       "${OPENAMP_LIB}"
+    )
+  endif (WITH_STATIC_LIB)
+endif (WITH_ZEPHYR)
 
 install (DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/openamp" DESTINATION include)
 

--- a/lib/common/hil.c
+++ b/lib/common/hil.c
@@ -127,7 +127,7 @@ struct metal_device *hil_create_generic_mem_dev(
 	ret = metal_bus_find("generic", NULL);
 	if (ret)
 		return NULL;
-	dev = malloc(sizeof(*dev));
+	dev = metal_allocate_memory(sizeof(*dev));
 	openamp_assert(dev);
 	memset(dev, 0, sizeof(*dev));
 	sprintf(dev->name, "%s%lx.%lx", HIL_DEV_NAME_PREFIX, pa,
@@ -157,7 +157,7 @@ void hil_close_generic_mem_dev(struct metal_device *dev)
 	} else {
 		metal_list_del(&dev->node);
 		mdev = metal_container_of(dev, struct hil_mem_device, device);
-		free(mdev);
+		metal_free_memory(mdev);
 	}
 }
 

--- a/lib/rpmsg/rpmsg_core.c
+++ b/lib/rpmsg/rpmsg_core.c
@@ -661,7 +661,7 @@ void rpmsg_ns_callback(struct rpmsg_channel *server_chnl, void *data, int len,
 		}
 	} else {
 		struct metal_io_region *io = rdev->proc->sh_buff.io;
-		char *name = malloc(len);
+		char *name = metal_allocate_memory(len);
 
 		openamp_assert(name);
 		metal_io_block_read(io,
@@ -669,7 +669,7 @@ void rpmsg_ns_callback(struct rpmsg_channel *server_chnl, void *data, int len,
 				name, len);
 		rp_chnl =
 		    _rpmsg_create_channel(rdev, name, 0x00, ns_msg->addr);
-		free(name);
+		metal_free_memory(name);
 		if (rp_chnl) {
 			rp_chnl->state = RPMSG_CHNL_STATE_ACTIVE;
 			/* Create default endpoint for channel */


### PR DESCRIPTION
Enable  to build OpenAMP library for Zephyr

Enable to build OpenAMP library for Zephyr project.

* $ cmake <where_libmetal_is_cloned> -DWITH_ZEPHYR=on \
      -DBOARD=qemu_cortex_m3 \
      -DCMAKE_INCLUDE_PATH=<built_libmetal_include_path> \
      -DCMAKE_LIBRARY_PATH=<built_libmetal_library_path>
* $ make VERBOSE=1 all
