### PR TITLE
remoteproc: elf_loader: Return success on no more loadable segment

### DIFF
--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -576,8 +576,10 @@ int elf_load(struct remoteproc *rproc,
 		phdr = elf_next_load_segment(*img_info, &nsegment, da,
 					     noffset, &nsize, &nsegmsize);
 		if (phdr == NULL) {
-			metal_log(METAL_LOG_DEBUG, "cannot find segement\r\n");
-			return -RPROC_EINVAL;
+			metal_log(METAL_LOG_DEBUG, "cannot find more segement\r\n");
+			*load_state = (*load_state & (~ELF_NEXT_SEGMENT_MASK)) |
+				      (unsigned int)(nsegment & ELF_NEXT_SEGMENT_MASK);
+			return *load_state;
 		}
 		*nlen = nsize;
 		*nmemsize = nsegmsize;


### PR DESCRIPTION
When there's no more segment to load, return success so that the caller
can proceed with further operations.

Signed-off-by: Hyun Kwon <hyun.kwon@xilinx.com>