### PR TITLE
remoteproc_shutdown fix

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -351,7 +351,6 @@ int remoteproc_shutdown(struct remote_proc *rproc)
 		if (rproc->rdev) {
 			rpmsg_deinit(rproc->rdev);
 			rproc->rdev = RPROC_NULL;
-			rproc->proc = RPROC_NULL;
 		}
 	}
 


### PR DESCRIPTION
I think rproc->proc doesn't need to assign RPROC_NULL;
Then we can omit proc->proc assignment in follow code.

>  remoteproc_shutdown(proc);
  proc->proc = hproc;
  remoteproc_boot(proc)
