### PR TITLE
hil: fix compile warning

### DIFF
--- a/lib/common/hil.c
+++ b/lib/common/hil.c
@@ -32,6 +32,7 @@
 #include <metal/utilities.h>
 #include <metal/time.h>
 #include <metal/cache.h>
+#include <stdio.h>
 
 #define DEFAULT_VRING_MEM_SIZE 0x10000
 #define HIL_DEV_NAME_PREFIX "hil-dev."


### PR DESCRIPTION
hil uses sprintf so we need to include stdio.h for it, otherwise we get:

lib/common/hil.c: In function ‘hil_create_generic_mem_dev’:
lib/common/hil.c:112:2: warning: implicit declaration of function ‘sprintf’ [-Wimplicit-function-declaration]
  sprintf(dev->name, "%s%lx.%lx", HIL_DEV_NAME_PREFIX, pa,

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>