### PR TITLE
apps: remove unused functions

### DIFF
--- a/apps/examples/echo/rpmsg-echo.c
+++ b/apps/examples/echo/rpmsg-echo.c
@@ -17,10 +17,6 @@ This application echoes back data that was sent to it by the master core. */
 static struct rpmsg_endpoint lept;
 static int shutdown_req = 0;
 
-/* External functions */
-extern int init_system(void);
-extern void cleanup_system(void);
-
 /*-----------------------------------------------------------------------------*
  *  RPMSG endpoint callbacks
  *-----------------------------------------------------------------------------*/

--- a/apps/examples/echo/rpmsg-ping.c
+++ b/apps/examples/echo/rpmsg-ping.c
@@ -32,10 +32,6 @@ static int rnum = 0;
 static int err_cnt = 0;
 static int ept_deleted = 0;
 
-/* External functions */
-extern int init_system();
-extern void cleanup_system();
-
 /*-----------------------------------------------------------------------------*
  *  RPMSG endpoint callbacks
  *-----------------------------------------------------------------------------*/

--- a/apps/examples/matrix_multiply/matrix_multiply.c
+++ b/apps/examples/matrix_multiply/matrix_multiply.c
@@ -33,10 +33,6 @@ static unsigned int result_returned = 0;
 static int err_cnt = 0;
 static int ept_deleted = 0;
 
-/* External functions */
-extern int init_system();
-extern void cleanup_system();
-
 /**
  * _gettimeofday() is called from time() which is used by srand() to generate
  * random number. It is defined here in case this function is not defined in

--- a/apps/examples/matrix_multiply/matrix_multiplyd.c
+++ b/apps/examples/matrix_multiply/matrix_multiplyd.c
@@ -28,11 +28,6 @@ typedef struct _matrix {
 static struct rpmsg_endpoint lept;
 static int shutdown_req = 0;
 
-/* External functions */
-extern int init_system(void);
-extern void cleanup_system(void);
-
-
 /*-----------------------------------------------------------------------------*
  *  Calculate the Matrix
  *-----------------------------------------------------------------------------*/

--- a/apps/examples/rpmsg_sample_echo/rpmsg-sample-echo.c
+++ b/apps/examples/rpmsg_sample_echo/rpmsg-sample-echo.c
@@ -21,10 +21,6 @@
 static struct rpmsg_endpoint lept;
 static int shutdown_req = 0;
 
-/* External functions */
-extern int init_system(void);
-extern void cleanup_system(void);
-
 /*-----------------------------------------------------------------------------*
  *  RPMSG endpoint callbacks
  *-----------------------------------------------------------------------------*/

--- a/apps/examples/rpmsg_sample_echo/rpmsg-sample-ping.c
+++ b/apps/examples/rpmsg_sample_echo/rpmsg-sample-ping.c
@@ -33,10 +33,6 @@ static int rnum = 0;
 static int err_cnt = 0;
 static int ept_deleted = 0;
 
-/* External functions */
-extern int init_system(void);
-extern void cleanup_system(void);
-
 /*-----------------------------------------------------------------------------*
  *  RPMSG endpoint callbacks
  *-----------------------------------------------------------------------------*/


### PR DESCRIPTION
Previously, init_system and cleanup_system were used within the
applications. Remove as they are no longer called in the application
files.

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>