### PR TITLE
lib: sh_mem: Clean types used in sh_mem_pool

### DIFF
--- a/lib/common/sh_mem.c
+++ b/lib/common/sh_mem.c
@@ -91,7 +91,8 @@ struct sh_mem_pool *sh_mem_create_pool(void *start_addr, unsigned int size,
 void *sh_mem_get_buffer(struct sh_mem_pool *pool)
 {
 	void *buff = NULL;
-	int idx, bit_idx;
+	int bit_idx;
+	unsigned int idx;
 
 	if (!pool)
 		return NULL;

--- a/lib/include/openamp/sh_mem.h
+++ b/lib/include/openamp/sh_mem.h
@@ -55,11 +55,11 @@ extern "C" {
 struct sh_mem_pool {
 	void *start_addr;
 	metal_mutex_t lock;
-	int size;
-	int buff_size;
-	int total_buffs;
-	int used_buffs;
-	int bmp_size;
+	unsigned int size;
+	unsigned int buff_size;
+	unsigned int total_buffs;
+	unsigned int used_buffs;
+	unsigned int bmp_size;
 };
 
 /* APIs */


### PR DESCRIPTION
Change a number of struct elements in sh_mem_pool to unsigned since they
contain values that will (or should) only be unsigned.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>