### PR TITLE
[RFC] virtqueue: optimize away vq_name for DEBUG only

### DIFF
--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -65,7 +65,9 @@ typedef enum {
 
 struct virtqueue {
 	struct virtio_device *vq_dev;
+#ifdef DEBUG
 	char vq_name[VIRTQUEUE_MAX_NAME_SZ];
+#endif
 	uint16_t vq_queue_index;
 	uint16_t vq_nentries;
 	uint32_t vq_flags;

--- a/lib/rpmsg/rpmsg_core.c
+++ b/lib/rpmsg/rpmsg_core.c
@@ -91,13 +91,17 @@ int rpmsg_start_ipc(struct remote_device *rdev)
 
 	/* Initialize names and callbacks based on the device role */
 	if (rdev->role == RPMSG_MASTER) {
+#ifdef DEBUG
 		vq_names[0] = "tx_vq";
 		vq_names[1] = "rx_vq";
+#endif
 		callback[0] = rpmsg_tx_callback;
 		callback[1] = rpmsg_rx_callback;
 	} else {
+#ifdef DEBUG
 		vq_names[0] = "rx_vq";
 		vq_names[1] = "tx_vq";
+#endif
 		callback[0] = rpmsg_rx_callback;
 		callback[1] = rpmsg_tx_callback;
 	}

--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -24,6 +24,15 @@ static int vq_ring_must_notify_host(struct virtqueue *vq);
 static void vq_ring_notify_host(struct virtqueue *vq);
 static int virtqueue_nused(struct virtqueue *vq);
 
+static inline char* vq_get_name(struct virtqueue *vq)
+{
+#ifdef DEBUG
+	return vq->vq_name;
+#else
+	return NULL;
+#endif
+}
+
 /**
  * virtqueue_create - Creates new VirtIO queue
  *
@@ -70,7 +79,9 @@ int virtqueue_create(struct virtio_device *virt_dev, unsigned short id,
 		memset(vq, 0x00, vq_size);
 
 		vq->vq_dev = virt_dev;
+#ifdef DEBUG
 		strncpy(vq->vq_name, name, VIRTQUEUE_MAX_NAME_SZ);
+#endif
 		vq->vq_queue_index = id;
 		vq->vq_nentries = ring->num_descs;
 		vq->vq_free_cnt = vq->vq_nentries;
@@ -289,7 +300,7 @@ void virtqueue_free(struct virtqueue *vq)
 		if (vq->vq_free_cnt != vq->vq_nentries) {
 			metal_log(METAL_LOG_WARNING,
 				  "%s: freeing non-empty virtqueue\r\n",
-				  vq->vq_name);
+				  vq_get_name(vq));
 		}
 
 		metal_free_memory(vq);
@@ -437,7 +448,7 @@ void virtqueue_dump(struct virtqueue *vq)
 		  "VQ: %s - size=%d; free=%d; used=%d; queued=%d; "
 		  "desc_head_idx=%d; avail.idx=%d; used_cons_idx=%d; "
 		  "used.idx=%d; avail.flags=0x%x; used.flags=0x%x\r\n",
-		  vq->vq_name, vq->vq_nentries, vq->vq_free_cnt,
+		  vq_get_name(vq), vq->vq_nentries, vq->vq_free_cnt,
 		  virtqueue_nused(vq), vq->vq_queued_cnt, vq->vq_desc_head_idx,
 		  vq->vq_ring.avail->idx, vq->vq_used_cons_idx,
 		  vq->vq_ring.used->idx, vq->vq_ring.avail->flags,


### PR DESCRIPTION
This saves about 70 bytes, and vq_name is only a debug option.  Wonder how we want to enable DEBUG from the build, do we use CMAKE_BUILD_TYPE or introduce a DEBUG flag option in cmake