### PR TITLE
separate hil_enalbe_vring_notifications

### DIFF
--- a/lib/common/hil.c
+++ b/lib/common/hil.c
@@ -418,15 +418,32 @@ int hil_enable_vdev_notification(struct hil_proc *proc, int id)
 }
 
 /**
- * hil_enable_vring_notifications()
+ * hil_save_vring_handle()
  *
  * This function is called after successful creation of virtqueues.
  * This function saves queue handle in the vring_info_table which
- * will be used during interrupt handling .This function setups
- * interrupt handlers.
+ * will be used during interrupt handling .
  *
  * @param vring_index - index to vring HW table
  * @param vq          - pointer to virtqueue to save in vring HW table
+ *
+ */
+void hil_save_vring_handle(int vring_index, struct virtqueue *vq)
+{
+	struct hil_proc *proc_hw = (struct hil_proc *)vq->vq_dev->device;
+	struct proc_vring *vring_hw = &proc_hw->vdev.vring_info[vring_index];
+	/* Save virtqueue pointer for later reference */
+	vring_hw->vq = vq;
+}
+
+/**
+ * hil_enable_vring_notifications()
+ *
+ * This function is called after saving queue handle. This function setups
+ * interrupt handlers.
+ *
+ * @param vring_index - index to vring HW table
+ * @param vq          - pointer to virtqueue to setup interrupt handlers.
  *
  * @return            - execution status
  */
@@ -434,8 +451,6 @@ int hil_enable_vring_notifications(int vring_index, struct virtqueue *vq)
 {
 	struct hil_proc *proc_hw = (struct hil_proc *)vq->vq_dev->device;
 	struct proc_vring *vring_hw = &proc_hw->vdev.vring_info[vring_index];
-	/* Save virtqueue pointer for later reference */
-	vring_hw->vq = vq;
 
 	if (proc_hw->ops->enable_interrupt) {
 		proc_hw->ops->enable_interrupt(&vring_hw->intr_info);

--- a/lib/include/openamp/hil.h
+++ b/lib/include/openamp/hil.h
@@ -309,15 +309,26 @@ void hil_free_vqs(struct virtio_device *vdev);
 int hil_enable_vdev_notification(struct hil_proc *proc, int id);
 
 /**
- * hil_enable_vring_notifications()
+ * hil_save_vring_handle()
  *
  * This function is called after successful creation of virtqueues.
  * This function saves queue handle in the vring_info_table which
- * will be used during interrupt handling .This function setups
- * interrupt handlers.
+ * will be used during interrupt handling .
  *
  * @param vring_index - index to vring HW table
  * @param vq          - pointer to virtqueue to save in vring HW table
+ *
+ */
+void hil_save_vring_handle(int vring_index, struct virtqueue *vq);
+
+/**
+ * hil_enable_vring_notifications()
+ *
+ * This function is called after saving queue handle.This function setups
+ * interrupt handlers.
+ *
+ * @param vring_index - index to vring HW table
+ * @param vq          - pointer to virtqueue to setup interrupt handlers 
  *
  * @return            - execution status
  */

--- a/lib/rpmsg/rpmsg_core.c
+++ b/lib/rpmsg/rpmsg_core.c
@@ -134,6 +134,9 @@ int rpmsg_start_ipc(struct remote_device *rdev)
 		vqs[1] = rdev->tvq;
 	}
 	for (i = 0; i <= 1; i++) {
+		hil_save_vring_handle(i, vqs[i]);
+	}
+	for (i = 0; i <= 1; i++) {
 		status = hil_enable_vring_notifications(i, vqs[i]);
 		if (status != RPMSG_SUCCESS) {
 			return status;


### PR DESCRIPTION
Hi. all
I used ISR (not polling) based remoteproc dirver on our RTOS.
In case an rpu application was loaded by Linux remoteproc and rpmsg_user_dev_driver 
on ZynqMP, ISR is called before saving second vring handle when first vring is enabling 
notfications, and then hil_notified is refer NULL pointer vring by called ISR. 

I need separate this function into two, set vring handle and enable notification.

