### PR TITLE
remoteproc: virtio: add service to get vdev status.

### DIFF
--- a/lib/include/openamp/remoteproc_virtio.h
+++ b/lib/include/openamp/remoteproc_virtio.h
@@ -131,6 +131,18 @@ int rproc_virtio_init_vring(struct virtio_device *vdev, unsigned int index,
  */
 int rproc_virtio_notified(struct virtio_device *vdev, uint32_t notifyid);
 
+/**
+ * rproc_virtio_wait_remote_ready
+ *
+ * Blocking function, waiting for the remote core is ready to start
+ * communications.
+ *
+ * @vdev - pointer to the virtio device
+ *
+ * return true when remote processor is ready.
+ */
+void rproc_virtio_wait_remote_ready(struct virtio_device *vdev);
+
 #if defined __cplusplus
 }
 #endif

--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -309,3 +309,22 @@ int rproc_virtio_notified(struct virtio_device *vdev, uint32_t notifyid)
 	}
 	return 0;
 }
+
+void rproc_virtio_wait_remote_ready(struct virtio_device *vdev)
+{
+	uint8_t status;
+
+	/*
+	 * No status available for slave. As Master has not to wait
+	 * slave action, we can return. Behavior should be updated
+	 * in future if a slave status is added.
+	 */
+	if (vdev->role == VIRTIO_DEV_MASTER)
+		return;
+
+	while (1) {
+		status = rproc_virtio_get_status(vdev);
+		if (status & VIRTIO_CONFIG_STATUS_DRIVER_OK)
+			return;
+	}
+}


### PR DESCRIPTION
On slave side, during the init sequence we need to wait
the vdev status before calling rproc_virtio_init_vring.
Indeed the virtual address(VA), provided as function
parameter, is based on the device address(DA).
Depending on the environment this DA is retrieved from
the resource table, filled by the master processor.
this service allow to block the processor waiting the
status update.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>