### PR TITLE
fix abort caused by null pointer at rproc->proc.

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -177,6 +177,7 @@ int remoteproc_init(char *fw_name, struct hil_proc *proc,
 	if (rproc) {
 		memset((void *)rproc, 0x00, sizeof(struct remote_proc));
 		/* Create proc instance */
+		rproc->proc = proc;
 		status = hil_init_proc(proc);
 		if (!status) {
 			/* Retrieve firmware attributes */


### PR DESCRIPTION
original code will hang up in handle_vdev_rsc function.
