### PR TITLE
cmake: Remove dead cmake option

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -75,7 +75,6 @@ if (WITH_ZEPHYR)
 endif (WITH_ZEPHYR)
 
 option (WITH_LIBMETAL_FIND "Check Libmetal library can be found" ON)
-option (WITH_EXT_INCLUDES_FIND "Check other external includes are found" ON)
 
 message ("-- C_FLAGS : ${CMAKE_C_FLAGS}")
 # vim: expandtab:ts=2:sw=2:smartindent


### PR DESCRIPTION
Removed WITH_EXT_INCLUDES_FIND as there is nothing that references or
uses it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>