### PR TITLE
rpmsg: make rpmsg_memb_match/cpy() internal

### DIFF
--- a/lib/include/openamp/rpmsg_core.h
+++ b/lib/include/openamp/rpmsg_core.h
@@ -117,10 +117,6 @@ struct remote_device {
 	int support_ns;
 };
 
-/* RPMsg internal helper functions */
-int rpmsg_memb_match(const void *ptr1, const void *ptr2, size_t n);
-void *rpmsg_memb_cpy(void *dest, const void *src, size_t n);
-
 /* Core functions */
 int rpmsg_start_ipc(struct remote_device *rdev);
 struct rpmsg_channel *_rpmsg_create_channel(struct remote_device *rdev,

--- a/lib/rpmsg/remote_device.c
+++ b/lib/rpmsg/remote_device.c
@@ -55,6 +55,34 @@ virtio_dispatch rpmsg_rdev_config_ops = {
 };
 
 /**
+ * rpmsg_memb_match
+ *
+ * This internal function checks if the contents in two memories matches byte
+ * by byte. This function is needed because memcmp() or strcmp() does not
+ * always work across different memories.
+ *
+ * @param ptr1 - pointer to memory
+ * @param ptr2 - pointer to memory
+ * @param n - number of bytes to compare
+ *
+ * @return 0 if the contents in the two memories matches, otherwise -1.
+ */
+static int rpmsg_memb_match(const void *ptr1, const void *ptr2, size_t n)
+{
+	size_t i;
+	const unsigned char *tmp1, *tmp2;
+
+	tmp1 = ptr1;
+	tmp2 = ptr2;
+	for (i = 0; i < n; i++, tmp1++, tmp2++) {
+		if (*tmp1 != *tmp2)
+			return -1;
+	}
+
+	return 0;
+}
+
+/**
  * rpmsg_rdev_init
  *
  * This function creates and initializes the remote device. The remote device

--- a/lib/rpmsg/rpmsg_core.c
+++ b/lib/rpmsg/rpmsg_core.c
@@ -37,36 +37,6 @@ static void rpmsg_rx_callback(struct virtqueue *vq);
 static void rpmsg_tx_callback(struct virtqueue *vq);
 
 /**
- * rpmsg_memb_match
- *
- * This function checks if the contents in two memories matches byte by byte.
- *
- * RPMsg can be used across different memories.
- * memcmp/strcmp doesn't always work.
- *
- * @param ptr1 - pointer to memory
- * @param ptr2 - pointer to memory
- * @param n - number of bytes to compare
- *
- * @return 0 if the contents in the two memories matches, otherwise -1.
- */
-int rpmsg_memb_match(const void *ptr1, const void *ptr2, size_t n)
-{
-	size_t i;
-	const unsigned char *tmp1, *tmp2;
-
-	tmp1 = ptr1;
-	tmp2 = ptr2;
-	for (i = 0; i < n; i++, tmp1++, tmp2++) {
-		if (*tmp1 == *tmp2)
-			continue;
-		return -1;
-	}
-
-	return 0;
-}
-
-/**
  * rpmsg_memb_cpy
  *
  * This function copies contents from one memory to the other byte by byte.
@@ -80,7 +50,7 @@ int rpmsg_memb_match(const void *ptr1, const void *ptr2, size_t n)
  *
  * @return pointer to dest
  */
-void *rpmsg_memb_cpy(void *dest, const void *src, size_t n)
+static void *rpmsg_memb_cpy(void *dest, const void *src, size_t n)
 {
 	size_t i;
 	unsigned char *tmp_dest;


### PR DESCRIPTION
Makes the `rpmsg_memb_match()` and `rpmsg_memb_cpy()` functions static in the modules where they are used, which allows the compiler to inline them.