### PR TITLE
static end point allocation

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -15,7 +15,7 @@ if (WITH_LINUXREMOTE)
   add_subdirectory (linux_firmware_remoteproc_slave)
 endif (WITH_LINUXREMOTE)
 
-#add_subdirectory (echo_test)
+add_subdirectory (echo_test)
 #add_subdirectory (matrix_multiply)
 add_subdirectory (load_fw)
 if (WITH_PROXY_APPS)

--- a/apps/echo_test/CMakeLists.txt
+++ b/apps/echo_test/CMakeLists.txt
@@ -15,7 +15,7 @@ collector_list (_deps PROJECT_LIB_DEPS)
 
 set (OPENAMP_LIB open_amp)
 
-foreach (_app echo_test echo_testd)
+foreach (_app echo_testd)
   collector_list (_sources APP_COMMON_SOURCES)
   set (build_app 1)
   if (WITH_REMOTEPROC_MASTER)
@@ -28,14 +28,14 @@ foreach (_app echo_test echo_testd)
   else (WITH_REMOTEPROC_MASTER)
     list (APPEND _sources "${CMAKE_CURRENT_SOURCE_DIR}/${_app}.c")
   endif (WITH_REMOTEPROC_MASTER)
-  
+
   if (${build_app} EQUAL "1")
     if (WITH_SHARED_LIB)
       add_executable (${_app}-shared ${_sources})
       target_link_libraries (${_app}-shared ${OPENAMP_LIB}-shared ${_deps})
       install (TARGETS ${_app}-shared RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     endif (WITH_SHARED_LIB)
-  
+
     if (WITH_STATIC_LIB)
       if (${PROJECT_SYSTEM} STREQUAL "linux")
         add_executable (${_app}-static ${_sources})
@@ -44,21 +44,21 @@ foreach (_app echo_test echo_testd)
       else (${PROJECT_SYSTEM})
         add_executable (${_app}.out ${_sources})
         set_source_files_properties(${_sources} PROPERTIES COMPILE_FLAGS "${_cflags}")
-  
+
         if (WITH_REMOTEPROC_MASTER)
           target_link_libraries(${_app}.out -Wl,-Map=${_app}.map -Wl,--gc-sections ${_linker_opt} -Wl,--start-group ${_fw_dir}/firmware1.o ${_fw_dir}/firmware2.o ${OPENAM__LIB}-static ${_deps} -Wl,--end-group)
           add_custom_target (${_app}.bin ALL
           ${CROSS_PREFIX}objcopy -O binary ${_app}.out ${_app}.bin
           DEPENDS ${_app}.out)
-  
+
           add_dependencies (${_app}.out ${_fw_dir}/firmware1.o ${_fw_dir}/firmware2.o)
-  
+
           install (FILES "${CMAKE_CURRENT_BINARY_DIR}/${_app}.bin" DESTINATION ${CMAKE_INSTALL_BINDIR})
-  
+
         else (WITH_REMOTEPROC_MASTER)
-  
+
           target_link_libraries(${_app}.out -Wl,-Map=${_app}.map -Wl,--gc-sections ${_linker_opt} -Wl,--start-group ${OPENAMP_LIB}-static ${_deps} -Wl,--end-group)
-  
+
           install (TARGETS ${_app}.out RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
         endif (WITH_REMOTEPROC_MASTER)
       endif (${PROJECT_SYSTEM} STREQUAL "linux" )

--- a/apps/echo_test/echo_testd.c
+++ b/apps/echo_test/echo_testd.c
@@ -4,126 +4,75 @@ This application echoes back data that was sent to it by the master core. */
 
 #include <stdio.h>
 #include <openamp/open_amp.h>
+#include <metal/alloc.h>
 #include "rsc_table.h"
 #include "platform_info.h"
 
 #define SHUTDOWN_MSG	0xEF56A55A
 
-//#define LPRINTF(format, ...) printf(format, ##__VA_ARGS__)
-#define LPRINTF(format, ...)
+#define LPRINTF(format, ...) xil_printf(format, ##__VA_ARGS__)
+//#define LPRINTF(format, ...)
 #define LPERROR(format, ...) LPRINTF("ERROR: " format, ##__VA_ARGS__)
+
+static struct rpmsg_endpoint *ept = NULL;
+static int ept_deleted = 0;
 
 /* External functions */
 extern int init_system(void);
 extern void cleanup_system(void);
 
-/* Local variables */
-static struct remote_proc *proc = NULL;
-static struct rsc_table_info rsc_info;
-static int evt_chnl_deleted = 0;
-static int evt_virtio_rst = 0;
-
-static void virtio_rst_cb(struct hil_proc *hproc, int id)
-{
-	/* hil_proc only supports single virtio device */
-	(void)id;
-
-	if (!proc || proc->proc != hproc || !proc->rdev)
-		return;
-
-	LPRINTF("Resetting RPMsg\n");
-	evt_virtio_rst = 1;
-}
-
 /*-----------------------------------------------------------------------------*
  *  RPMSG callbacks setup by remoteproc_resource_init()
  *-----------------------------------------------------------------------------*/
-static void rpmsg_read_cb(struct rpmsg_channel *rp_chnl, void *data, int len,
-			  void *priv, unsigned long src)
+static void rpmsg_endpoint_cb(struct rpmsg_endpoint *ept, void *data, size_t len,
+			      uint32_t src, void *priv)
 {
 	(void)priv;
 	(void)src;
 
 	/* On reception of a shutdown we signal the application to terminate */
 	if ((*(unsigned int *)data) == SHUTDOWN_MSG) {
-		evt_chnl_deleted = 1;
+		ept_deleted = 1;
 		return;
 	}
 
 	/* Send data back to master */
-	if (rpmsg_send(rp_chnl, data, len) < 0) {
+	if (rpmsg_send(ept, data, len) < 0) {
 		LPERROR("rpmsg_send failed\n");
 	}
 }
 
-static void rpmsg_channel_created(struct rpmsg_channel *rp_chnl)
+static void rpmsg_endpoint_destroy(struct rpmsg_endpoint *ept)
 {
-	(void)rp_chnl;
-}
-
-static void rpmsg_channel_deleted(struct rpmsg_channel *rp_chnl)
-{
-	(void)rp_chnl;
-
-	evt_chnl_deleted = 1;
+	(void)ept;
+	LPERROR("Endpoint is destroyed\n");
+	/* user application will need to free the endpoint memory */
+	metal_free_memory(ept);
+	ept_deleted = 1;
 }
 
 /*-----------------------------------------------------------------------------*
  *  Application
  *-----------------------------------------------------------------------------*/
-int app(struct hil_proc *hproc)
+int app(struct rpmsg_device *rdev, void *priv)
 {
-	int status = 0;
-
 	/* Initialize RPMSG framework */
-	LPRINTF("Try to init remoteproc resource\n");
-	status = remoteproc_resource_init(&rsc_info, hproc,
-				     rpmsg_channel_created,
-				     rpmsg_channel_deleted, rpmsg_read_cb,
-				     &proc, 0);
+	LPRINTF("Try to create rpmsg endpoint.\n");
 
-	if (RPROC_SUCCESS != status) {
-		LPERROR("Failed  to initialize remoteproc resource.\n");
+	ept = rpmsg_create_ept(rdev, RPMSG_CHAN_NAME, 0, RPMSG_ADDR_ANY,
+			       rpmsg_endpoint_cb, rpmsg_endpoint_destroy);
+	if (!ept) {
+		LPERROR("Failed to create endpoint.\n");
 		return -1;
 	}
-	LPRINTF("Init remoteproc resource succeeded\n");
 
-	hil_set_vdev_rst_cb(hproc, 0, virtio_rst_cb);
-
-	LPRINTF("Waiting for events...\n");
 	while(1) {
-		hil_poll(proc->proc, 0);
-
+		platform_poll(priv);
 		/* we got a shutdown request, exit */
-		if (evt_chnl_deleted) {
+		if (ept_deleted) {
 			break;
 		}
-
-		if (evt_virtio_rst) {
-			/* vring rst callback, reset rpmsg */
-			LPRINTF("De-initializing RPMsg\n");
-			rpmsg_deinit(proc->rdev);
-			proc->rdev = NULL;
-
-			LPRINTF("Reinitializing RPMsg\n");
-			status = rpmsg_init(hproc, &proc->rdev,
-					    rpmsg_channel_created,
-					    rpmsg_channel_deleted, 
-					    rpmsg_read_cb,
-					    1);
-			if (status != RPROC_SUCCESS) {
-				LPERROR("Reinit RPMsg failed\n");
-				break;
-			} 
-			LPRINTF("Reinit RPMsg succeeded\n");
-			evt_chnl_deleted=0;
-			evt_virtio_rst = 0;
-		}
 	}
-
-	/* disable interrupts and free resources */
-	LPRINTF("De-initializating remoteproc resource\n");
-	remoteproc_resource_deinit(proc);
 
 	return 0;
 }
@@ -135,7 +84,8 @@ int main(int argc, char *argv[])
 {
 	unsigned long proc_id = 0;
 	unsigned long rsc_id = 0;
-	struct hil_proc *hproc;
+	struct remoteproc *rproc;
+	struct rpmsg_device *rdev;
 	int status = -1;
 
 	LPRINTF("Starting application...\n");
@@ -151,20 +101,22 @@ int main(int argc, char *argv[])
 		rsc_id = strtoul(argv[2], NULL, 0);
 	}
 
-	hproc = platform_create_proc(proc_id);
-	if (!hproc) {
-		LPERROR("Failed to create proc platform data.\n");
+	rproc = platform_create_proc(proc_id, rsc_id);
+	if (!rproc) {
+		LPERROR("Failed to create remoteproc device.\n");
 	} else {
-		rsc_info.rsc_tab = get_resource_table(
-			(int)rsc_id, &rsc_info.size);
-		if (!rsc_info.rsc_tab) {
-			LPERROR("Failed to get resource table data.\n");
+		rdev = platform_create_rpmsg_vdev(rproc, 0,
+						   VIRTIO_DEV_SLAVE,
+						   NULL);
+		if (!rdev) {
+			LPERROR("Failed to create rpmsg virtio device.\n");
 		} else {
-			status = app(hproc);
+			app(rdev, (void *)rproc);
 		}
 	}
 
 	LPRINTF("Stopping application...\n");
+	remoteproc_remove(rproc);
 	cleanup_system();
 
 	return status;

--- a/apps/echo_test_decouple/CMakeLists.txt
+++ b/apps/echo_test_decouple/CMakeLists.txt
@@ -1,0 +1,67 @@
+
+set (_cflags "${CMAKE_C_FLAGS} ${APP_EXTRA_C_FLAGS}")
+set (_fw_dir "${APPS_SHARE_DIR}")
+
+collector_list (_list PROJECT_INC_DIRS)
+collector_list (_app_list APP_INC_DIRS)
+include_directories (${_list} ${_app_list} ${CMAKE_CURRENT_SOURCE_DIR})
+
+collector_list (_list PROJECT_LIB_DIRS)
+collector_list (_app_list APP_LIB_DIRS)
+link_directories (${_list} ${_app_list})
+
+get_property (_linker_opt GLOBAL PROPERTY APP_LINKER_OPT)
+collector_list (_deps PROJECT_LIB_DEPS)
+
+set (OPENAMP_LIB open_amp)
+
+foreach (_app echo_test echo_testd)
+  collector_list (_sources APP_COMMON_SOURCES)
+  set (build_app 1)
+  if (WITH_REMOTEPROC_MASTER)
+    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_app}_remoteproc_master.c")
+      list (APPEND _sources "${CMAKE_CURRENT_SOURCE_DIR}/${_app}_remoteproc_master.c")
+      set (_cflags "${_cflags} -DBAREMETAL_MASTER=1")
+    else ()
+      set (build_app 0)
+    endif ()
+  else (WITH_REMOTEPROC_MASTER)
+    list (APPEND _sources "${CMAKE_CURRENT_SOURCE_DIR}/${_app}.c")
+  endif (WITH_REMOTEPROC_MASTER)
+  
+  if (${build_app} EQUAL "1")
+    if (WITH_SHARED_LIB)
+      add_executable (${_app}-shared ${_sources})
+      target_link_libraries (${_app}-shared ${OPENAMP_LIB}-shared ${_deps})
+      install (TARGETS ${_app}-shared RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    endif (WITH_SHARED_LIB)
+  
+    if (WITH_STATIC_LIB)
+      if (${PROJECT_SYSTEM} STREQUAL "linux")
+        add_executable (${_app}-static ${_sources})
+        target_link_libraries (${_app}-static ${OPENAMP_LIB}-static ${_deps})
+        install (TARGETS ${_app}-static RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+      else (${PROJECT_SYSTEM})
+        add_executable (${_app}.out ${_sources})
+        set_source_files_properties(${_sources} PROPERTIES COMPILE_FLAGS "${_cflags}")
+  
+        if (WITH_REMOTEPROC_MASTER)
+          target_link_libraries(${_app}.out -Wl,-Map=${_app}.map -Wl,--gc-sections ${_linker_opt} -Wl,--start-group ${_fw_dir}/firmware1.o ${_fw_dir}/firmware2.o ${OPENAM__LIB}-static ${_deps} -Wl,--end-group)
+          add_custom_target (${_app}.bin ALL
+          ${CROSS_PREFIX}objcopy -O binary ${_app}.out ${_app}.bin
+          DEPENDS ${_app}.out)
+  
+          add_dependencies (${_app}.out ${_fw_dir}/firmware1.o ${_fw_dir}/firmware2.o)
+  
+          install (FILES "${CMAKE_CURRENT_BINARY_DIR}/${_app}.bin" DESTINATION ${CMAKE_INSTALL_BINDIR})
+  
+        else (WITH_REMOTEPROC_MASTER)
+  
+          target_link_libraries(${_app}.out -Wl,-Map=${_app}.map -Wl,--gc-sections ${_linker_opt} -Wl,--start-group ${OPENAMP_LIB}-static ${_deps} -Wl,--end-group)
+  
+          install (TARGETS ${_app}.out RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+        endif (WITH_REMOTEPROC_MASTER)
+      endif (${PROJECT_SYSTEM} STREQUAL "linux" )
+    endif (WITH_STATIC_LIB)
+  endif (${build_app} EQUAL "1")
+endforeach(_app)

--- a/apps/echo_test_decouple/echo_test.c
+++ b/apps/echo_test_decouple/echo_test.c
@@ -1,0 +1,210 @@
+/* This is a sample demonstration application that showcases usage of rpmsg 
+This application is meant to run on the remote CPU running baremetal code. 
+This application echoes back data that was sent to it by the master core. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <openamp/open_amp.h>
+#include <metal/alloc.h>
+#include "rsc_table.h"
+
+#define SHUTDOWN_MSG	0xEF56A55A
+#define LPRINTF(format, ...) printf(format, ##__VA_ARGS__)
+#define LPERROR(format, ...) LPRINTF("ERROR: " format, ##__VA_ARGS__)
+
+struct _payload {
+	unsigned long num;
+	unsigned long size;
+	unsigned char data[];
+};
+
+static int err_cnt;
+
+#define RPMSG_GET_KFIFO_SIZE 1
+#define RPMSG_GET_AVAIL_DATA_SIZE 2
+#define RPMSG_GET_FREE_SPACE 3
+
+#define RPMSG_HEADER_LEN sizeof(struct rpmsg_hdr)
+#define MAX_RPMSG_BUFF_SIZE (RPMSG_BUFFER_SIZE - RPMSG_HEADER_LEN)
+#define PAYLOAD_MIN_SIZE	1
+#define PAYLOAD_MAX_SIZE	(MAX_RPMSG_BUFF_SIZE - 24)
+#define NUM_PAYLOADS		(PAYLOAD_MAX_SIZE/PAYLOAD_MIN_SIZE)
+
+/* Internal functions */
+static void rpmsg_channel_created(struct rpmsg_channel *rp_chnl);
+static void rpmsg_channel_deleted(struct rpmsg_channel *rp_chnl);
+static void rpmsg_read_cb(struct rpmsg_channel *, void *, int, void *,
+			  unsigned long);
+/* Globals */
+static struct rpmsg_channel *app_rp_chnl;
+static struct rpmsg_endpoint *rp_ept;
+static struct remote_proc *proc = NULL;
+static struct rsc_table_info rsc_info;
+static struct _payload *i_payload;
+static int rnum = 0;
+static int err_cnt = 0;
+
+/* External functions */
+extern int init_system();
+extern void cleanup_system();
+extern struct hil_proc *platform_create_proc(int proc_index);
+extern void *get_resource_table (int rsc_id, int *len);
+
+/* Application entry point */
+int app (struct hil_proc *hproc)
+{
+	int status = 0;
+	int shutdown_msg = SHUTDOWN_MSG;
+	int i;
+	int size;
+	int expect_rnum = 0;
+
+	LPRINTF(" 1 - Send data to remote core, retrieve the echo");
+	LPRINTF(" and validate its integrity ..\n");
+
+	i_payload =
+	    (struct _payload *)metal_allocate_memory(2 * sizeof(unsigned long) +
+				      PAYLOAD_MAX_SIZE);
+
+	if (!i_payload) {
+		LPERROR("memory allocation failed.\n");
+		return -1;
+	}
+
+	/* Initialize RPMSG framework */
+	status =
+	    remoteproc_resource_init(&rsc_info, hproc,
+				     rpmsg_channel_created,
+				     rpmsg_channel_deleted, rpmsg_read_cb,
+				     &proc, 1);
+
+	if (status) {
+		LPERROR("Failed to initialize remoteproc resource.\n");
+		return -1;
+	}
+
+	LPRINTF("Remote proc resource initialized.\n");
+	while (!app_rp_chnl) {
+		hil_poll(proc->proc, 0);
+	}
+
+	LPRINTF("RPMSG channel has created.\n");
+	for (i = 0, size = PAYLOAD_MIN_SIZE; i < (int)NUM_PAYLOADS; i++, size++) {
+		i_payload->num = i;
+		i_payload->size = size;
+
+		/* Mark the data buffer. */
+		memset(&(i_payload->data[0]), 0xA5, size);
+
+		LPRINTF("sending payload number %lu of size %d\n",
+			i_payload->num, (2 * sizeof(unsigned long)) + size);
+
+		status = rpmsg_send(app_rp_chnl, i_payload,
+			(2 * sizeof(unsigned long)) + size);
+
+		if (status < 0) {
+			LPRINTF("Error sending data...\n");
+			break;
+		}
+		LPRINTF("echo test: sent : %d\n",
+		(2 * sizeof(unsigned long)) + size);
+
+		expect_rnum++;
+		do {
+			hil_poll(proc->proc, 0);
+		} while ((rnum < expect_rnum) && !err_cnt && app_rp_chnl);
+
+	}
+
+	LPRINTF("**********************************\n");
+	LPRINTF(" Test Results: Error count = %d \n", err_cnt);
+	LPRINTF("**********************************\n");
+	/* Send shutdown message to remote */
+	rpmsg_send(app_rp_chnl, &shutdown_msg, sizeof(int));
+	sleep(1);
+	LPRINTF("Quitting application .. Echo test end\n");
+
+	remoteproc_resource_deinit(proc);
+	cleanup_system();
+	metal_free_memory(i_payload);
+	return 0;
+}
+
+static void rpmsg_channel_created(struct rpmsg_channel *rp_chnl)
+{
+	app_rp_chnl = rp_chnl;
+	rp_ept = rpmsg_create_ept(rp_chnl, rpmsg_read_cb, RPMSG_NULL,
+				  RPMSG_ADDR_ANY);
+}
+
+static void rpmsg_channel_deleted(struct rpmsg_channel *rp_chnl)
+{
+	(void)rp_chnl;
+	rpmsg_destroy_ept(rp_ept);
+	LPRINTF("%s\n", __func__);
+	app_rp_chnl = NULL;
+	rp_ept = NULL;
+}
+
+static void rpmsg_read_cb(struct rpmsg_channel *rp_chnl, void *data, int len,
+			  void *priv, unsigned long src)
+{
+	(void)rp_chnl;
+	(void)src;
+	(void)priv;
+	int i;
+	struct _payload *r_payload = (struct _payload *)data;
+
+	LPRINTF(" received payload number %lu of size %d \r\n",
+		r_payload->num, len);
+
+	if (r_payload->size == 0) {
+		LPERROR(" Invalid size of package is received.\n");
+		err_cnt++;
+		return;
+	}
+	/* Validate data buffer integrity. */
+	for (i = 0; i < (int)r_payload->size; i++) {
+		if (r_payload->data[i] != 0xA5) {
+			LPRINTF("Data corruption at index %d\n", i);
+			err_cnt++;
+			break;
+		}
+	}
+	rnum = r_payload->num + 1;
+}
+
+int main(int argc, char *argv[])
+{
+	unsigned long proc_id = 0;
+	unsigned long rsc_id = 0;
+	struct hil_proc *hproc;
+
+	/* Initialize HW system components */
+	init_system();
+
+	if (argc >= 2) {
+		proc_id = strtoul(argv[1], NULL, 0);
+	}
+
+	if (argc >= 3) {
+		rsc_id = strtoul(argv[2], NULL, 0);
+	}
+
+	/* Create HIL proc */
+	hproc = platform_create_proc(proc_id);
+	if (!hproc) {
+		LPERROR("Failed to create hil proc.\n");
+		return -1;
+	}
+	rsc_info.rsc_tab = get_resource_table(
+		(int)rsc_id, &rsc_info.size);
+	if (!rsc_info.rsc_tab) {
+		LPRINTF("Failed to get resource table data.\n");
+		return -1;
+	}
+	return app(hproc);
+}
+

--- a/apps/echo_test_decouple/echo_test_measurement.c
+++ b/apps/echo_test_decouple/echo_test_measurement.c
@@ -1,0 +1,262 @@
+/* This is a sample demonstration application that showcases usage of rpmsg 
+This application is meant to run on the remote CPU running baremetal code. 
+This application echoes back data that was sent to it by the master core. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <$1>
+#include <metal/alloc.h>
+#include "rsc_table.h"
+
+#define SHUTDOWN_MSG	0xEF56A55A
+#define LPRINTF(format, ...) printf(format, ##__VA_ARGS__)
+#define LPERROR(format, ...) LPRINTF("ERROR: " format, ##__VA_ARGS__)
+
+struct _payload {
+	unsigned long num;
+	unsigned long size;
+	unsigned char data[];
+};
+
+#define RPMSG_GET_KFIFO_SIZE 1
+#define RPMSG_GET_AVAIL_DATA_SIZE 2
+#define RPMSG_GET_FREE_SPACE 3
+
+#define RPMSG_HEADER_LEN sizeof(struct rpmsg_hdr)
+#define MAX_RPMSG_BUFF_SIZE (RPMSG_BUFFER_SIZE - RPMSG_HEADER_LEN)
+#define PAYLOAD_MIN_SIZE	1
+#define PAYLOAD_MAX_SIZE	(MAX_RPMSG_BUFF_SIZE - 24)
+#define NUM_PAYLOADS		(PAYLOAD_MAX_SIZE/PAYLOAD_MIN_SIZE)
+#define NS_PER_S        (1000 * 1000 * 1000)
+
+/* Internal functions */
+static void rpmsg_channel_created(struct rpmsg_channel *rp_chnl);
+static void rpmsg_channel_deleted(struct rpmsg_channel *rp_chnl);
+static void rpmsg_read_cb(struct rpmsg_channel *, void *, int, void *,
+			  unsigned long);
+/* Globals */
+static struct rpmsg_channel *app_rp_chnl;
+static struct rpmsg_endpoint *rp_ept;
+static struct remote_proc *proc = NULL;
+static struct rsc_table_info rsc_info;
+static struct _payload *i_payload;
+static int rnum = 0;
+static int err_cnt = 0;
+
+/* External functions */
+extern void init_system();
+extern void cleanup_system();
+extern struct hil_proc *platform_create_proc(int proc_index);
+extern void *get_resource_table (int rsc_id, int *len);
+
+/* Application entry point */
+int app (struct hil_proc *hproc)
+{
+	int status = 0;
+	int shutdown_msg = SHUTDOWN_MSG;
+	int i;
+	int size;
+	int expect_rnum = 0;
+	int r;
+	struct timespec tp_start, tp_end;
+	unsigned long long tstart, tend, tdiff;
+	unsigned long long tdiff_avg_s = 0, tdiff_avg_ns = 0;
+
+	LPRINTF(" 1 - Send data to remote core, retrieve the echo");
+	LPRINTF(" and validate its integrity ..\n");
+
+	i_payload =
+	    (struct _payload *)metal_allocate_memory(2 * sizeof(unsigned long) +
+				      PAYLOAD_MAX_SIZE);
+
+	if (!i_payload) {
+		LPERROR("memory allocation failed.\n");
+		return -1;
+	}
+
+	/* Initialize RPMSG framework */
+	status =
+	    remoteproc_resource_init(&rsc_info, hproc,
+				     rpmsg_channel_created,
+				     rpmsg_channel_deleted, rpmsg_read_cb,
+				     &proc, 1);
+
+	if (status) {
+		LPERROR("Failed to initialize remoteproc resource.\n");
+		return -1;
+	}
+
+	LPRINTF("Remote proc resource initialized.\n");
+	while (!app_rp_chnl) {
+		hil_poll(proc->proc, 0);
+	}
+
+	LPRINTF("RPMSG channel has created.\n");
+	i_payload->size = PAYLOAD_MAX_SIZE;
+
+	/* Mark the data buffer. */
+	memset(&(i_payload->data[0]), 0xA5, PAYLOAD_MAX_SIZE);
+	r = clock_gettime(CLOCK_MONOTONIC, &tp_start);
+	if (r == -1) {
+		LPRINTF("ERROR: Bad clock_gettime!\n");
+		return -1;
+	}
+//	for (i = 0, size = PAYLOAD_MIN_SIZE; i < (int)NUM_PAYLOADS; i++, size++) {
+	for (i = 0; i < (int)0x1000; i++) {
+		i_payload->num = i;
+
+		//LPRINTF("try to send data %d...\n", i);
+#if 0
+		status = rpmsg_send(app_rp_chnl, i_payload,
+			(2 * sizeof(unsigned long)) + PAYLOAD_MAX_SIZE);
+		//LPRINTF("try to send data %d...\n", i);
+		if (status < 0) {
+			status = 0;
+			while (!status && (rnum < expect_rnum) && !err_cnt && app_rp_chnl) {
+				status = hil_poll(proc->proc, 0);
+			}
+			if (err_cnt || !app_rp_chnl)
+				return -1;
+			if (!status)
+				status = rpmsg_send(app_rp_chnl, i_payload,
+					(2 * sizeof(unsigned long)) + PAYLOAD_MAX_SIZE);
+			if (status < 0) {
+				LPRINTF("Error sending data...\n");
+				return -1;
+			}
+		}
+#else
+		if (expect_rnum && !(expect_rnum%512)) {
+			status = 0;
+			while (!status && (rnum < expect_rnum) && !err_cnt && app_rp_chnl) {
+				status = hil_poll(proc->proc, 0);
+			}
+			if (err_cnt || !app_rp_chnl)
+				return -1;
+		}
+		status = rpmsg_send(app_rp_chnl, i_payload,
+			(2 * sizeof(unsigned long)) + PAYLOAD_MAX_SIZE);
+		if (status < 0) {
+			LPRINTF("Error sending data...\n");
+			return -1;
+		}
+#endif
+
+		expect_rnum++;
+		//LPRINTF("sent data %d, %d...\n", i, rnum);
+	}
+
+	while ((rnum < expect_rnum) && !err_cnt && app_rp_chnl) {
+		hil_poll(proc->proc, 0);
+	}
+
+	r = clock_gettime(CLOCK_MONOTONIC, &tp_end);
+	if (r == -1) {
+		LPRINTF("ERROR: Bad clock_gettime!\n");
+		return -1;
+	}
+
+	LPRINTF("**********************************\n");
+	LPRINTF(" Test Results: Error count = %d \n", err_cnt);
+	LPRINTF("**********************************\n");
+	tstart = (tp_start.tv_sec * NS_PER_S) + tp_start.tv_nsec;
+	tend = (tp_end.tv_sec * NS_PER_S) + tp_end.tv_nsec;
+	tdiff = (tend - tstart)/rnum;
+	tdiff_avg_s = tdiff / NS_PER_S;
+	tdiff_avg_ns = tdiff % NS_PER_S;
+	LPRINTF("Total packages: %d, time_avg = %lds, %ldns\n",
+		rnum, (long int)tdiff_avg_s, (long int)tdiff_avg_ns);
+	/* Send shutdown message to remote */
+	rpmsg_send(app_rp_chnl, &shutdown_msg, sizeof(int));
+	sleep(1);
+	LPRINTF("Quitting application .. Echo test end\n");
+
+	remoteproc_resource_deinit(proc);
+	cleanup_system();
+	metal_free_memory(i_payload);
+	return 0;
+}
+
+static void rpmsg_channel_created(struct rpmsg_channel *rp_chnl)
+{
+	app_rp_chnl = rp_chnl;
+	rp_ept = rpmsg_create_ept(rp_chnl, rpmsg_read_cb, RPMSG_NULL,
+				  RPMSG_ADDR_ANY);
+}
+
+static void rpmsg_channel_deleted(struct rpmsg_channel *rp_chnl)
+{
+	(void)rp_chnl;
+	rpmsg_destroy_ept(rp_ept);
+	LPRINTF("%s\n", __func__);
+	app_rp_chnl = NULL;
+	rp_ept = NULL;
+}
+
+static void rpmsg_read_cb(struct rpmsg_channel *rp_chnl, void *data, int len,
+			  void *priv, unsigned long src)
+{
+	(void)rp_chnl;
+	(void)src;
+	(void)priv;
+	int i;
+	struct _payload *r_payload = (struct _payload *)data;
+
+#if 0
+	if (r_payload->size == 0) {
+		LPERROR(" Invalid size of package is received.\n");
+		err_cnt++;
+		return;
+	}
+	if (r_payload->num != rnum) {
+		LPERROR("Package sequence error: expect: %d, actual: %d\n",
+			rnum, r_payload->num);
+		return;
+	}
+	/* Validate data buffer integrity. */
+	for (i = 0; i < (int)r_payload->size; i++) {
+		if (r_payload->data[i] != 0xA5) {
+			LPRINTF("Data corruption at index %d\n", i);
+			err_cnt++;
+			break;
+		}
+	}
+#endif
+	rnum = r_payload->num + 1;
+	//LPRINTF("%s: %d.\n", __func__, rnum);
+}
+
+int main(int argc, char *argv[])
+{
+	unsigned long proc_id = 0;
+	unsigned long rsc_id = 0;
+	struct hil_proc *hproc;
+
+	/* Initialize HW system components */
+	init_system();
+
+	if (argc >= 2) {
+		proc_id = strtoul(argv[1], NULL, 0);
+	}
+
+	if (argc >= 3) {
+		rsc_id = strtoul(argv[2], NULL, 0);
+	}
+
+	/* Create HIL proc */
+	hproc = platform_create_proc(proc_id);
+	if (!hproc) {
+		LPERROR("Failed to create hil proc.\n");
+		return -1;
+	}
+	rsc_info.rsc_tab = get_resource_table(
+		(int)rsc_id, &rsc_info.size);
+	if (!rsc_info.rsc_tab) {
+		LPRINTF("Failed to get resource table data.\n");
+		return -1;
+	}
+	return app(hproc);
+}
+

--- a/apps/echo_test_decouple/echo_testd.c
+++ b/apps/echo_test_decouple/echo_testd.c
@@ -1,0 +1,119 @@
+/* This is a sample demonstration application that showcases usage of rpmsg
+This application is meant to run on the remote CPU running baremetal code.
+This application echoes back data that was sent to it by the master core. */
+
+#include <stdio.h>
+#include <openamp/open_amp.h>
+#include <openamp/virtio.h>
+#include "rsc_table.h"
+#include "platform_info.h"
+
+#define SHUTDOWN_MSG	0xEF56A55A
+
+//#define LPRINTF(format, ...) printf(format, ##__VA_ARGS__)
+#define LPRINTF(format, ...)
+#define LPERROR(format, ...) LPRINTF("ERROR: " format, ##__VA_ARGS__)
+
+/* External functions */
+extern int init_system(void);
+extern void cleanup_system(void);
+
+/* Local variables */
+static struct remoteproc *rproc;
+static struct rpmsg_virtio_device *rpmsg_vdev;
+static struct rsc_table_info rsc_info;
+
+static void virtio_rst_cb(struct virtio_device *vdev)
+{
+	/* TODO: need to be implemented */
+	(void)id;
+}
+
+/*-----------------------------------------------------------------------------*
+ *  RPMSG callbacks setup by remoteproc_resource_init()
+ *-----------------------------------------------------------------------------*/
+static void rpmsg_read_cb(struct rpmsg_channel *rp_chnl, void *data, int len,
+			  void *priv, unsigned long src)
+{
+	(void)priv;
+	(void)src;
+
+	/* On reception of a shutdown we signal the application to terminate */
+	if ((*(unsigned int *)data) == SHUTDOWN_MSG) {
+		evt_chnl_deleted = 1;
+		return;
+	}
+
+	/* Send data back to master */
+	if (rpmsg_send(rp_chnl, data, len) < 0) {
+		LPERROR("rpmsg_send failed\n");
+	}
+}
+
+static void rpmsg_channel_created(struct rpmsg_channel *rp_chnl)
+{
+	(void)rp_chnl;
+}
+
+static void rpmsg_channel_deleted(struct rpmsg_channel *rp_chnl)
+{
+	(void)rp_chnl;
+
+	evt_chnl_deleted = 1;
+}
+
+/*-----------------------------------------------------------------------------*
+ *  Application
+ *-----------------------------------------------------------------------------*/
+int app(struct rpmsg_virtio_device *rpmsg_vdev)
+{
+	int status = 0;
+
+
+	/* disable interrupts and free resources */
+	LPRINTF("De-initializating remoteproc resource\n");
+	remoteproc_resource_deinit(proc);
+
+	return 0;
+}
+
+/*-----------------------------------------------------------------------------*
+ *  Application entry point
+ *-----------------------------------------------------------------------------*/
+int main(int argc, char *argv[])
+{
+	unsigned long proc_id = 0;
+	unsigned long rsc_id = 0;
+	int status = -1;
+
+	LPRINTF("Starting application...\n");
+
+	/* Initialize HW system components */
+	init_system();
+
+	if (argc >= 2) {
+		proc_id = strtoul(argv[1], NULL, 0);
+	}
+
+	if (argc >= 3) {
+		rsc_id = strtoul(argv[2], NULL, 0);
+	}
+
+	rproc = platform_create_proc(proc_id, rsc_id);
+	if (!rproc)
+		return -1;
+	rpmsg_vdev = platform_create_rpmsg_vdev(rproc,
+						0, VIRTIO_DEV_HOST,
+						virtio_rst_cb);
+	if (!rpmsg_vdev) {
+		remoteproc_remove(rproc);
+		status = -1;
+	}
+	app(rpmsg_vdev);
+
+	LPRINTF("Stopping application...\n");
+	cleanup_system();
+
+	return status;
+}
+

--- a/apps/echo_test_decouple/echo_testd_remoteproc_master.c
+++ b/apps/echo_test_decouple/echo_testd_remoteproc_master.c
@@ -1,0 +1,123 @@
+/* This is a sample demonstration application that showcases usage of remoteproc
+and rpmsg APIs. This application is meant to run on the master CPU running baremetal env
+and showcases booting of linux remote firmware using remoteproc and 
+IPC with remote firmware using rpmsg; Baremetal env on master core acts as a remoteproc master
+but as an rpmsg remote;It brings up a remote Linux based 
+firmware which acts as an rpmsg master and transmits data payloads to bametal code.
+Linux app sends paylaods of incremental sizes to baremetal code which echoes them back to Linux. 
+Once Linux application is complete, it requests a shutdown from baremetal env. 
+Baremetal env acknowledges with a shutdown message which results in Linux starting a system halt. 
+Baremetal env shutsdown the remote core after a reasonable delay which allows
+Linux to gracefully shutdown. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <openamp/open_amp.h>
+
+#ifdef ZYNQ7_BAREMETAL
+#include "baremetal.h"
+#endif
+
+#define SHUTDOWN_MSG	0xEF56A55A
+
+/* Internal functions */
+static void rpmsg_channel_created(struct rpmsg_channel *rp_chnl);
+static void rpmsg_channel_deleted(struct rpmsg_channel *rp_chnl);
+static void rpmsg_read_cb(struct rpmsg_channel *, void *, int, void *,
+			  unsigned long);
+static void sleep();
+
+/* Globals */
+static struct rpmsg_channel *app_rp_chnl;
+static struct rpmsg_endpoint *rp_ept;
+
+char fw_name[] = "firmware1";
+
+static int shutdown_called = 0;
+
+/* External functions */
+extern int init_system();
+extern void cleanup_system();
+
+/* External variables */
+extern struct hil_proc proc_table[];
+
+/* Application entry point */
+int main()
+{
+
+	int status;
+	struct remote_proc *proc;
+	int shutdown_msg = SHUTDOWN_MSG;
+	int i;
+
+#ifdef ZYNQ7_BAREMETAL
+	/* Switch to System Mode */
+	SWITCH_TO_SYS_MODE();
+#endif
+
+	/* Initialize HW system components */
+	init_system();
+
+	status =
+	    remoteproc_init((void *)fw_name, &proc_table[0], rpmsg_channel_created,
+			    rpmsg_channel_deleted, rpmsg_read_cb, &proc);
+
+	if (!status) {
+		status = remoteproc_boot(proc);
+	}
+
+	if (status) {
+		return -1;
+	}
+
+	while (!shutdown_called) {
+		hil_poll(proc->proc, 0);
+	}
+
+	/* Send shutdown message to remote */
+	rpmsg_send(app_rp_chnl, &shutdown_msg, sizeof(int));
+
+	for (i = 0; i < 100000; i++) {
+		sleep();
+	}
+
+	remoteproc_shutdown(proc);
+
+	remoteproc_deinit(proc);
+
+	cleanup_system();
+	return 0;
+}
+
+static void rpmsg_channel_created(struct rpmsg_channel *rp_chnl)
+{
+	app_rp_chnl = rp_chnl;
+	rp_ept = rpmsg_create_ept(rp_chnl, rpmsg_read_cb, RPMSG_NULL,
+				  RPMSG_ADDR_ANY);
+}
+
+static void rpmsg_channel_deleted(struct rpmsg_channel *rp_chnl)
+{
+	rpmsg_destroy_ept(rp_ept);
+}
+
+static void rpmsg_read_cb(struct rpmsg_channel *rp_chnl, void *data, int len,
+			  void *priv, unsigned long src)
+{
+
+	if ((*(int *)data) == SHUTDOWN_MSG) {
+		shutdown_called = 1;
+	} else {
+		/* Send data back to master */
+		rpmsg_send(rp_chnl, data, len);
+	}
+}
+
+void sleep()
+{
+	volatile int i;
+	for (i = 0; i < 100000; i++) ;
+}
+

--- a/apps/machine/zynqmp_r5/CMakeLists.txt
+++ b/apps/machine/zynqmp_r5/CMakeLists.txt
@@ -1,4 +1,4 @@
-#collect (APP_COMMON_SOURCES platform_info.c)
-#collect (APP_COMMON_SOURCES rsc_table.c)
-#collect (APP_INC_DIRS "${CMAKE_CURRENT_SOURCE_DIR}")
+collect (APP_COMMON_SOURCES platform_info.c)
+collect (APP_COMMON_SOURCES rsc_table.c)
+collect (APP_INC_DIRS "${CMAKE_CURRENT_SOURCE_DIR}")
 

--- a/apps/machine/zynqmp_r5/platform_info.c
+++ b/apps/machine/zynqmp_r5/platform_info.c
@@ -18,82 +18,335 @@
  *
  **************************************************************************/
 
-#include <openamp/hil.h>
 #include <metal/atomic.h>
+#include <metal/assert.h>
+#include <metal/device.h>
+#include <metal/irq.h>
+#include <metal/utilities.h>
+#include <openamp/rpmsg_virtio.h>
 #include "platform_info.h"
+#include "rsc_table.h"
 
+#define IPI_DEV_NAME         "ipi_dev"
+#define IPI_BUS_NAME         "generic"
 #define IPI_BASE_ADDR        XPAR_XIPIPSU_0_BASE_ADDRESS /* IPI base address*/
 #define IPI_CHN_BITMASK      0x01000000 /* IPI channel bit mask for IPI from/to
 					   APU */
+/* IPI REGs OFFSET */
+#define IPI_TRIG_OFFSET          0x00000000    /* IPI trigger register offset */
+#define IPI_OBS_OFFSET           0x00000004    /* IPI observation register offset */
+#define IPI_ISR_OFFSET           0x00000010    /* IPI interrupt status register offset */
+#define IPI_IMR_OFFSET           0x00000014    /* IPI interrupt mask register offset */
+#define IPI_IER_OFFSET           0x00000018    /* IPI interrupt enable register offset */
+#define IPI_IDR_OFFSET           0x0000001C    /* IPI interrupt disable register offset */
 
-#define APU_CPU_ID           0 /* APU remote CPU Index. We only talk to one CPU
-				* in the example. We set the CPU index to 0. */
+/* Cortex R5 memory attributes */
+#define DEVICE_SHARED		0x00000001U /*device, shareable*/
+#define DEVICE_NONSHARED	0x00000010U /*device, non shareable*/
+#define NORM_NSHARED_NCACHE	0x00000008U /* Non cacheable  non shareable */
+#define NORM_SHARED_NCACHE	0x0000000CU /* Non cacheable shareable */
+#define	PRIV_RW_USER_RW		(0x00000003U<<8U) /* Full Access */
+
+#define SHARED_BUF_PA  0x3ED40000UL
+#define SHARED_BUF_SIZE 0x100000UL
+
+#define _rproc_wait() asm volatile("wfi")
 
 /* IPI information used by remoteproc operations.
  */
+static metal_phys_addr_t ipi_phys_addr = IPI_BASE_ADDR;
+struct metal_device ipi_device = {
+	.name = "ipi_dev",
+	.bus = NULL,
+	.num_regions = 1,
+	.regions = {
+		{
+			.virt = (void*)IPI_BASE_ADDR,
+			.physmap = &ipi_phys_addr,
+			.size = 0x1000,
+			.page_shift = -1UL,
+			.page_mask = -1UL,
+			.mem_flags = DEVICE_NONSHARED | PRIV_RW_USER_RW,
+			.ops = {NULL},
+		}
+	},
+	.node = {NULL},
+	.irq_num = 1,
+	.irq_info = (void *)IPI_IRQ_VECT_ID,
+};
+
 struct ipi_info {
 	const char *name; /* IPI device name */
 	const char *bus_name; /* IPI bus name */
-	struct meta_device *dev; /* IPI metal device */
-	struct metal_io_region *io; /* IPI metal IO region */
-	metal_phys_addr_t paddr; /* IPI registers base address */
 	uint32_t ipi_chn_mask; /* IPI channel mask */
-	int registered; /* used internally by RPU to APU remoteproc to mark
-			 * if the IPI interrup has been registered */
-	atomic_int sync; /* used internally by RPU to APU remoteproc to mark
-			  * if there is kick from the remote */
 };
 
-/* processor operations for hil_proc from r5 to a53. It defines
- * notification operation and remote processor managementi operations. */
-extern struct hil_platform_ops zynqmp_r5_a53_proc_ops;
-
-/* IPI information definition. It is used in the RPU to APU remoteproc
- * operations. The fields name, bus_name, dev and io are NULL because they
- * are set by remoteproc operations internally later. */
-static struct ipi_info chn_ipi_info[] = {
-	{NULL, NULL, NULL, NULL, IPI_BASE_ADDR, IPI_CHN_BITMASK, 0, 0},
+struct ipi_info ipi_info = {
+	.name = IPI_DEV_NAME,
+	.bus_name = IPI_BUS_NAME,
+	.ipi_chn_mask = IPI_CHN_BITMASK,
 };
 
-/* Firmware_info and fw_table_size are required in current version (2017.3)
- * of OpenAMP library to pass compilation. Will be removed in next release
- * if the OpenAMP application is not used to boot the remote. */
-const struct firmware_info fw_table[] =
+struct remoteproc_priv {
+	struct remoteproc rproc;
+	struct metal_device *ipi_dev;
+	struct metal_io_region *ipi_io;
+	unsigned int ipi_chn_mask;
+	atomic_int ipi_nokick;
+};
+
+static int zynqmp_r5_a53_proc_irq_handler(int vect_id, void *data)
 {
-	{"unknown",
-	 0,
-	 0}
-};
-const int fw_table_size = sizeof(fw_table)/sizeof(struct firmware_info);
+	struct remoteproc_priv *prproc = data;
+	unsigned int ipi_intr_status;
 
-struct hil_proc *platform_create_proc(int proc_index)
+	(void)vect_id;
+	if (!prproc)
+		return METAL_IRQ_NOT_HANDLED;
+	ipi_intr_status = (unsigned int)metal_io_read32(prproc->ipi_io,
+							IPI_ISR_OFFSET);
+	if (ipi_intr_status & prproc->ipi_chn_mask) {
+		atomic_flag_clear(&prproc->ipi_nokick);
+		metal_io_write32(prproc->ipi_io, IPI_ISR_OFFSET,
+				 prproc->ipi_chn_mask);
+		return METAL_IRQ_HANDLED;
+	}
+	return METAL_IRQ_NOT_HANDLED;
+}
+
+static struct remoteproc *
+zynqmp_r5_a53_proc_init(struct remoteproc_ops *ops, void *arg)
 {
-	(void) proc_index;
+	struct ipi_info *ipi = arg;
+	struct remoteproc_priv *prproc;
+	struct metal_device *ipi_dev;
+	unsigned int irq_vect;
+	int ret;
 
-	/* structure to represent a remote processor. It encapsulates the
-	 * shared memory and notification info required for inter processor
-	 * communication. */
-	struct hil_proc *proc;
-	proc = hil_create_proc(&zynqmp_r5_a53_proc_ops, APU_CPU_ID, NULL);
-	if (!proc)
+	if (!ipi || !ops)
 		return NULL;
+	prproc = metal_allocate_memory(sizeof(*prproc));
+	if (!prproc)
+		return NULL;
+	memset(prproc, 0, sizeof(*prproc));
+	ret = metal_device_open(ipi->bus_name, ipi->name, &ipi_dev);
+	if (ret) {
+		xil_printf("failed to open ipi device: %d.\r\n", ret);
+		goto err1;
+	}
+	prproc->ipi_dev = ipi_dev;
+	prproc->ipi_io = metal_device_io_region(ipi_dev, 0);
+	if (!prproc->ipi_io)
+		goto err2;
+	prproc->ipi_chn_mask = ipi->ipi_chn_mask;
+	atomic_store(&prproc->ipi_nokick, 1);
+	prproc->rproc.ops = ops;
 
-	/*************************************************************
-	 * Set VirtIO device and vrings notification private data to
-	 * hil_proc.
-	 *************************************************************/
-	/* Set VirtIO device nofication private data. It will be used when it
-	 * needs to notify the remote on the virtio device status change. */
-	hil_set_vdev_ipi(proc, 0,
-		IPI_IRQ_VECT_ID, (void *)&chn_ipi_info[0]);
-	/* Set vring 0 nofication private data. */
-	hil_set_vring_ipi(proc, 0,
-		IPI_IRQ_VECT_ID, (void *)&chn_ipi_info[0]);
-	/* Set vring 1 nofication private data. */
-	hil_set_vring_ipi(proc, 1,
-		IPI_IRQ_VECT_ID, (void *)&chn_ipi_info[0]);
-	/* Set name of RPMsg channel 0 */
-	hil_set_rpmsg_channel(proc, 0, RPMSG_CHAN_NAME);
+	/* Register interrupt handler and enable interrupt */
+	irq_vect = IPI_IRQ_VECT_ID;
+	metal_irq_register(irq_vect, zynqmp_r5_a53_proc_irq_handler,
+			   ipi_dev, prproc);
+	metal_irq_enable(irq_vect);
+	metal_io_write32(prproc->ipi_io, IPI_IER_OFFSET,
+			 prproc->ipi_chn_mask);
+	return &prproc->rproc;
+err2:
+	metal_device_close(ipi_dev);
+err1:
+	metal_free_memory(prproc);
+	return NULL;
+}
 
-	return proc;
+static void zynqmp_r5_a53_proc_remove(struct remoteproc *rproc)
+{
+	struct remoteproc_priv *prproc;
+
+	if (!rproc)
+		return;
+	prproc = metal_container_of(rproc, struct remoteproc_priv, rproc);
+	metal_io_write32(prproc->ipi_io, IPI_IDR_OFFSET, prproc->ipi_chn_mask);
+	metal_irq_disable(IPI_IRQ_VECT_ID);
+	metal_irq_unregister(IPI_IRQ_VECT_ID, NULL, NULL, NULL);
+	if (prproc->ipi_dev)
+		metal_device_close(prproc->ipi_dev);
+	metal_free_memory(prproc);
+}
+
+static void *
+zynqmp_r5_a53_proc_mmap(struct remoteproc *rproc, metal_phys_addr_t *pa,
+			metal_phys_addr_t *da, size_t size,
+			unsigned int attribute, struct metal_io_region **io)
+{
+	struct remoteproc_mem *mem;
+	metal_phys_addr_t lpa, lda;
+	struct metal_io_region *tmpio;
+
+	lpa = *pa;
+	lda = *da;
+
+	if (lpa == METAL_BAD_PHYS && lda == METAL_BAD_PHYS)
+		return NULL;
+	if (lpa == METAL_BAD_PHYS)
+		lpa = lda;
+	if (lda == METAL_BAD_PHYS)
+		lda = lpa;
+
+	if (!attribute)
+		attribute = NORM_SHARED_NCACHE | PRIV_RW_USER_RW;
+	mem = metal_allocate_memory(sizeof(*mem));
+	if (!mem)
+		return NULL;
+	mem->pa = lpa;
+	mem->da = lda;
+	mem->size = size;
+	tmpio = metal_allocate_memory(sizeof(*tmpio));
+	if (!tmpio) {
+		metal_free_memory(mem);
+		return NULL;
+	}
+	/* va is the same as pa in this platform */
+	metal_io_init(tmpio, (void *)mem->pa, &mem->pa, size,
+		      sizeof(metal_phys_addr_t)<<3, attribute, NULL);
+	mem->io = tmpio;
+	metal_list_add_tail(&rproc->mems, &mem->node);
+	*pa = lpa;
+	*da = lda;
+	*io = tmpio;
+	return metal_io_phys_to_virt(tmpio, mem->pa);
+}
+
+static int zynqmp_r5_a53_proc_notify(struct remoteproc *rproc, uint32_t id)
+{
+	struct remoteproc_priv *prproc;
+
+	(void)id;
+	if (!rproc)
+		return -1;
+	prproc = metal_container_of(rproc, struct remoteproc_priv, rproc);
+
+	/* TODO: use IPI driver instead and pass ID */
+	metal_io_write32(prproc->ipi_io, IPI_TRIG_OFFSET,
+			  prproc->ipi_chn_mask);
+	return 0;
+}
+
+/* processor operations from r5 to a53. It defines
+ * notification operation and remote processor managementi operations. */
+static struct remoteproc_ops zynqmp_r5_a53_proc_ops = {
+	.init = zynqmp_r5_a53_proc_init,
+	.remove = zynqmp_r5_a53_proc_remove,
+	.mmap = zynqmp_r5_a53_proc_mmap,
+	.notify = zynqmp_r5_a53_proc_notify,
+	.start = NULL,
+	.stop = NULL,
+	.shutdown = NULL,
+};
+
+
+struct remoteproc *platform_create_proc(int proc_index, int rsc_index)
+{
+	struct remoteproc *rproc;
+	void *rsc_table;
+	int rsc_size;
+	int ret;
+	metal_phys_addr_t pa;
+
+	(void) proc_index;
+	rsc_table = get_resource_table(rsc_index, &rsc_size);
+
+	/* Register IPI device */
+	(void)metal_register_generic_device(&ipi_device);
+	/* Initialize remoteproc instance */
+	rproc = remoteproc_init(&zynqmp_r5_a53_proc_ops, &ipi_info);
+	if (!rproc) {
+		xil_printf("Failed to intialize remoteproc\r\n");
+		return NULL;
+	}
+
+	/*
+	 * Mmap shared memories
+	 * Or shall we constraint that they will be set as carved out
+	 * in the resource table?
+	 */
+	/* mmap resource table */
+	pa = (metal_phys_addr_t)rsc_table;
+	(void *)remoteproc_mmap(rproc, &pa,
+				NULL, rsc_size,
+				NORM_NSHARED_NCACHE|PRIV_RW_USER_RW,
+				&rproc->rsc_io);
+	/* mmap shared memory */
+	pa = SHARED_BUF_PA;
+	(void *)remoteproc_mmap(rproc, &pa,
+				NULL, SHARED_BUF_SIZE,
+				NORM_NSHARED_NCACHE|PRIV_RW_USER_RW,
+				NULL);
+
+	/* parse resource table to remoteproc */
+	ret = remoteproc_set_rsc_table(rproc, rsc_table, rsc_size);
+	if (ret) {
+		xil_printf("Failed to parse resource table\r\n");
+		remoteproc_remove(rproc);
+		return NULL;
+	}
+	xil_printf("Successfully parse resource table\r\n");
+
+	return rproc;
+}
+
+struct  rpmsg_device *
+platform_create_rpmsg_vdev(struct remoteproc *rproc, unsigned int vdev_index,
+			   unsigned int role,
+			   void (*rst_cb)(struct virtio_device *vdev))
+{
+	struct rpmsg_virtio_device *rpmsg_vdev;
+	struct virtio_device *vdev;
+	void *shbuf;
+	struct metal_io_region *shbuf_io;
+	int ret;
+
+	rpmsg_vdev = metal_allocate_memory(sizeof(*rpmsg_vdev));
+	if (!rpmsg_vdev)
+		return NULL;
+	shbuf_io = remoteproc_get_io_with_pa(rproc, SHARED_BUF_PA);
+	if (!shbuf_io)
+		return NULL;
+	shbuf = metal_io_phys_to_virt(shbuf_io, SHARED_BUF_PA);
+
+	/* TODO: can we have a wrapper for the following two functions? */
+	vdev = remoteproc_create_virtio(rproc, vdev_index, role, rst_cb);
+	if (!vdev) {
+		xil_printf("failed remoteproc_create_virtio\r\n");
+		goto err1;
+	}
+
+	ret =  rpmsg_init_vdev(rpmsg_vdev, vdev, NULL, shbuf_io, shbuf,
+			       SHARED_BUF_SIZE);
+	if (ret) {
+		xil_printf("failed rpmsg_init_vdev\r\n");
+		goto err2;
+	}
+	return rpmsg_virtio_get_rpmsg_device(rpmsg_vdev);
+err2:
+	remoteproc_remove_virtio(rproc, vdev);
+err1:
+	metal_free_memory(rpmsg_vdev);
+	return NULL;
+}
+
+int platform_poll(void *priv)
+{
+	struct remoteproc *rproc = priv;
+	struct remoteproc_priv *prproc;
+	unsigned int flags;
+
+	prproc = metal_container_of(rproc, struct remoteproc_priv, rproc);
+	while(1) {
+		flags = metal_irq_save_disable();
+		if (!(atomic_flag_test_and_set(&prproc->ipi_nokick))) {
+			metal_irq_restore_enable(flags);
+			remoteproc_get_notification(rproc, RSC_NOTIFY_ID_ANY);
+		}
+		_rproc_wait();
+		metal_irq_restore_enable(flags);
+	}
 }

--- a/apps/machine/zynqmp_r5/platform_info.h
+++ b/apps/machine/zynqmp_r5/platform_info.h
@@ -1,13 +1,20 @@
 #ifndef PLATFORM_INFO_H_
 #define PLATFORM_INFO_H_
 
-#include <openamp/hil.h>
+#include <openamp/remoteproc.h>
+#include <openamp/virtio.h>
+#include <openamp/rpmsg.h>
 
 /* Interrupt vectors */
 #define IPI_IRQ_VECT_ID         XPAR_XIPIPSU_0_INT_ID
 
 #define RPMSG_CHAN_NAME         "rpmsg-openamp-demo-channel"
 
-struct hil_proc *platform_create_proc(int proc_index);
+struct remoteproc *platform_create_proc(int proc_index, int rsc_index);
 
+struct  rpmsg_device *
+platform_create_rpmsg_vdev(struct remoteproc *rproc, unsigned int vdev_index,
+			   unsigned int role,
+			   void (*rst_cb)(struct virtio_device *vdev));
+int platform_poll(void *priv);
 #endif /* PLATFORM_INFO_H_ */

--- a/apps/system/generic/machine/zynqmp_r5/CMakeLists.txt
+++ b/apps/system/generic/machine/zynqmp_r5/CMakeLists.txt
@@ -1,4 +1,4 @@
-#collect (APP_COMMON_SOURCES helper.c)
+collect (APP_COMMON_SOURCES helper.c)
 
 if (WITH_REMOTEPROC_MASTER)
   message(FATAL_ERROR "Remoteproc master is not currently supported on ${MACHINE}/${SYSTEM}.")

--- a/apps/system/generic/machine/zynqmp_r5/helper.c
+++ b/apps/system/generic/machine/zynqmp_r5/helper.c
@@ -76,11 +76,22 @@ static int app_gic_initialize(void)
 	return 0;
 }
 
+static void system_metal_logger(enum metal_log_level level,
+			   const char *format, ...)
+{
+	(void)level;
+	(void)format;
+}
+
+
 /* Main hw machinery initialization entry point, called from main()*/
 /* return 0 on success */
 int init_system(void)
 {
-	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+	struct metal_init_params metal_param = {
+		.log_handler = system_metal_logger,
+		.log_level = METAL_LOG_INFO,
+	};
 
 	/* Low level abstraction layer for openamp initialization */
 	metal_init(&metal_param);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,7 +8,7 @@ collect (PROJECT_INC_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 add_subdirectory (common)
 add_subdirectory (virtio)
-#add_subdirectory (rpmsg)
+add_subdirectory (rpmsg)
 add_subdirectory (remoteproc)
 
 if (WITH_PROXY)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,7 +7,7 @@ collect (PROJECT_INC_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 
 add_subdirectory (common)
-#add_subdirectory (virtio)
+add_subdirectory (virtio)
 #add_subdirectory (rpmsg)
 add_subdirectory (remoteproc)
 

--- a/lib/include/openamp/open_amp.h
+++ b/lib/include/openamp/open_amp.h
@@ -11,6 +11,7 @@
 #include <openamp/rpmsg.h>
 #include <openamp/rpmsg_virtio.h>
 #include <openamp/remoteproc.h>
+#include <openamp/remoteproc_virtio.h>
 
 
 #endif				/* OPEN_AMP_H_ */

--- a/lib/include/openamp/open_amp.h
+++ b/lib/include/openamp/open_amp.h
@@ -9,6 +9,7 @@
 #define OPEN_AMP_H_
 
 #include <openamp/rpmsg.h>
+#include <openamp/rpmsg_virtio.h>
 #include <openamp/remoteproc.h>
 
 

--- a/lib/include/openamp/remoteproc_virtio.h
+++ b/lib/include/openamp/remoteproc_virtio.h
@@ -38,49 +38,33 @@
 
 #include <metal/io.h>
 #include <metal/list.h>
+#include <openamp/virtio.h>
 
 #if defined __cplusplus
 extern "C" {
 #endif
 
 /* define vdev notification funciton user should implement */
-typedef int (*notify_func)(uint32_t id, void *priv);
-
-/**
- * struct remoteproc_vring - remoteproc vring structure
- * @vq virtio queue
- * @va logical address
- * @notifyid vring notify id
- * @num_descs number of descriptors
- * @align vring alignment
- * @io metal I/O region of the vring memory, can be NULL
- */
-struct remoteproc_vring {
-	struct virtqueue *vq;
-	void *va;
-	uint32_t notifyid;
-	unsigned int num_descs;
-	unsigned int align;
-	struct metal_io_region *io;
-};
+typedef int (*rpvdev_notify_func)(void *priv, uint32_t id);
 
 /**
  * struct remoteproc_virtio
- * @rproc pointer to remoteproc instance
- * @rvrings vrings information list
- * @vdev pointer to virtio device
- * @num_vrings number of vrings
- * @vdev_rsc address of vdev informaiton
+ * @priv pointer to private data
+ * @notifyid notification id
+ * @vdev_rsc address of vdev resource
  * @vdev_rsc_io metal I/O region of vdev_info, can be NULL
+ * @notify notification function
  * @vdev virtio device
+ * @node list node
  */
 struct remoteproc_virtio {
-	struct remoteproc *rproc;
-	struct remoteproc_vring *rvrings;
-	unsigned int num_vrings;
+	void *priv;
+	uint32_t notify_id;
 	void *vdev_rsc;
 	struct metal_io_region *vdev_rsc_io;
+	rpvdev_notify_func notify;
 	struct virtio_device vdev;
+	struct metal_list node;
 };
 
 /**
@@ -88,35 +72,64 @@ struct remoteproc_virtio {
  *
  * Create rproc virtio vdev
  *
- * @rproc:  pointer to the remoteproc instance
  * @role: 0 - virtio master, 1 - virtio slave
- * @index: virtio device index
+ * @notifyid: virtio device notification id
  * @rsc: pointer to the virtio device resource
+ * @rsc_io: pointer to the virtio device resource I/O region
+ * @priv: pointer to the private data
+ * @notify: vdev and virtqueue notification function
  * @rst_cb: reset virtio device callback
  *
  * return pointer to the created virtio device for success,
  * NULL for failure.
  */
 struct virtio_device *
-rproc_virtio_create_vdev(struct remoteproc *rproc, unsigned int role,
-			 int index, void *rsc,
-			 int (*rst_cb)(struct virtio_device *vdev));
+rproc_virtio_create_vdev(unsigned int role, unsigned int notifyid,
+			 void *rsc, struct metal_io_region *rsc_io,
+			 void *priv,
+			 rpvdev_notify_func notify,
+			 virtio_dev_reset_cb rst_cb);
+
+/**
+ * rproc_virtio_remove_vdev
+ *
+ * Create rproc virtio vdev
+ *
+ * @vdev - pointer to the virtio device
+ */
+void rproc_virtio_remove_vdev(struct virtio_device *vdev);
 
 /**
  * rproc_virtio_create_vring
  *
  * Create rproc virtio vring
  *
- * @rpvdev: pointer to the rproc virtio device
- * @index: vring index
+ * @vdev: pointer to the virtio device
+ * @index: vring index in the virtio device
+ * @notifyid: remoteproc vring notification id
  * @va: vring virtual address
+ * @io: pointer to vring I/O region
  * @num_desc: number of descriptors
  * @align: vring alignment
  *
  * return 0 for success, negative value for failure.
  */
-int rproc_virtio_create_vring(struct remoteproc_virtio *rpvdev, int index,
-			      void *va, size_t num_descs, unsigned int align);
+int rproc_virtio_init_vring(struct virtio_device *vdev, unsigned int index,
+			    unsigned int notifyid, void *va,
+			    struct metal_io_region *io,
+			    unsigned int num_descs, unsigned int align);
+
+/**
+ * rproc_virtio_notified
+ *
+ * remoteproc virtio is got notified
+ *
+ * @vdev - pointer to the virtio device
+ * @notifyid - notify id
+ *
+ * return 0 for successful, negative value for failure
+ */
+int rproc_virtio_notified(struct virtio_device *vdev, uint32_t notifyid);
 
 #if defined __cplusplus
 }

--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -312,10 +312,9 @@ static inline void rpmsg_init_ept(struct rpmsg_endpoint *ept,
  * source address.
  */
 
-struct rpmsg_endpoint *rpmsg_create_ept(struct rpmsg_device *rdev,
-					const char *name, uint32_t src,
-					uint32_t dest, rpmsg_ept_cb cb,
-					rpmsg_ept_destroy_cb destroy_cb);
+int rpmsg_create_ept(struct rpmsg_endpoint *ept, struct rpmsg_device *rdev,
+		     const char *name, uint32_t src, uint32_t dest,
+		     rpmsg_ept_cb cb, rpmsg_ept_destroy_cb destroy_cb);
 
 /**
  * rpmsg_destroy_ept - destroy rpmsg endpoint and unregister it from rpmsg

--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -88,6 +88,7 @@ struct rpmsg_device_ops {
 /**
  * struct rpmsg_device - representation of a RPMsg device
  * @endpoints: list of endpoints
+ * @ns_ept: name service endpoint
  * @bitmap: table endpoin address allocation.
  * @lock: mutex lock for rpmsg management
  * @new_endpoint_cb: callback handler for new service announcement without local
@@ -96,6 +97,7 @@ struct rpmsg_device_ops {
  */
 struct rpmsg_device {
 	struct metal_list endpoints;
+	struct rpmsg_endpoint ns_ept;
 	unsigned long bitmap[RPMSG_ADDR_BMP_SIZE];
 	metal_mutex_t lock;
 	void (*new_endpoint_cb)(struct rpmsg_endpoint *ep);

--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -1,0 +1,333 @@
+/*
+ * Remote processor messaging
+ *
+ * Copyright (C) 2011 Texas Instruments, Inc.
+ * Copyright (C) 2011 Google, Inc.
+ * All rights reserved.
+ * Copyright (c) 2016 Freescale Semiconductor, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _RPMSG_H_
+#define _RPMSG_H_
+
+#include <openamp/compiler.h>
+#include <openamp/sh_mem.h>
+#include <metal/mutex.h>
+#include <metal/list.h>
+#include <string.h>
+#include <stdbool.h>
+
+#if defined __cplusplus
+extern "C" {
+#endif
+
+/* Configurable parameters */
+#define RPMSG_NAME_SIZE		(32)
+#define RPMSG_ADDR_BMP_SIZE	(4)
+
+#define RPMSG_NS_EPT_ADDR	(0x35)
+#define RPMSG_ADDR_ANY		0xFFFFFFFF
+
+/* Error macros. */
+#define RPMSG_SUCCESS		0
+#define RPMSG_ERROR_BASE	-2000
+#define RPMSG_ERR_NO_MEM	(RPMSG_ERROR_BASE - 1)
+#define RPMSG_ERR_NO_BUFF	(RPMSG_ERROR_BASE - 2)
+#define RPMSG_ERR_PARAM		(RPMSG_ERROR_BASE - 3)
+#define RPMSG_ERR_DEV_STATE	(RPMSG_ERROR_BASE - 4)
+#define RPMSG_ERR_BUFF_SIZE	(RPMSG_ERROR_BASE - 5)
+#define RPMSG_ERR_INIT		(RPMSG_ERROR_BASE - 6)
+#define RPMSG_ERR_ADDR		(RPMSG_ERROR_BASE - 7)
+
+struct rpmsg_endpoint;
+
+typedef void (*rpmsg_ept_cb)(struct rpmsg_endpoint *ept, void *data,
+			     size_t len, uint32_t src, void *priv);
+typedef void (*rpmsg_ept_destroy_cb)(struct rpmsg_endpoint *ept);
+
+struct rpmsg_device;
+
+/**
+ * struct rpmsg_endpoint - binds a local rpmsg address to its user
+ * @name:name of the service supported
+ * @rdev: pointer to the rpmsg device
+ * @addr: local address of the endpoint
+ * @dest_addr: address of the default remote endpoint binded.
+ * @cb: user rx callback
+ * @destroy_cb: user end point detsroy callback
+ * @node: end point node.
+ * @addr: local rpmsg address
+ * @priv: private data for the driver's use
+ *
+ * In essence, an rpmsg endpoint represents a listener on the rpmsg bus, as
+ * it binds an rpmsg address with an rx callback handler.
+ */
+struct rpmsg_endpoint {
+	char name[RPMSG_NAME_SIZE];
+	struct rpmsg_device *rdev;
+	uint32_t addr;
+	uint32_t dest_addr;
+	rpmsg_ept_cb cb;
+	rpmsg_ept_destroy_cb destroy_cb;
+	struct metal_list node;
+	void *priv;
+};
+
+/**
+ * struct rpmsg_device_ops - RPMsg device operations
+ * @send_offchannel_raw: send RPMsg data
+ */
+struct rpmsg_device_ops {
+	int (*send_offchannel_raw)(struct rpmsg_device *rdev,
+				   uint32_t src, uint32_t dst,
+				   const void *data, int size, int wait);
+};
+
+/**
+ * struct rpmsg_device - representation of a RPMsg device
+ * @endpoints: list of endpoints
+ * @bitmap: table endpoin address allocation.
+ * @lock: mutex lock for rpmsg management
+ * @new_endpoint_cb: callback handler for new service announcement without local
+ *                   endpoints waiting to bind.
+ * @ops: RPMsg device operations
+ */
+struct rpmsg_device {
+	struct metal_list endpoints;
+	unsigned long bitmap[RPMSG_ADDR_BMP_SIZE];
+	metal_mutex_t lock;
+	void (*new_endpoint_cb)(struct rpmsg_endpoint *ep);
+	struct rpmsg_device_ops ops;
+};
+
+int rpmsg_send_offchannel_raw(struct rpmsg_endpoint *ept, uint32_t src,
+			      uint32_t dst, const void *data, int size,
+			      int wait);
+
+/**
+ * rpmsg_send() - send a message across to the remote processor
+ * @ept: the rpmsg endpoint
+ * @data: payload of the message
+ * @len: length of the payload
+ *
+ * This function sends @data of length @len based on the @ept.
+ * The message will be sent to the remote processor which the channel belongs
+ * to, using @ept's source and destination addresses.
+ * In case there are no TX buffers available, the function will block until
+ * one becomes available, or a timeout of 15 seconds elapses. When the latter
+ * happens, -ERESTARTSYS is returned.
+ *
+ * Can only be called from process context (for now).
+ *
+ * Returns number of bytes it has sent or negative error value on failure.
+ */
+static inline int rpmsg_send(struct rpmsg_endpoint *ept, const void *data, int len)
+{
+	if (ept->dest_addr == RPMSG_ADDR_ANY)
+		return RPMSG_ERR_ADDR;
+	return rpmsg_send_offchannel_raw(ept, ept->addr, ept->dest_addr, data,
+					 len, true);
+}
+
+/**
+ * rpmsg_sendto() - send a message across to the remote processor, specify dst
+ * @ept: the rpmsg endpoint
+ * @data: payload of message
+ * @len: length of payload
+ * @dst: destination address
+ *
+ * This function sends @data of length @len to the remote @dst address.
+ * The message will be sent to the remote processor which the @ept
+ * channel belongs to, using @ept's source address.
+ * In case there are no TX buffers available, the function will block until
+ * one becomes available, or a timeout of 15 seconds elapses. When the latter
+ * happens, -ERESTARTSYS is returned.
+ *
+ * Can only be called from process context (for now).
+ *
+ * Returns number of bytes it has sent or negative error value on failure.
+ */
+static inline int rpmsg_sendto(struct rpmsg_endpoint *ept, const void *data,
+			int len, uint32_t dst)
+{
+	return rpmsg_send_offchannel_raw(ept, ept->addr, dst, data, len, true);
+}
+
+/**
+ * rpmsg_send_offchannel() - send a message using explicit src/dst addresses
+ * @ept: the rpmsg endpoint
+ * @src: source address
+ * @dst: destination address
+ * @data: payload of message
+ * @len: length of payload
+ *
+ * This function sends @data of length @len to the remote @dst address,
+ * and uses @src as the source address.
+ * The message will be sent to the remote processor which the @ept
+ * channel belongs to.
+ * In case there are no TX buffers available, the function will block until
+ * one becomes available, or a timeout of 15 seconds elapses. When the latter
+ * happens, -ERESTARTSYS is returned.
+ *
+ * Can only be called from process context (for now).
+ *
+ * Returns number of bytes it has sent or negative error value on failure.
+ */
+static inline int rpmsg_send_offchannel(struct rpmsg_endpoint *ept,
+					uint32_t src, uint32_t dst,
+					const void *data, int len)
+{
+	return rpmsg_send_offchannel_raw(ept, src, dst, data, len, true);
+}
+
+/**
+ * rpmsg_trysend() - send a message across to the remote processor
+ * @ept: the rpmsg endpoint
+ * @data: payload of message
+ * @len: length of payload
+ *
+ * This function sends @data of length @len on the @ept channel.
+ * The message will be sent to the remote processor which the @ept
+ * channel belongs to, using @ept's source and destination addresses.
+ * In case there are no TX buffers available, the function will immediately
+ * return -ENOMEM without waiting until one becomes available.
+ *
+ * Can only be called from process context (for now).
+ *
+ * Returns number of bytes it has sent or negative error value on failure.
+ */
+static inline int rpmsg_trysend(struct rpmsg_endpoint *ept, const void *data,
+				int len)
+{
+	if (ept->dest_addr == RPMSG_ADDR_ANY)
+		return RPMSG_ERR_ADDR;
+	return rpmsg_send_offchannel_raw(ept, ept->addr, ept->dest_addr, data,
+					 len, false);
+}
+
+/**
+ * rpmsg_trysendto() - send a message across to the remote processor,
+ * specify dst
+ * @ept: the rpmsg endpoint
+ * @data: payload of message
+ * @len: length of payload
+ * @dst: destination address
+ *
+ * This function sends @data of length @len to the remote @dst address.
+ * The message will be sent to the remote processor which the @ept
+ * channel belongs to, using @ept's source address.
+ * In case there are no TX buffers available, the function will immediately
+ * return -ENOMEM without waiting until one becomes available.
+ *
+ * Can only be called from process context (for now).
+ *
+ * Returns number of bytes it has sent or negative error value on failure.
+ */
+static inline int rpmsg_trysendto(struct rpmsg_endpoint *ept, const void *data,
+				  int len, uint32_t dst)
+{
+	return rpmsg_send_offchannel_raw(ept, ept->addr, dst, data, len, false);
+}
+
+/**
+ * rpmsg_trysend_offchannel() - send a message using explicit src/dst addresses
+ * @ept: the rpmsg endpoint
+ * @src: source address
+ * @dst: destination address
+ * @data: payload of message
+ * @len: length of payload
+ *
+ * This function sends @data of length @len to the remote @dst address,
+ * and uses @src as the source address.
+ * The message will be sent to the remote processor which the @ept
+ * channel belongs to.
+ * In case there are no TX buffers available, the function will immediately
+ * return -ENOMEM without waiting until one becomes available.
+ *
+ * Can only be called from process context (for now).
+ *
+ * Returns number of bytes it has sent or negative error value on failure.
+ */
+static inline int rpmsg_trysend_offchannel(struct rpmsg_endpoint *ept,
+					   uint32_t src, uint32_t dst,
+					   const void *data, int len)
+{
+	return rpmsg_send_offchannel_raw(ept, src, dst, data, len, false);
+}
+
+void (*rpmsg_endpoint_destroy_callback)(struct rpmsg_endpoint *ept, void *priv);
+
+/**
+ * rpmsg_init_ept - initialize rpmsg endpoint
+ *
+ * Initialize an RPMsg endpoint with a name, source address,
+ * remoteproc address, endpoitn callback, and destroy endpoint callback.
+ *
+ * @ept: pointer to rpmsg endpoint
+ * @name: service name associated to the endpoint
+ * @src: local address of the endpoint
+ * @dest: target address of the endpoint
+ * @cb: endpoint callback
+ * @destroy_cb: destory endpoint callback
+ */
+static inline void rpmsg_init_ept(struct rpmsg_endpoint *ept,
+				  const char *name,
+				  uint32_t src, uint32_t dest,
+				  rpmsg_ept_cb cb,
+				  rpmsg_ept_destroy_cb destroy_cb)
+{
+	strncpy(ept->name, name, sizeof(ept->name));
+	ept->addr = src;
+	ept->dest_addr = dest;
+	ept->cb = cb;
+	ept->destroy_cb = destroy_cb;
+}
+
+/**
+ * rpmsg_create_ept - create rpmsg endpoint and register it to rpmsg device
+ *
+ * Create a RPMsg endpoint, initialize it with a name, source address,
+ * remoteproc address, endpoitn callback, and destroy endpoint callback,
+ * and register it to the RPMsg device.
+ *
+ * @ept: pointer to rpmsg endpoint
+ * @name: service name associated to the endpoint
+ * @src: local address of the endpoint
+ * @dest: target address of the endpoint
+ * @cb: endpoint callback
+ * @destroy_cb: destory endpoint callback
+ *
+ * In essence, an rpmsg endpoint represents a listener on the rpmsg bus, as
+ * it binds an rpmsg address with an rx callback handler.
+ *
+ * Rpmsg client should create an endpoint to discuss with remote. rpmsg client
+ * provide at least a channel name, a callback for message notification and by
+ * default endpoint source address should be set to RPMSG_ADDR_ANY.
+ *
+ * As an option Some rpmsg clients can specify an endpoint with a specific
+ * source address.
+ */
+
+struct rpmsg_endpoint *rpmsg_create_ept(struct rpmsg_device *rdev,
+					const char *name, uint32_t src,
+					uint32_t dest, rpmsg_ept_cb cb,
+					rpmsg_ept_destroy_cb destroy_cb);
+
+/**
+ * rpmsg_destroy_ept - destroy rpmsg endpoint and unregister it from rpmsg
+ *                     device
+ *
+ * @ept: pointer to the rpmsg endpoint
+ *
+ * It unregisters the rpmsg endpoint from the rpmsg device and calls the
+ * destroy endpoint callback if it is provided.
+ */
+void rpmsg_destroy_ept(struct rpmsg_endpoint *ept);
+
+#if defined __cplusplus
+}
+#endif
+
+#endif				/* _RPMSG_H_ */

--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -100,7 +100,7 @@ struct rpmsg_device {
 	struct rpmsg_endpoint ns_ept;
 	unsigned long bitmap[RPMSG_ADDR_BMP_SIZE];
 	metal_mutex_t lock;
-	void (*new_endpoint_cb)(struct rpmsg_endpoint *ep);
+	void (*new_endpoint_cb)(const char *name, uint32_t src);
 	struct rpmsg_device_ops ops;
 };
 

--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -1,0 +1,101 @@
+/*
+ * rpmsg based on virtio
+ *
+ * Copyright (C) 2018 Linaro, Inc.
+ *
+ * All rights reserved.
+ * Copyright (c) 2016 Freescale Semiconductor, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _RPMSG_VIRTIO_H_
+#define _RPMSG_VIRTIO_H_
+
+#include <metal/io.h>
+#include <metal/mutex.h>
+#include <openamp/rpmsg.h>
+#include <openamp/virtio.h>
+
+#if defined __cplusplus
+extern "C" {
+#endif
+
+/* Configurable parameters */
+#ifndef RPMSG_BUFFER_SIZE
+#define RPMSG_BUFFER_SIZE	(512)
+#endif
+
+/* The feature bitmap for virtio rpmsg */
+#define VIRTIO_RPMSG_F_NS 0 /* RP supports name service notifications */
+
+/**
+ * struct rpmsg_virtio_device - representation of a rpmsg device based on virtio
+ * @rdev: rpmsg device, first property in the struct
+ * @vdev: pointer to the virtio device
+ * @rvq: pointer to receive virtqueue
+ * @svq: pointer to send virtqueue
+ * @buffers_number: number of shared buffers
+ * @shbuf_io: pointer to the shared buffer I/O region.
+ * @new_endpoint_cb: callback handler for new service announcement without local
+ *                   endpoints waiting to bind.
+ * @endpoints: list of endpoints.
+ */
+struct rpmsg_virtio_device {
+	struct rpmsg_device rdev;
+	struct virtio_device *vdev;
+	struct virtqueue *rvq;
+	struct virtqueue *svq;
+	struct metal_io_region *shbuf_io;
+	struct sh_mem_pool *shbuf;
+};
+
+#define RPMSG_REMOTE	VIRTIO_DEV_SLAVE
+#define RPMSG_MASTER	VIRTIO_DEV_MASTER
+static inline unsigned int rpmsg_virtio_get_role(struct rpmsg_virtio_device *rvdev)
+{
+	return rvdev->vdev->role;
+}
+
+static inline void rpmsg_virtio_set_status(struct rpmsg_virtio_device *rvdev, uint8_t status)
+{
+	rvdev->vdev->func->set_status(rvdev->vdev, status);
+}
+
+static inline uint8_t rpmsg_virtio_get_status(struct rpmsg_virtio_device *rvdev)
+{
+	return rvdev->vdev->func->get_status(rvdev->vdev);
+}
+
+static inline uint32_t rpmsg_virtio_get_features(struct rpmsg_virtio_device *rvdev)
+{
+	return rvdev->vdev->func->get_features(rvdev->vdev);
+}
+
+static inline int rpmsg_virtio_create_virtqueues(struct rpmsg_virtio_device * rvdev, int flags,
+				  unsigned int nvqs, const char *names[],
+				  vq_callback * callbacks[])
+{
+	return virtio_create_virtqueues(rvdev->vdev, flags, nvqs, names, callbacks);
+}
+
+int rpmsg_init_vdev(struct rpmsg_virtio_device *rvdev,
+		    struct virtio_device *vdev,
+		    void (*new_endpoint_cb)(struct rpmsg_endpoint *ep),
+		    struct metal_io_region *shm_io,
+		    void *shm, unsigned int len);
+
+void rpmsg_deinit_vdev(struct rpmsg_virtio_device *rvdev);
+
+static inline struct rpmsg_device *
+rpmsg_virtio_get_rpmsg_device(struct rpmsg_virtio_device *rvdev)
+{
+	return &rvdev->rdev;
+}
+
+
+#if defined __cplusplus
+}
+#endif
+
+#endif	/* _RPMSG_VIRTIO_H_ */

--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -81,7 +81,7 @@ static inline int rpmsg_virtio_create_virtqueues(struct rpmsg_virtio_device * rv
 
 int rpmsg_init_vdev(struct rpmsg_virtio_device *rvdev,
 		    struct virtio_device *vdev,
-		    void (*new_endpoint_cb)(struct rpmsg_endpoint *ep),
+		    void (*new_endpoint_cb)(const char *name, uint32_t src),
 		    struct metal_io_region *shm_io,
 		    void *shm, unsigned int len);
 

--- a/lib/include/openamp/virtio.h
+++ b/lib/include/openamp/virtio.h
@@ -8,9 +8,15 @@
 #define _VIRTIO_H_
 
 #include <openamp/virtqueue.h>
+#include <metal/spinlock.h>
 
 #if defined __cplusplus
 extern "C" {
+#endif
+
+/* TODO: define this as compiler flags */
+#ifndef VIRTIO_MAX_NUM_VRINGS
+#define VIRTIO_MAX_NUM_VRINGS 2
 #endif
 
 /* VirtIO device IDs. */
@@ -20,7 +26,7 @@ extern "C" {
 #define VIRTIO_ID_ENTROPY    0x04
 #define VIRTIO_ID_BALLOON    0x05
 #define VIRTIO_ID_IOMEMORY   0x06
-#define VIRTIO_ID_RPMSG      0x07 /* virtio remote remote_proc messaging */
+#define VIRTIO_ID_RPMSG	     0x07 /* virtio remote remote_proc messaging */
 #define VIRTIO_ID_SCSI       0x08
 #define VIRTIO_ID_9P         0x09
 
@@ -30,6 +36,16 @@ extern "C" {
 #define VIRTIO_CONFIG_STATUS_DRIVER_OK 0x04
 #define VIRTIO_CONFIG_STATUS_NEEDS_RESET 0x40
 #define VIRTIO_CONFIG_STATUS_FAILED    0x80
+
+/* Virtio device role */
+#define VIRTIO_DEV_MASTER	0UL
+#define VIRTIO_DEV_SLAVE	1UL
+
+struct virtio_device_id {
+	uint32_t device;
+	uint32_t vendor;
+};
+#define VIRTIO_DEV_ANY_ID	((unsigned int)-1)
 
 /*
  * Generate interrupt when the virtqueue ring is
@@ -52,47 +68,69 @@ extern "C" {
 #define VIRTIO_TRANSPORT_F_END        32
 
 typedef struct _virtio_dispatch_ virtio_dispatch;
+typedef void (*virtio_dev_reset_cb)(struct virtio_device *vdev);
 
 struct virtio_feature_desc {
 	uint32_t vfd_val;
 	const char *vfd_str;
 };
 
+/**
+ * struct proc_shm
+ *
+ * This structure is maintained by hardware interface layer for
+ * shared memory information. The shared memory provides buffers
+ * for use by the vring to exchange messages between the cores.
+ *
+ */
+struct virtio_buffer_info {
+	/* Start address of shared memory used for buffers. */
+	void *vaddr;
+	/* Start physical address of shared memory used for buffers. */
+	metal_phys_addr_t paddr;
+	/* sharmed memory I/O region */
+	struct metal_io_region *io;
+	/* Size of shared memory. */
+	unsigned long size;
+};
+
+/**
+ * struct remoteproc_vring - remoteproc vring structure
+ * @vq virtio queue
+ * @va logical address
+ * @notifyid vring notify id
+ * @num_descs number of descriptors
+ * @align vring alignment
+ * @io metal I/O region of the vring memory, can be NULL
+ */
+struct virtio_vring_info {
+	struct virtqueue *vq;
+	struct vring_alloc_info info;
+	uint32_t notifyid;
+	struct metal_io_region *io;
+};
+
 /*
  * Structure definition for virtio devices for use by the
  * applications/drivers
- *
  */
 
 struct virtio_device {
-	/*
-	 * Since there is no generic device structure so
-	 * keep its type as void. The driver layer will take
-	 * care of it.
-	 */
-	void *device;
-
-	/* Device name */
-	char *name;
-
-	/* List of virtqueues encapsulated by virtio device. */
-	//TODO : Need to implement a list service for ipc stack.
-	void *vq_list;
-
-	/* Virtio device specific features */
-	uint32_t features;
-
-	/* Virtio dispatch table */
-	virtio_dispatch *func;
-
-	/*
-	 * Pointer to hold some private data, useful
-	 * in callbacks.
-	 */
-	void *data;
+	uint32_t index; /**< unique position on the virtio bus */
+	struct virtio_device_id id; /**< the device type identification
+				         (used to match it with a driver). */
+	uint64_t features; /**< the features supported by both ends. */
+	unsigned int role; /**< if it is virtio backend or front end. */
+	virtio_dev_reset_cb reset_cb; /**< user registered virtio
+						         device callback */
+	virtio_dispatch *func;/**< Virtio dispatch table */
+	void *priv; /**< TODO: should remove pointer to virtio_device private
+		         data */
+	unsigned int vrings_num; /**< number of vrings */
+	struct virtio_vring_info *vrings_info;
 };
 
-/* 
+/*
  * Helper functions.
  */
 const char *virtio_dev_name(uint16_t devid);
@@ -101,16 +139,12 @@ void virtio_describe(struct virtio_device *dev, const char *msg,
 		     struct virtio_feature_desc *feature_desc);
 
 /*
- * Functions for virtio device configuration as defined in Rusty Russell's paper.
+ * Functions for virtio device configuration as defined in Rusty Russell's
+ * paper.
  * Drivers are expected to implement these functions in their respective codes.
- * 
  */
 
 struct _virtio_dispatch_ {
-	int (*create_virtqueues) (struct virtio_device * dev, int flags,
-				  int nvqs, const char *names[],
-				  vq_callback * callbacks[],
-				  struct virtqueue * vqs[]);
 	uint8_t(*get_status) (struct virtio_device * dev);
 	void (*set_status) (struct virtio_device * dev, uint8_t status);
 	uint32_t(*get_features) (struct virtio_device * dev);
@@ -128,8 +162,12 @@ struct _virtio_dispatch_ {
 	void (*write_config) (struct virtio_device * dev, uint32_t offset,
 			      void *src, int length);
 	void (*reset_device) (struct virtio_device * dev);
-
+	void (*notify) (struct virtqueue *vq);
 };
+
+int virtio_create_virtqueues(struct virtio_device *vdev, unsigned int flags,
+			     unsigned int nvqs, const char *names[],
+			     vq_callback *callbacks[]);
 
 #if defined __cplusplus
 }

--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -70,7 +70,7 @@ struct virtqueue_buf {
 
 struct virtqueue {
 	struct virtio_device *vq_dev;
-	char vq_name[VIRTQUEUE_MAX_NAME_SZ];
+	const char *vq_name;
 	uint16_t vq_queue_index;
 	uint16_t vq_nentries;
 	uint32_t vq_flags;

--- a/lib/remoteproc/CMakeLists.txt
+++ b/lib/remoteproc/CMakeLists.txt
@@ -1,5 +1,5 @@
 collect (PROJECT_LIB_SOURCES elf_loader.c)
 collect (PROJECT_LIB_SOURCES remoteproc.c)
-#collect (PROJECT_LIB_SOURCES remoteproc_loader.c)
+collect (PROJECT_LIB_SOURCES remoteproc_virtio.c)
 collect (PROJECT_LIB_SOURCES rsc_table_parser.c)
 #add_subdirectory (drivers)

--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -35,89 +35,264 @@
 
 #include <openamp/remoteproc.h>
 #include <openamp/remoteproc_virtio.h>
+#include <openamp/virtqueue.h>
+#include <metal/utilities.h>
+#include <metal/alloc.h>
 
-static int rproc_virtio_notify(unsigned int notifyid, struct remoteproc *rproc)
+static void rproc_virtio_virtqueue_notify(struct virtqueue *vq)
 {
-	return rproc->kick(rproc, id);
+	struct remoteproc_virtio *rpvdev;
+	struct virtio_vring_info *vring_info;
+	struct virtio_device *vdev;
+	unsigned int vq_id = vq->vq_queue_index;
+
+	vdev = vq->vq_dev;
+	rpvdev = metal_container_of(vdev, struct remoteproc_virtio, vdev);
+	metal_assert(vq_id <= vdev->vrings_num);
+	vring_info = &vdev->vrings_info[vq_id];
+	rpvdev->notify(rpvdev->priv, vring_info->notifyid);
 }
 
-struct _virtio_dispatch_ remoteproc_virtio_dispatch_funcs = {
-	.create_virtqueue = rproc_vritio_create_virtqueues,
+static unsigned char rproc_virtio_get_status(struct virtio_device *vdev)
+{
+	struct remoteproc_virtio *rpvdev;
+	struct fw_rsc_vdev *vdev_rsc;
+	struct metal_io_region *io;
+	char status;
+
+	rpvdev = metal_container_of(vdev, struct remoteproc_virtio, vdev);
+	vdev_rsc = rpvdev->vdev_rsc;
+	io = rpvdev->vdev_rsc_io;
+	status = metal_io_read8(io,
+				metal_io_virt_to_offset(io, &vdev_rsc->status));
+	return status;
+}
+
+static void rproc_virtio_set_status(struct virtio_device *vdev,
+				    unsigned char status)
+{
+	struct remoteproc_virtio *rpvdev;
+	struct fw_rsc_vdev *vdev_rsc;
+	struct metal_io_region *io;
+
+	rpvdev = metal_container_of(vdev, struct remoteproc_virtio, vdev);
+	vdev_rsc = rpvdev->vdev_rsc;
+	io = rpvdev->vdev_rsc_io;
+	metal_io_write8(io,
+			metal_io_virt_to_offset(io, &vdev_rsc->status),
+			status);
+	rpvdev->notify(rpvdev->priv, vdev->index);
+}
+
+static uint32_t rproc_virtio_get_features(struct virtio_device *vdev)
+{
+	struct remoteproc_virtio *rpvdev;
+	struct fw_rsc_vdev *vdev_rsc;
+	struct metal_io_region *io;
+	uint32_t features;
+
+	rpvdev = metal_container_of(vdev, struct remoteproc_virtio, vdev);
+	vdev_rsc = rpvdev->vdev_rsc;
+	io = rpvdev->vdev_rsc_io;
+	/* TODO: shall we get features based on the role ? */
+	features = metal_io_read32(io,
+				  metal_io_virt_to_offset(io,
+				  &vdev_rsc->dfeatures));
+	return features;
+}
+
+static void rproc_virtio_set_features(struct virtio_device *vdev,
+				      uint32_t features)
+{
+	struct remoteproc_virtio *rpvdev;
+	struct fw_rsc_vdev *vdev_rsc;
+	struct metal_io_region *io;
+
+	rpvdev = metal_container_of(vdev, struct remoteproc_virtio, vdev);
+	vdev_rsc = rpvdev->vdev_rsc;
+	io = rpvdev->vdev_rsc_io;
+	/* TODO: shall we set features based on the role ? */
+	metal_io_write32(io,
+			 metal_io_virt_to_offset(io, &vdev_rsc->status),
+			 features);
+	rpvdev->notify(rpvdev->priv, vdev->index);
+}
+
+static uint32_t rproc_virtio_negotiate_features(struct virtio_device *vdev,
+						uint32_t features)
+{
+	(void)vdev;
+	(void)features;
+
+	return 0;
+}
+
+static void rproc_virtio_read_config(struct virtio_device *vdev,
+				     uint32_t offset, void *dst, int length)
+{
+	(void)vdev;
+	(void)offset;
+	(void)dst;
+	(void)length;
+}
+
+static void rproc_virtio_write_config(struct virtio_device *vdev,
+				      uint32_t offset, void *src, int length)
+{
+	(void)vdev;
+	(void)offset;
+	(void)src;
+	(void)length;
+}
+
+static void rproc_virtio_reset_device(struct virtio_device *vdev)
+{
+	if (vdev->role == VIRTIO_DEV_MASTER)
+		rproc_virtio_set_status(vdev,
+					VIRTIO_CONFIG_STATUS_NEEDS_RESET);
+}
+
+virtio_dispatch remoteproc_virtio_dispatch_funcs = {
 	.get_status =  rproc_virtio_get_status,
 	.set_status = rproc_virtio_set_status,
 	.get_features = rproc_virtio_get_features,
 	.set_features = rproc_virtio_set_features,
 	.negotiate_features = rproc_virtio_negotiate_features,
-	.read_config = rproc_read_config,
-	.write_config = rproc_write_config,
-	.reset_device = rproc_reset_device,
+	.read_config = rproc_virtio_read_config,
+	.write_config = rproc_virtio_write_config,
+	.reset_device = rproc_virtio_reset_device,
+	.notify = rproc_virtio_virtqueue_notify,
 };
 
 struct virtio_device *
-rproc_virtio_create_vdev(struct remoteporc *rproc, unsigned int role,
-			 int index, void *rsc,
-			 int (*rst_cb)(struct virtio_device *vdev))
+rproc_virtio_create_vdev(unsigned int role, unsigned int notifyid,
+			 void *rsc, struct metal_io_region *rsc_io,
+			 void *priv,
+			 rpvdev_notify_func notify,
+			 virtio_dev_reset_cb rst_cb)
 {
 	struct remoteproc_virtio *rpvdev;
-	struct remoteproc_vring *rvrings;
+	struct virtio_vring_info *vrings_info;
 	struct fw_rsc_vdev *vdev_rsc = rsc;
-	struct fw_rsc_vdev_vring *rvring_rsc;
 	struct virtio_device *vdev;
 	unsigned int num_vrings = vdev_rsc->num_of_vrings;
 	unsigned int i;
 
-	rpvdev = metal_allocate_memory(sizeof(*rpvdev) +
-				       sizeof(struct virtqueue)*
-				       (num_vrings - 1));
+	rpvdev = metal_allocate_memory(sizeof(*rpvdev));
 	if (!rpvdev)
 		return NULL;
-	rvrings = metal_allocate_memory(sizeof(*rvrings) * num_vrings);
-	if (!rvrings)
-		return NULL;
-	rpvdev->num_vrings = num_vrings;
-	rpvdev->rvrings = rvrings;
+	vrings_info = metal_allocate_memory(sizeof(*vrings_info) * num_vrings);
+	if (!vrings_info)
+		goto err0;
+	memset(rpvdev, 0, sizeof(*rpvdev));
+	memset(vrings_info, 0, sizeof(*vrings_info));
+	vdev = &rpvdev->vdev;
+
+	for (i = 0; i < num_vrings; i++) {
+		struct virtqueue *vq;
+		struct fw_rsc_vdev_vring *vring_rsc;
+		unsigned int num_extra_desc = 0;
+
+		vring_rsc = &vdev_rsc->vring[i];
+		if (role == VIRTIO_DEV_MASTER) {
+			num_extra_desc = vring_rsc->num;
+		}
+		vq = virtqueue_allocate(num_extra_desc);
+		if (!vq)
+			goto err1;
+		vrings_info[i].vq = vq;
+	}
+
+	/* FIXME commended as seems not nedded, already stored in vdev */
+	//rpvdev->notifyid = notifyid;
+	rpvdev->notify = notify;
+	rpvdev->priv = priv;
+	vdev->vrings_info = vrings_info;
 	/* Assuming the shared memory has been mapped and registered if
 	 * necessary
 	 */
 	rpvdev->vdev_rsc = vdev_rsc;
-	rpvdev->vdev_rsc_io = remoteproc_get_mem_with_va(rproc,vdev_rsc);
+	rpvdev->vdev_rsc_io = rsc_io;
 
-	/* Initialize remoteproc virtio vrings */
-	for (i = 0; i < num_vrings; i++) {
-		struct metal_io_region *io;
-		unsigned int num_descs = rvring_rsc->num;
-		unsigned int align =  rvring_rsc->align;
-		void *va;
-
-		rvring_rsc = &vdev_rsc->vring[i];
-		rvrings[i].num_descs = num_descs
-		rvrings[i].align = align;
-		va = remoteproc_get_mem_with_da(rproc, vring_rsc->da,
-						vring_size(num_descs, align),
-						*io);
-		rvrings[i].va = va;
-		rvrings[i].io = io;
-	}
-
-	memset(&rpvdev->vdev);
-	vdev = rpvdev->vdev;
-	vdev->index = index;
+	vdev->index = notifyid;
 	vdev->role = role;
-	vdev->rst_cb = rst_cb;
+	vdev->reset_cb = rst_cb;
 	vdev->vrings_num = num_vrings;
-	metal_spinlock_init(&vdev->lock);
+	vdev->func = &remoteproc_virtio_dispatch_funcs;
 	/* TODO: Shall we set features here ? */
 
 	return &rpvdev->vdev;
+
+err1:
+	for (i = 0; i < num_vrings; i++) {
+		if (vrings_info[i].vq)
+			metal_free_memory(vrings_info[i].vq);
+	}
+	metal_free_memory(vrings_info);
+err0:
+	metal_free_memory(rpvdev);
+	return NULL;
 }
 
-
-int rproc_virtio_set_shm(struct remoteproc_virtio *rpvdev,
-			 struct remoteproc_vshm_pool *shm)
+void rproc_virtio_remove_vdev(struct virtio_device *vdev)
 {
-	if (!rpvdev)
+	struct remoteproc_virtio *rpvdev;
+	unsigned int i;
+
+	if (!vdev)
+		return;
+	rpvdev = metal_container_of(vdev, struct remoteproc_virtio, vdev);
+	for (i = 0; i < vdev->vrings_num; i++) {
+		struct virtqueue *vq;
+
+		vq = vdev->vrings_info[i].vq;
+		if (vq)
+			metal_free_memory(vq);
+	}
+	metal_free_memory(vdev->vrings_info);
+	metal_free_memory(rpvdev);
+}
+
+int rproc_virtio_init_vring(struct virtio_device *vdev, unsigned int index,
+			    unsigned int notifyid, void *va,
+			    struct metal_io_region *io,
+			    unsigned int num_descs, unsigned int align)
+{
+	struct virtio_vring_info *vring_info;
+	unsigned int num_vrings;;
+
+	num_vrings = vdev->vrings_num;
+	if (index >= num_vrings)
 		return -RPROC_EINVAL;
-	rpvdev->shm = shm;
+	vring_info = &vdev->vrings_info[index];
+	vring_info->io = io;
+	vring_info->notifyid = notifyid;
+	vring_info->info.vaddr = va;
+	vring_info->info.num_descs = num_descs;
+	vring_info->info.align = align;
 
 	return 0;
+}
+
+int rproc_virtio_notified(struct virtio_device *vdev, uint32_t notifyid)
+{
+	unsigned int num_vrings, i;
+	struct virtio_vring_info *vring_info;
+	struct virtqueue *vq;
+
+	if (!vdev)
+		return -EINVAL;
+	/* We do nothing for vdev notification in this implementation */
+	if (vdev->index == notifyid)
+		return 0;
+	num_vrings = vdev->vrings_num;
+	for (i = 0; i < num_vrings; i++) {
+		vring_info = &vdev->vrings_info[i];
+		if (vring_info->notifyid == notifyid ||
+		    notifyid == RSC_NOTIFY_ID_ANY) {
+			vq = vring_info->vq;
+			virtqueue_notification(vq);
+		}
+	}
+	return -EINVAL;
 }

--- a/lib/rpmsg/CMakeLists.txt
+++ b/lib/rpmsg/CMakeLists.txt
@@ -1,0 +1,2 @@
+collect (PROJECT_LIB_SOURCES rpmsg.c)
+collect (PROJECT_LIB_SOURCES rpmsg_virtio.c)

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2014, Mentor Graphics Corporation
+ * All rights reserved.
+ * Copyright (c) 2016 Freescale Semiconductor, Inc. All rights reserved.
+ * Copyright (c) 2018 Linaro, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <openamp/rpmsg.h>
+#include <metal/alloc.h>
+#include <metal/utilities.h>
+
+#include "rpmsg_internal.h"
+
+/**
+ * rpmsg_get_address
+ *
+ * This function provides unique 32 bit address.
+ *
+ * @param bitmap - bit map for addresses
+ * @param size   - size of bitmap
+ *
+ * return - a unique address
+ */
+static int rpmsg_get_address(unsigned long *bitmap, int size)
+{
+	int addr = -1;
+	int i, tmp32;
+
+	/* Find first available buffer */
+	for (i = 0; i < size; i++) {
+		tmp32 = get_first_zero_bit(bitmap[i]);
+
+		if (tmp32 < 32) {
+			addr = tmp32 + (i * 32);
+			bitmap[i] |= (1 << tmp32);
+			break;
+		}
+	}
+
+	return addr;
+}
+
+/**
+ * rpmsg_release_address
+ *
+ * Frees the given address.
+ *
+ * @param bitmap - bit map for addresses
+ * @param size   - size of bitmap
+ * @param addr   - address to free
+ *
+ * return - none
+ */
+static int rpmsg_release_address(unsigned long *bitmap, int size, int addr)
+{
+	unsigned int i, j;
+	unsigned long mask = 1;
+
+	if (addr >= size * 32)
+		return -1;
+
+	/* Mark the addr as available */
+	i = addr / 32;
+	j = addr % 32;
+
+	mask = mask << j;
+	bitmap[i] = bitmap[i] & (~mask);
+
+	return RPMSG_SUCCESS;
+}
+
+/**
+ * rpmsg_is_address_set
+ *
+ * Checks whether address is used or free.
+ *
+ * @param bitmap - bit map for addresses
+ * @param size   - size of bitmap
+ * @param addr   - address to free
+ *
+ * return - TRUE/FALSE
+ */
+static int rpmsg_is_address_set(unsigned long *bitmap, int size, int addr)
+{
+	int i, j;
+	unsigned long mask = 1;
+
+	if (addr >= size * 32)
+		return -1;
+
+	/* Mark the id as available */
+	i = addr / 32;
+	j = addr % 32;
+	mask = mask << j;
+
+	return (bitmap[i] & mask);
+}
+
+/**
+ * rpmsg_set_address
+ *
+ * Marks the address as consumed.
+ *
+ * @param bitmap - bit map for addresses
+ * @param size   - size of bitmap
+ * @param addr   - address to free
+ *
+ * return - none
+ */
+static int rpmsg_set_address(unsigned long *bitmap, int size, int addr)
+{
+	int i, j;
+	unsigned long mask = 1;
+
+	if (addr >= size * 32)
+		return -1;
+
+	/* Mark the id as available */
+	i = addr / 32;
+	j = addr % 32;
+	mask = mask << j;
+	bitmap[i] |= mask;
+
+	return RPMSG_SUCCESS;
+}
+
+/**
+ * This function sends rpmsg "message" to remote device.
+ *
+ * @param ept     - pointer to end point
+ * @param src     - source address of channel
+ * @param dst     - destination address of channel
+ * @param data    - data to transmit
+ * @param size    - size of data
+ * @param wait    - boolean, wait or not for buffer to become
+ *                  available
+ *
+ * @return - size of data sent or negative value for failure.
+ *
+ */
+int rpmsg_send_offchannel_raw(struct rpmsg_endpoint *ept, uint32_t src,
+			      uint32_t dst, const void *data, int size,
+			      int wait)
+{
+	struct rpmsg_device *rdev;
+
+	if (!ept || !data || (dst == RPMSG_ADDR_ANY))
+		return RPMSG_ERR_PARAM;
+
+	/* Get the associated rpmsg device for endpoint. */
+	rdev = ept->rdev;
+	if (rdev->ops.send_offchannel_raw)
+		return rdev->ops.send_offchannel_raw(rdev, src, dst, data,
+						      size, wait);
+
+	return RPMSG_ERR_PARAM;
+}
+
+int rpmsg_send_ns_message(struct rpmsg_endpoint *ept, unsigned long flags)
+{
+	struct rpmsg_ns_msg ns_msg;
+	int ret;
+
+	ns_msg.flags = flags;
+	ns_msg.addr = ept->addr;
+	strncpy(ns_msg.name, ept->name, sizeof(ns_msg.name));
+	ret = rpmsg_send_offchannel_raw(ept, ept->addr,
+					RPMSG_NS_EPT_ADDR,
+					&ns_msg, sizeof(ns_msg), true);
+	if (ret < 0)
+		return ret;
+	else
+		return RPMSG_SUCCESS;
+}
+
+struct rpmsg_endpoint *rpmsg_get_endpoint(struct rpmsg_device *rdev,
+					  const char *name, uint32_t addr,
+					  uint32_t dest_addr)
+{
+	struct metal_list *node;
+	struct rpmsg_endpoint *ept;
+
+	metal_list_for_each(&rdev->endpoints, node) {
+		int name_match = 1;
+
+		ept = metal_container_of(node, struct rpmsg_endpoint, node);
+		if (addr != RPMSG_ADDR_ANY && ept->addr == addr)
+			return ept;
+		if (name)
+			name_match = !strncmp(ept->name, name,
+					      sizeof(ept->name));
+		if (dest_addr == RPMSG_ADDR_ANY &&
+		    ept->addr == RPMSG_ADDR_ANY &&
+		    name_match)
+			return ept;
+		if (addr == RPMSG_ADDR_ANY &&
+		    ept->dest_addr == RPMSG_ADDR_ANY &&
+		    name_match)
+			return ept;
+		if (addr == ept->addr && dest_addr == ept->dest_addr &&
+		    name_match)
+			return ept;
+	}
+	return NULL;
+}
+
+static void rpmsg_unregister_endpoint(struct rpmsg_endpoint *ept)
+{
+	struct rpmsg_device *rdev;
+
+	if (!ept)
+		return;
+
+	rdev = ept->rdev;
+
+	if(ept->addr != RPMSG_ADDR_ANY)
+		rpmsg_release_address(rdev->bitmap, RPMSG_ADDR_BMP_SIZE,
+				      ept->addr);
+	metal_list_del(&ept->node);
+}
+
+int rpmsg_register_endpoint(struct rpmsg_device *rdev,
+			    struct rpmsg_endpoint *ept)
+{
+	ept->rdev = rdev;
+
+	metal_list_add_tail(&rdev->endpoints, &ept->node);
+	return RPMSG_SUCCESS;
+}
+
+struct rpmsg_endpoint *rpmsg_create_ept(struct rpmsg_device *rdev,
+					const char *name, uint32_t src,
+					uint32_t dest, rpmsg_ept_cb cb,
+					rpmsg_ept_destroy_cb destroy_cb)
+{
+	struct rpmsg_endpoint *ept;
+	int status;
+
+	metal_mutex_acquire(&rdev->lock);
+	if (src != RPMSG_ADDR_ANY) {
+		if (!rpmsg_is_address_set
+		    (rdev->bitmap, RPMSG_ADDR_BMP_SIZE, src))
+			/* Mark the address as used in the address bitmap. */
+			rpmsg_set_address(rdev->bitmap, RPMSG_ADDR_BMP_SIZE,
+					  src);
+		else
+			goto ret_err;
+	} else {
+		src = rpmsg_get_address(rdev->bitmap, RPMSG_ADDR_BMP_SIZE);
+	}
+
+	ept = rpmsg_get_endpoint(rdev, name, src, dest);
+	if (!ept)
+		ept = metal_allocate_memory(sizeof(*ept));
+	if (!ept)
+		goto ret_err;
+	rpmsg_init_ept(ept, name, src, dest, cb, destroy_cb);
+
+	status = rpmsg_register_endpoint(rdev, ept);
+	if (status < 0)
+		goto reg_err;
+
+	metal_mutex_release(&rdev->lock);
+
+	if (ept->dest_addr == RPMSG_ADDR_ANY) {
+		/* Send NS announcement to remote processor */
+		status = rpmsg_send_ns_message(ept, RPMSG_NS_CREATE);
+		if(status)
+			goto ns_err;
+	}
+
+	return ept;
+
+ns_err:
+	rpmsg_unregister_endpoint(ept);
+reg_err:
+	metal_free_memory(ept);
+
+ret_err:
+	metal_mutex_release(&rdev->lock);
+	return NULL;
+}
+
+/**
+ * rpmsg_destroy_ept
+ *
+ * This function deletes rpmsg endpoint and performs cleanup.
+ *
+ * @param ept - pointer to endpoint to destroy
+ *
+ */
+void rpmsg_destroy_ept(struct rpmsg_endpoint *ept)
+{
+	if (!ept)
+		return;
+
+	rpmsg_unregister_endpoint(ept);
+	if (ept->destroy_cb)
+		ept->destroy_cb(ept);
+	metal_free_memory(ept);
+}

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -197,7 +197,7 @@ struct rpmsg_endpoint *rpmsg_get_endpoint(struct rpmsg_device *rdev,
 			return ept;
 		if (addr == RPMSG_ADDR_ANY &&
 		    ept->dest_addr == RPMSG_ADDR_ANY &&
-		    name_match)
+		    name && name_match)
 			return ept;
 		if (addr == ept->addr && dest_addr == ept->dest_addr &&
 		    name_match)

--- a/lib/rpmsg/rpmsg_internal.h
+++ b/lib/rpmsg/rpmsg_internal.h
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * $FreeBSD$
+ */
+
+#ifndef _RPMSG_INTERNAL_H_
+#define _RPMSG_INTERNAL_H_
+
+#include <stdint.h>
+#include <openamp/rpmsg.h>
+
+#if defined __cplusplus
+extern "C" {
+#endif
+
+#ifdef RPMSG_DEBUG
+#define RPMSG_ASSERT(_exp, _msg) do { \
+		if (!(_exp)) { \
+			openamp_print("FATAL: %s - "_msg, __func__); \
+			while (1); \
+		} \
+	} while (0)
+#else
+#define RPMSG_ASSERT(_exp, _msg) if (!(_exp)) while (1)
+#endif
+
+#define RPMSG_LOCATE_DATA(p) ((unsigned char *)p + sizeof(struct rpmsg_hdr))
+/**
+ * enum rpmsg_ns_flags - dynamic name service announcement flags
+ *
+ * @RPMSG_NS_CREATE: a new remote service was just created
+ * @RPMSG_NS_DESTROY: a known remote service was just destroyed
+ * @RPMSG_NS_CREATE_WITH_ACK: a new remote service was just created waiting
+ *                            acknowledgment.
+ */
+enum rpmsg_ns_flags {
+	RPMSG_NS_CREATE = 0,
+	RPMSG_NS_DESTROY = 1,
+};
+
+/**
+ * struct rpmsg_hdr - common header for all rpmsg messages
+ * @src: source address
+ * @dst: destination address
+ * @reserved: reserved for future use
+ * @len: length of payload (in bytes)
+ * @flags: message flags
+ *
+ * Every message sent(/received) on the rpmsg bus begins with this header.
+ */
+OPENAMP_PACKED_BEGIN
+struct rpmsg_hdr {
+	uint32_t src;
+	uint32_t dst;
+	uint32_t reserved;
+	uint16_t len;
+	uint16_t flags;
+} OPENAMP_PACKED_END;
+
+/**
+ * struct rpmsg_ns_msg - dynamic name service announcement message
+ * @name: name of remote service that is published
+ * @addr: address of remote service that is published
+ * @flags: indicates whether service is created or destroyed
+ *
+ * This message is sent across to publish a new service, or announce
+ * about its removal. When we receive these messages, an appropriate
+ * rpmsg channel (i.e device) is created/destroyed. In turn, the ->probe()
+ * or ->remove() handler of the appropriate rpmsg driver will be invoked
+ * (if/as-soon-as one is registered).
+ */
+OPENAMP_PACKED_BEGIN
+struct rpmsg_ns_msg {
+	char name[RPMSG_NAME_SIZE];
+	uint32_t addr;
+	uint32_t flags;
+} OPENAMP_PACKED_END;
+
+
+int rpmsg_send_ns_message(struct rpmsg_endpoint *ept, unsigned long flags);
+
+struct rpmsg_endpoint *rpmsg_get_endpoint(struct rpmsg_device *rvdev,
+					  const char *name, uint32_t addr,
+					  uint32_t dest_addr);
+int rpmsg_register_endpoint(struct rpmsg_device *rdev,
+			    struct rpmsg_endpoint *ept);
+
+static inline struct rpmsg_endpoint *
+rpmsg_get_ept_from_remote_addr(struct rpmsg_device *rdev,
+			       uint32_t addr)
+{
+	return rpmsg_get_endpoint(rdev, NULL, RPMSG_ADDR_ANY, addr);
+}
+
+static inline struct rpmsg_endpoint *
+rpmsg_get_ept_from_addr(struct rpmsg_device *rdev, uint32_t addr)
+{
+	return rpmsg_get_endpoint(rdev, NULL, addr, RPMSG_ADDR_ANY);
+}
+#if defined __cplusplus
+}
+#endif
+
+#endif /* _RPMSG_INTERNAL_H_ */

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -1,0 +1,610 @@
+/*
+ * Copyright (c) 2014, Mentor Graphics Corporation
+ * All rights reserved.
+ * Copyright (c) 2016 Freescale Semiconductor, Inc. All rights reserved.
+ * Copyright (c) 2018 Linaro, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <metal/alloc.h>
+#include <metal/cache.h>
+#include <metal/sleep.h>
+#include <openamp/rpmsg_virtio.h>
+#include <openamp/virtqueue.h>
+
+#include "rpmsg_internal.h"
+
+#define RPMSG_NUM_VRINGS (2)
+
+/* Total tick count for 15secs - 1msec tick. */
+#define RPMSG_TICK_COUNT                        15000
+
+/* Time to wait - In multiple of 10 msecs. */
+#define RPMSG_TICKS_PER_INTERVAL                10
+
+/**
+ * rpmsg_virtio_return_buffer
+ *
+ * Places the used buffer back on the virtqueue.
+ *
+ * @param rvdev   - pointer to remote core
+ * @param buffer - buffer pointer
+ * @param len    - buffer length
+ * @param idx    - buffer index
+ *
+ */
+static void rpmsg_virtio_return_buffer(struct rpmsg_virtio_device *rvdev,
+				       void *buffer, unsigned long len,
+				       unsigned short idx)
+{
+	struct virtqueue_buf vqbuf;
+
+	if (rpmsg_virtio_get_role(rvdev) == RPMSG_MASTER) {
+		/* Initialize buffer node */
+		vqbuf.buf = buffer;
+		vqbuf.len = len;
+		virtqueue_add_buffer(rvdev->rvq, &vqbuf, 0, 1, buffer);
+	} else {
+		virtqueue_add_consumed_buffer(rvdev->rvq, idx, len);
+	}
+}
+
+/**
+ * rpmsg_virtio_enqueue_buffer
+ *
+ * Places buffer on the virtqueue for consumption by the other side.
+ *
+ * @param rvdev   - pointer to rpmsg virtio
+ * @param buffer - buffer pointer
+ * @param len    - buffer length
+ * @idx          - buffer index
+ *
+ * @return - status of function execution
+ */
+static int rpmsg_virtio_enqueue_buffer(struct rpmsg_virtio_device *rvdev,
+				       void *buffer, unsigned long len,
+				       unsigned short idx)
+{
+	int status;
+	struct virtqueue_buf vqbuf;
+
+	if (rpmsg_virtio_get_role(rvdev) == RPMSG_MASTER) {
+		/* Initialize buffer node */
+		vqbuf.buf = buffer;
+		vqbuf.len = len;
+		status = virtqueue_add_buffer(rvdev->svq, &vqbuf, 0, 1, buffer);
+	} else {
+		status = virtqueue_add_consumed_buffer(rvdev->svq, idx, len);
+	}
+
+	return status;
+}
+
+/**
+ * rpmsg_virtio_get_tx_buffer
+ *
+ * Provides buffer to transmit messages.
+ *
+ * @param rvdev - pointer to rpmsg device
+ * @param len  - length of returned buffer
+ * @param idx  - buffer index
+ *
+ * return - pointer to buffer.
+ */
+static void *rpmsg_virtio_get_tx_buffer(struct rpmsg_virtio_device *rvdev,
+					unsigned long *len,
+					unsigned short *idx)
+{
+	void *data;
+
+	if (rpmsg_virtio_get_role(rvdev) == RPMSG_MASTER) {
+		data = virtqueue_get_buffer(rvdev->svq, (uint32_t *)len, idx);
+		if (data == NULL) {
+			data = sh_mem_get_buffer(rvdev->shbuf);
+			*len = RPMSG_BUFFER_SIZE;
+		}
+	} else {
+		data =
+		    virtqueue_get_available_buffer(rvdev->svq, idx,
+						   (uint32_t *)len);
+	}
+	return data;
+}
+
+/**
+ * rpmsg_virtio_get_rx_buffer
+ *
+ * Retrieves the received buffer from the virtqueue.
+ *
+ * @param rvdev - pointer to rpmsg device
+ * @param len  - size of received buffer
+ * @param idx  - index of buffer
+ *
+ * @return - pointer to received buffer
+ *
+ */
+static void *rpmsg_virtio_get_rx_buffer(struct rpmsg_virtio_device *rvdev,
+					unsigned long *len,
+					unsigned short *idx)
+{
+	void *data;
+
+	if (rpmsg_virtio_get_role(rvdev) == RPMSG_MASTER) {
+		data = virtqueue_get_buffer(rvdev->rvq, (uint32_t *)len, idx);
+	} else {
+		data =
+		    virtqueue_get_available_buffer(rvdev->rvq, idx,
+						   (uint32_t *)len);
+	}
+	if (data) {
+		/* FIX ME: library should not worry about if it needs
+		 * to flush/invalidate cache, it is shared memory.
+		 * The shared memory should be mapped properly before
+		 * using it.
+		 */
+		metal_cache_invalidate(data, (unsigned int)(*len));
+	}
+
+	return data;
+}
+
+/**
+ * check if the remote is ready to start RPMsg communication
+ */
+static int rpmsg_virtio_wait_remote_ready(struct rpmsg_virtio_device *rvdev)
+{
+	uint8_t status;
+
+	while (1) {
+		status = rpmsg_virtio_get_status(rvdev);
+		/* Busy wait until the remote is ready */
+		if (status & VIRTIO_CONFIG_STATUS_NEEDS_RESET) {
+			rpmsg_virtio_set_status(rvdev, 0);
+			/* TODO notify remote processor */
+		} else if (status & VIRTIO_CONFIG_STATUS_DRIVER_OK) {
+			return true;
+		}
+		/* TODO: clarify metal_cpu_yield usage*/
+		metal_cpu_yield();
+	}
+
+	return false;
+}
+
+/**
+ * rpmsg_virtio_get_buffer_size
+ *
+ * Returns buffer size available for sending messages.
+ *
+ * @param channel - pointer to rpmsg channel
+ *
+ * @return - buffer size
+ *
+ */
+static int rpmsg_virtio_get_buffer_size(struct rpmsg_virtio_device *rvdev)
+{
+	int length;
+
+	if (rpmsg_virtio_get_role(rvdev) == RPMSG_MASTER) {
+		/*
+		 * If device role is Remote then buffers are provided by us
+		 * (RPMSG Master), so just provide the macro.
+		 */
+		length = RPMSG_BUFFER_SIZE - sizeof(struct rpmsg_hdr);
+	} else {
+		/*
+		 * If other core is Master then buffers are provided by it,
+		 * so get the buffer size from the virtqueue.
+		 */
+		length =
+		    (int)virtqueue_get_desc_size(rvdev->svq) -
+		    sizeof(struct rpmsg_hdr);
+	}
+
+	return length;
+}
+
+/**
+ * This function sends rpmsg "message" to remote device.
+ *
+ * @param rdev    - pointer to rpmsg device
+ * @param src     - source address of channel
+ * @param dst     - destination address of channel
+ * @param data    - data to transmit
+ * @param size    - size of data
+ * @param wait    - boolean, wait or not for buffer to become
+ *                  available
+ *
+ * @return - size of data sent or negative value for failure.
+ *
+ */
+static int rpmsg_virtio_send_offchannel_raw(struct rpmsg_device *rdev,
+					    uint32_t src, uint32_t dst,
+					    const void *data,
+					    int size, int wait)
+{
+	struct rpmsg_virtio_device *rvdev;
+	struct rpmsg_hdr rp_hdr;
+	void *buffer;
+	unsigned short idx;
+	int ret, tick_count = 0;
+	unsigned long buff_len;
+	uint8_t status;
+	struct metal_io_region *io;
+
+	/* Get the associated remote device for channel. */
+	rvdev = metal_container_of(rdev, struct rpmsg_virtio_device, rdev);
+
+	status = rpmsg_virtio_get_status(rvdev);
+	/* Validate device state */
+	if (!(status & VIRTIO_CONFIG_STATUS_DRIVER_OK)) {
+		return RPMSG_ERR_DEV_STATE;
+	}
+
+	/* Lock the device to enable exclusive access to virtqueues */
+	metal_mutex_acquire(&rdev->lock);
+	if (size > (rpmsg_virtio_get_buffer_size(rvdev))) {
+		metal_mutex_release(&rdev->lock);
+		return RPMSG_ERR_BUFF_SIZE;
+	}
+
+	/* Get rpmsg buffer for sending message. */
+	buffer = rpmsg_virtio_get_tx_buffer(rvdev, &buff_len, &idx);
+	/* Unlock the device */
+	metal_mutex_release(&rdev->lock);
+
+	if (!buffer && !wait) {
+		return RPMSG_ERR_NO_BUFF;
+	}
+
+	while (!buffer) {
+		/*
+		 * Wait parameter is true - pool the buffer for
+		 * 15 secs as defined by the APIs.
+		 */
+		metal_sleep_usec(RPMSG_TICKS_PER_INTERVAL);
+		metal_mutex_acquire(&rdev->lock);
+		buffer = rpmsg_virtio_get_tx_buffer(rvdev, &buff_len, &idx);
+		metal_mutex_release(&rdev->lock);
+		tick_count += RPMSG_TICKS_PER_INTERVAL;
+		if (!buffer && (tick_count >=
+		    (RPMSG_TICK_COUNT / RPMSG_TICKS_PER_INTERVAL))) {
+			return RPMSG_ERR_NO_BUFF;
+		}
+	}
+
+	/* Initialize RPMSG header. */
+	rp_hdr.dst = dst;
+	rp_hdr.src = src;
+	rp_hdr.len = size;
+	rp_hdr.reserved = 0;
+
+	/* Copy data to rpmsg buffer. */
+	io = rvdev->shbuf_io;
+	metal_io_block_write(io,
+			metal_io_virt_to_offset(io, buffer),
+			&rp_hdr, sizeof(rp_hdr));
+	metal_io_block_write(io,
+			metal_io_virt_to_offset(io, RPMSG_LOCATE_DATA(buffer)),
+			data, size);
+	metal_mutex_acquire(&rdev->lock);
+
+	/* Enqueue buffer on virtqueue. */
+	ret = rpmsg_virtio_enqueue_buffer(rvdev, buffer, buff_len, idx);
+	RPMSG_ASSERT(ret == VQUEUE_SUCCESS, "failed to enqueue buffer\n");
+	/* Let the other side know that there is a job to process. */
+	virtqueue_kick(rvdev->svq);
+
+	metal_mutex_release(&rdev->lock);
+
+	return size;
+}
+
+/**
+ * rpmsg_virtio_tx_callback
+ *
+ * Tx callback function.
+ *
+ * @param vq - pointer to virtqueue on which Tx is has been
+ *             completed.
+ *
+ */
+static void rpmsg_virtio_tx_callback(struct virtqueue *vq)
+{
+	(void)vq;
+}
+
+/**
+ * rpmsg_virtio_rx_callback
+ *
+ * Rx callback function.
+ *
+ * @param vq - pointer to virtqueue on which messages is received
+ *
+ */
+static void rpmsg_virtio_rx_callback(struct virtqueue *vq)
+{
+	struct virtio_device *vdev = vq->vq_dev;
+	struct rpmsg_virtio_device *rvdev = vdev->priv;
+	struct rpmsg_device *rdev = &rvdev->rdev;
+	struct rpmsg_endpoint *ept;
+	struct rpmsg_hdr *rp_hdr;
+	unsigned long len;
+	unsigned short idx;
+
+	metal_mutex_acquire(&rdev->lock);
+
+	/* Process the received data from remote node */
+	rp_hdr = (struct rpmsg_hdr *)rpmsg_virtio_get_rx_buffer(rvdev,
+								&len, &idx);
+
+	metal_mutex_release(&rdev->lock);
+
+	while (rp_hdr) {
+		/* Get the channel node from the remote device channels list. */
+		metal_mutex_acquire(&rdev->lock);
+		ept = rpmsg_get_ept_from_addr(rdev, rp_hdr->dst);
+		metal_mutex_release(&rdev->lock);
+
+		if (!ept)
+			/* Fatal error no endpoint for the given dst addr. */
+			return;
+
+		if (ept->dest_addr == RPMSG_ADDR_ANY) {
+			/*
+			 * First message received from the remote side,
+			 * update channel destination address
+			 */
+			ept->dest_addr = rp_hdr->src;
+		}
+		ept->cb(ept, (void *)RPMSG_LOCATE_DATA(rp_hdr),
+				   rp_hdr->len, ept->addr, ept->priv);
+
+		metal_mutex_acquire(&rdev->lock);
+
+		/* Return used buffers. */
+		rpmsg_virtio_return_buffer(rvdev, rp_hdr, len, idx);
+
+		rp_hdr = (struct rpmsg_hdr *)
+			 rpmsg_virtio_get_rx_buffer(rvdev, &len, &idx);
+		metal_mutex_release(&rdev->lock);
+	}
+}
+
+/**
+ * rpmsg_virtio_ns_callback
+ *
+ * This callback handles name service announcement from the remote device
+ * and creates/deletes rpmsg channels.
+ *
+ * @param server_chnl - pointer to server channel control block.
+ * @param data        - pointer to received messages
+ * @param len         - length of received data
+ * @param priv        - any private data
+ * @param src         - source address
+ *
+ * @return - none
+ */
+static void rpmsg_virtio_ns_callback(struct rpmsg_endpoint *ept, void *data,
+				     size_t len, uint32_t src, void *priv)
+{
+	struct rpmsg_device *rdev = ept->rdev;
+	struct rpmsg_virtio_device *rvdev = (struct rpmsg_virtio_device *)rdev;
+	struct rpmsg_endpoint *_ept;
+	struct rpmsg_ns_msg *ns_msg;
+	int status;
+
+	(void)priv;
+	(void)src;
+
+	ns_msg = (struct rpmsg_ns_msg *)data;
+
+	/* check if a Ept has been locally registered */
+	metal_mutex_acquire(&rdev->lock);
+	_ept = rpmsg_get_ept_from_remote_addr(rdev, ns_msg->addr);
+	metal_mutex_release(&rdev->lock);
+
+	if (ns_msg->flags & RPMSG_NS_DESTROY) {
+		if (!_ept)
+			return;
+		metal_mutex_acquire(&rdev->lock);
+		rpmsg_destroy_ept(_ept);
+		metal_mutex_release(&rdev->lock);
+	} else {
+		struct metal_io_region *io = rvdev->shbuf_io;
+
+		if (!_ept) {
+			/*create an endpoint to store remote end point */
+			_ept = (struct rpmsg_endpoint *)
+				metal_allocate_memory(sizeof(*_ept));
+			metal_io_block_read(io,
+				metal_io_virt_to_offset(io, ns_msg->name),
+				&_ept->name, len);
+			_ept->addr = RPMSG_ADDR_ANY;
+			_ept->dest_addr = ns_msg->addr;
+			status = rpmsg_register_endpoint(rdev, _ept);
+			if (status < 0) {
+				metal_free_memory(ept);
+				return;
+			}
+			if (rdev->new_endpoint_cb)
+				rdev->new_endpoint_cb(_ept);
+		} else {
+			_ept->dest_addr = ns_msg->addr;
+		}
+	}
+}
+
+/**
+ * rpmsg_init_vdev: ropmsg initialisation
+ * Master side:
+ * Initialize RPMsg virtio queues and shared buffers, the address of shm can be
+ * ANY. In this case, function will get shared memory from system shared memory
+ * pools. If the vdev has RPMsg name service feature, this API will create an
+ * name service endpoint.
+ *
+ * Slave side:
+ * This API will not return until the driver ready is set by the master side.
+ *
+ * @param rvdev  - pointer to the rpmsg device
+ * @param vdev   - pointer to the virtio device
+ * @param new_endpoint_cb - pointer to callback on creation of a new endpoint
+ * @param shm_io - pointer to the share memory I/O region.
+ * @param shm    - pointer to the share memory.
+ * @param len    - length of the shared memory section.
+ *
+ * @return - status of function execution
+ */
+int rpmsg_init_vdev(struct rpmsg_virtio_device *rvdev,
+		    struct virtio_device *vdev,
+		    void (*new_endpoint_cb)(struct rpmsg_endpoint *ep),
+		    struct metal_io_region *shm_io,
+		    void *shm, unsigned int len)
+{
+	struct rpmsg_device *rdev;
+	const char *vq_names[RPMSG_NUM_VRINGS];
+	void (*callback[RPMSG_NUM_VRINGS]) (struct virtqueue *vq);
+	unsigned long dev_features;
+	int status;
+	unsigned int i;
+
+	rdev = &rvdev->rdev;
+	metal_mutex_init(&rdev->lock);
+	rvdev->vdev = vdev;
+	rdev->new_endpoint_cb = new_endpoint_cb;
+	vdev->priv = rvdev;
+	rdev->ops.send_offchannel_raw = rpmsg_virtio_send_offchannel_raw;
+	if (rpmsg_virtio_get_role(rvdev) == RPMSG_MASTER) {
+		/*
+		 * Since device is RPMSG Remote so we need to manage the
+		 * shared buffers. Create shared memory pool to handle buffers.
+		 */
+		if (!shm || !len)
+			return -RPMSG_ERR_NO_MEM;
+
+		rvdev->shbuf =
+		    sh_mem_create_pool(shm, len, RPMSG_BUFFER_SIZE);
+
+		if (!rvdev->shbuf)
+			return RPMSG_ERR_NO_MEM;
+
+		vq_names[0] = "rx_vq";
+		vq_names[1] = "tx_vq";
+		callback[0] = rpmsg_virtio_rx_callback;
+		callback[1] = rpmsg_virtio_tx_callback;
+		rvdev->rvq  = vdev->vrings_info[0].vq;
+		rvdev->svq  = vdev->vrings_info[1].vq;
+	} else {
+		vq_names[0] = "tx_vq";
+		vq_names[1] = "rx_vq";
+		callback[0] = rpmsg_virtio_tx_callback;
+		callback[1] = rpmsg_virtio_rx_callback;
+		rvdev->rvq  = vdev->vrings_info[1].vq;
+		rvdev->svq  = vdev->vrings_info[0].vq;
+	}
+
+	rvdev->shbuf_io = shm_io;
+
+	if (rpmsg_virtio_get_role(rvdev) == RPMSG_REMOTE) {
+		/* wait synchro with the master */
+		rpmsg_virtio_wait_remote_ready(rvdev);
+	}
+
+	/* Create virtqueues for remote device */
+	status = rpmsg_virtio_create_virtqueues(rvdev, 0, RPMSG_NUM_VRINGS,
+					       vq_names, callback);
+	if (status != RPMSG_SUCCESS)
+		return status;
+
+	/* TODO: can have a virtio function to set the shared memory I/O */
+	for (i = 0; i < RPMSG_NUM_VRINGS; i++) {
+		struct virtqueue *vq;
+
+		vq = vdev->vrings_info[i].vq;
+		vq->shm_io = shm_io;
+	}
+
+	if (rpmsg_virtio_get_role(rvdev) == RPMSG_MASTER) {
+		struct virtqueue_buf vqbuf;
+		unsigned int idx;
+		void * buffer;
+
+                vqbuf.len = RPMSG_BUFFER_SIZE;
+                for (idx = 0; ((idx < rvdev->rvq->vq_nentries)
+                               && (idx < rvdev->shbuf->total_buffs / 2));
+                     idx++) {
+
+                        /* Initialize TX virtqueue buffers for remote device */
+                        buffer = sh_mem_get_buffer(rvdev->shbuf);
+
+                        if (!buffer) {
+                                return RPMSG_ERR_NO_BUFF;
+                        }
+
+                        vqbuf.buf = buffer;
+
+                        metal_io_block_set(shm_io,
+                                metal_io_virt_to_offset(shm_io, buffer),
+                                0x00,
+                                RPMSG_BUFFER_SIZE);
+                        status =
+                            virtqueue_add_buffer(rvdev->rvq, &vqbuf, 0, 1,
+                                                 buffer);
+
+                        if (status != RPMSG_SUCCESS) {
+                                return status;
+                        }
+                }
+
+	}
+
+	/* Initialize channels and endpoints list */
+	metal_list_init(&rdev->endpoints);
+
+	dev_features = rpmsg_virtio_get_features(rvdev);
+
+	/*
+	 * Create name service announcement endpoint if device supports name
+	 * service announcement feature.
+	 */
+	if ((dev_features & (1 << VIRTIO_RPMSG_F_NS))) {
+		if (!rpmsg_create_ept(rdev, "NS", RPMSG_NS_EPT_ADDR,
+				      RPMSG_NS_EPT_ADDR,
+				      rpmsg_virtio_ns_callback,
+				      NULL))
+			return RPMSG_ERR_NO_MEM;
+
+	}
+
+	if (rpmsg_virtio_get_role(rvdev) == RPMSG_MASTER)
+		rpmsg_virtio_set_status(rvdev, VIRTIO_CONFIG_STATUS_DRIVER_OK);
+
+
+	return status;
+}
+
+void rpmsg_deinit_vdev(struct rpmsg_virtio_device *rvdev)
+{
+	struct metal_list *node;
+	struct rpmsg_device *rdev;
+	struct rpmsg_endpoint *ept;
+
+	rdev = &rvdev->rdev;
+	metal_mutex_acquire(&rdev->lock);
+	while (!metal_list_is_empty(&rdev->endpoints)) {
+		node = rdev->endpoints.next;
+		ept = metal_container_of(node, struct rpmsg_endpoint, node);
+		rpmsg_destroy_ept(ept);
+	}
+
+	rvdev->rvq = 0;
+	rvdev->svq = 0;
+	if (rvdev->shbuf) {
+		sh_mem_delete_pool(rvdev->shbuf);
+		rvdev->shbuf = NULL;
+	}
+	metal_mutex_release(&rdev->lock);
+
+	metal_mutex_deinit(&rdev->lock);
+}

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -569,12 +569,10 @@ int rpmsg_init_vdev(struct rpmsg_virtio_device *rvdev,
 	 * service announcement feature.
 	 */
 	if ((dev_features & (1 << VIRTIO_RPMSG_F_NS))) {
-		if (!rpmsg_create_ept(rdev, "NS", RPMSG_NS_EPT_ADDR,
-				      RPMSG_NS_EPT_ADDR,
-				      rpmsg_virtio_ns_callback,
-				      NULL))
-			return RPMSG_ERR_NO_MEM;
-
+		rpmsg_init_ept(&rdev->ns_ept, "NS",
+			       RPMSG_NS_EPT_ADDR, RPMSG_NS_EPT_ADDR,
+			       rpmsg_virtio_ns_callback, NULL);
+		(void)rpmsg_register_endpoint(rdev, &rdev->ns_ept);
 	}
 
 	if (rpmsg_virtio_get_role(rvdev) == RPMSG_MASTER)

--- a/lib/virtio/virtio.c
+++ b/lib/virtio/virtio.c
@@ -79,3 +79,42 @@ void virtio_describe(struct virtio_device *dev, const char *msg,
 	// TODO: Not used currently - keeping it for future use
 	virtio_feature_name(0, desc);
 }
+
+int virtio_create_virtqueues(struct virtio_device *vdev, unsigned int flags,
+			     unsigned int nvqs, const char *names[],
+			     vq_callback *callbacks[])
+{
+	struct virtio_vring_info *vring_info;
+	struct vring_alloc_info *vring_alloc;
+	unsigned int num_vrings, i;
+	int ret;
+	(void)flags;
+
+	num_vrings = vdev->vrings_num;
+	if (nvqs > num_vrings)
+		return -ERROR_VQUEUE_INVLD_PARAM;
+	/* Initialize virtqueue for each vring */
+	for (i = 0; i < nvqs; i++) {
+		vring_info = &vdev->vrings_info[i];
+
+		vring_alloc = &vring_info->info;
+		if (vdev->role == VIRTIO_DEV_MASTER) {
+			size_t offset;
+			struct metal_io_region *io = vring_info->io;
+
+			offset = metal_io_virt_to_offset(io, vring_alloc->vaddr);
+			metal_io_block_set(io, offset, 0,
+					   vring_size(vring_alloc->num_descs,
+						      vring_alloc->align));
+		}
+		ret = virtqueue_create(vdev, i,
+					names[i], vring_alloc,
+					callbacks[i],
+					vdev->func->notify,
+					vring_info->vq);
+		if (ret)
+			return ret;
+	}
+	return 0;
+}
+

--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -69,7 +69,7 @@ int virtqueue_create(struct virtio_device *virt_dev, unsigned short id,
 
 	if (status == VQUEUE_SUCCESS) {
 		vq->vq_dev = virt_dev;
-		strncpy(vq->vq_name, name, VIRTQUEUE_MAX_NAME_SZ);
+		vq->vq_name =  name;
 		vq->vq_queue_index = id;
 		vq->vq_nentries = ring->num_descs;
 		vq->vq_free_cnt = vq->vq_nentries;


### PR DESCRIPTION
Add patches that suppress the memory allocation/free in openamp lib.
with these patches application have to declare the endpoint ( dynamic or static allocation) and provide
the structure address as parameter of the  rpmsg_create_ept function.
On the other side, when a new service announcement is received, no more endpoint is created. 
Instead, a user callback is created to provide service name and remote address.  application can:
- create the associated endpoint in callback ( calling rpmsg_create_ept )
- save the name and the remote address for future use
- Ignore the service as not supported. in this case the service request is dropped.  
