### PR TITLE
virtqueue cleanup

### DIFF
--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -72,7 +72,6 @@ struct virtqueue {
 	uint16_t vq_queue_index;
 	uint16_t vq_nentries;
 	uint32_t vq_flags;
-	int vq_ring_size;
 	void *vq_ring_mem;
 	void (*callback) (struct virtqueue * vq);
 	void (*notify) (struct virtqueue * vq);

--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -74,12 +74,9 @@ struct virtqueue {
 	uint32_t vq_flags;
 	int vq_alignment;
 	int vq_ring_size;
-	boolean vq_inuse;
 	void *vq_ring_mem;
 	void (*callback) (struct virtqueue * vq);
 	void (*notify) (struct virtqueue * vq);
-	int vq_max_indirect_size;
-	int vq_indirect_mem_size;
 	struct vring vq_ring;
 	uint16_t vq_free_cnt;
 	uint16_t vq_queued_cnt;
@@ -105,7 +102,7 @@ struct virtqueue {
 	 */
 	uint16_t vq_available_idx;
 
-	uint8_t padd;
+	boolean vq_inuse;
 
 	/*
 	 * Used by the host side during callback. Cookie
@@ -115,8 +112,6 @@ struct virtqueue {
 
 	struct vq_desc_extra {
 		void *cookie;
-		struct vring_desc *indirect;
-		uint32_t indirect_paddr;
 		uint16_t ndescs;
 	} vq_descx[0];
 };

--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -72,7 +72,6 @@ struct virtqueue {
 	uint16_t vq_queue_index;
 	uint16_t vq_nentries;
 	uint32_t vq_flags;
-	void *vq_ring_mem;
 	void (*callback) (struct virtqueue * vq);
 	void (*notify) (struct virtqueue * vq);
 	struct vring vq_ring;

--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -64,9 +64,6 @@ typedef enum {
 } vq_postpone_t;
 
 struct virtqueue {
-	//TODO: Need to define proper structure for
-	//        virtio device with RPmsg and paravirtualization.
-
 	struct virtio_device *vq_dev;
 	char vq_name[VIRTQUEUE_MAX_NAME_SZ];
 	uint16_t vq_queue_index;

--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -72,7 +72,6 @@ struct virtqueue {
 	uint16_t vq_queue_index;
 	uint16_t vq_nentries;
 	uint32_t vq_flags;
-	int vq_alignment;
 	int vq_ring_size;
 	void *vq_ring_mem;
 	void (*callback) (struct virtqueue * vq);

--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -80,8 +80,6 @@ int virtqueue_create(struct virtio_device *virt_dev, unsigned short id,
 		vq->notify = notify;
 		vq->shm_io = shm_io;
 
-		//TODO : Whether we want to support indirect addition or not.
-		vq->vq_ring_size = vring_size(ring->num_descs, ring->align);
 		vq->vq_ring_mem = (void *)ring->vaddr;
 
 		/* Initialize vring control block in virtqueue. */
@@ -307,7 +305,6 @@ void virtqueue_free(struct virtqueue *vq)
 		//TODO : Need to free indirect buffers here
 
 		if (vq->vq_ring_mem != NULL) {
-			vq->vq_ring_size = 0;
 			vq->vq_ring_mem = NULL;
 		}
 

--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -57,8 +57,6 @@ int virtqueue_create(struct virtio_device *virt_dev, unsigned short id,
 	VQ_PARAM_CHK(ring->num_descs & (ring->num_descs - 1), status,
 		     ERROR_VRING_ALIGN);
 
-	//TODO : Error check for indirect buffer addition
-
 	if (status == VQUEUE_SUCCESS) {
 
 		vq_size = sizeof(struct virtqueue)
@@ -89,9 +87,6 @@ int virtqueue_create(struct virtio_device *virt_dev, unsigned short id,
 		virtqueue_disable_cb(vq);
 
 		*v_queue = vq;
-
-		//TODO : Need to add cleanup in case of error used with the indirect buffer addition
-		//TODO: do we need to save the new queue in db based on its id
 	}
 
 	return (status);
@@ -126,13 +121,9 @@ int virtqueue_add_buffer(struct virtqueue *vq, struct metal_sg *sg,
 	VQ_PARAM_CHK(needed < 1, status, ERROR_VQUEUE_INVLD_PARAM);
 	VQ_PARAM_CHK(vq->vq_free_cnt == 0, status, ERROR_VRING_FULL);
 
-	//TODO: Add parameters validation for indirect buffer addition
-
 	VQUEUE_BUSY(vq);
 
 	if (status == VQUEUE_SUCCESS) {
-
-		//TODO : Indirect buffer addition support
 
 		VQASSERT(vq, cookie != NULL, "enqueuing with no cookie");
 


### PR DESCRIPTION
Some cleanups to the virtqueue implementation to remove some dead code and reduce the struct virtqueue size to drastically reduce the memory requirements for dynamic allocation.