### PR TITLE
virtio: Fix offset of struct vring::used

### DIFF
--- a/lib/include/openamp/virtio_ring.h
+++ b/lib/include/openamp/virtio_ring.h
@@ -127,7 +127,8 @@ vring_init(struct vring *vr, unsigned int num, uint8_t *p, unsigned long align)
 	vr->desc = (struct vring_desc *)p;
 	vr->avail = (struct vring_avail *)(p + num * sizeof(struct vring_desc));
 	vr->used = (struct vring_used *)
-	    (((unsigned long)&vr->avail->ring[num] + align - 1) & ~(align - 1));
+	    (((unsigned long)&vr->avail->ring[num] + sizeof(uint16_t) +
+	      align - 1) & ~(align - 1));
 }
 
 /*


### PR DESCRIPTION
A comment block in virtio_ring.h describes vring layout, and according
to this commnt, __u16 used_event_idx is a member of struct vring.

virtio_ring.h provided by Linux Kernel properly takes this member
into account in vring_size() and vring_init(). Whereas virtio_ring.h
in OpenAMP, vring_size() is aware of used_event_idx but vring_init()
forgets to add __u16 storage to calculate the offset of used member.

Typically aling passed to vring_size() and vring_init() is 0x1000,
so this is not a problem, but fix this for consistency.

Signed-off-by: Hiroaki SHIMODA <hiroaki.shimoda@miraclelinux.com>