### PR TITLE
virtqueue: only include vq_inuse in debug mode

### DIFF
--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -96,7 +96,9 @@ struct virtqueue {
 	 */
 	uint16_t vq_available_idx;
 
+#if (VQUEUE_DEBUG == true)
 	boolean vq_inuse;
+#endif
 
 	/*
 	 * Used by the host side during callback. Cookie


### PR DESCRIPTION
Adds an #if around the vq_inuse variable in the virtqueue struct, as
this variable is only used when VQUEUE_DEBUG is set to true.

Signed-off-by: Kristian Klomsten Skordal <kristian.skordal@nordicsemi.no>