### PR TITLE
lib: virtio: suppress virtqueue memory allocation

### DIFF
--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -20,6 +20,7 @@ extern "C" {
 typedef uint8_t boolean;
 
 #include <openamp/virtio_ring.h>
+#include <metal/alloc.h>
 #include <metal/dma.h>
 #include <metal/io.h>
 
@@ -175,7 +176,7 @@ int virtqueue_create(struct virtio_device *device, unsigned short id,
 		     void (*callback) (struct virtqueue * vq),
 		     void (*notify) (struct virtqueue * vq),
 		     struct metal_io_region *shm_io,
-		     struct virtqueue **v_queue);
+		     struct virtqueue *v_queue);
 
 int virtqueue_add_buffer(struct virtqueue *vq, struct metal_sg *sg,
 			 int readable, int writable, void *cookie);
@@ -197,6 +198,21 @@ void virtqueue_disable_cb(struct virtqueue *vq);
 int virtqueue_enable_cb(struct virtqueue *vq);
 
 void virtqueue_kick(struct virtqueue *vq);
+
+static inline struct virtqueue * virtqueue_allocate(unsigned int num_descs)
+{
+	struct virtqueue *vqs;
+	uint32_t vq_size = sizeof(struct virtqueue) +
+		 num_descs * sizeof(struct vq_desc_extra);
+
+	vqs = (struct virtqueue *)metal_allocate_memory(vq_size);
+
+	if (vqs) {
+		memset(vqs, 0x00, vq_size);
+	}
+
+	return vqs;
+}
 
 void virtqueue_free(struct virtqueue *vq);
 

--- a/lib/rpmsg/remote_device.c
+++ b/lib/rpmsg/remote_device.c
@@ -428,11 +428,16 @@ int rpmsg_rdev_create_virtqueues(struct virtio_device *dev, int flags, int nvqs,
 				vring_table[idx].align));
 		}
 
+		vqs[idx] = virtqueue_allocate(ring_info.num_descs);
+		if (vqs[idx] == NULL) {
+			return (ERROR_NO_MEM);
+		}
+
 		status =
 		    virtqueue_create(dev, idx, (char *)names[idx], &ring_info,
 				     callbacks[idx], hil_vring_notify,
 				     rdev->proc->sh_buff.io,
-				     &vqs[idx]);
+				     vqs[idx]);
 
 		if (status != RPMSG_SUCCESS) {
 			return status;


### PR DESCRIPTION
To be able to support static allocation, vq should no more allocated in
virtio but in rpmsg or application.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>
Signed-off-by: Kumar Gala <kumar.gala@linaro.org>