### PR TITLE
rpmsg: fix virtio set_status usage of vdev status for slave

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,7 @@ names to be CC'd when submitting a patch.
 
 ## Project Administration
 Wendy Liang <wendy.liang@xilinx.com>
-Ed T. Mooring <emooring@xilinx.com>
+Ed T. Mooring <ed.mooring@linaro.org>
 Arnaud Pouliquen <arnaud.pouliquen@st.com>
 
 ### All patches CC here
@@ -19,8 +19,8 @@ open-amp@googlegroups.com
 ## Machines
 ### Xilinx Platform - Zynq-7000
 Wendy Liang <wendy.liang@xilinx.com>
-Ed T. Mooring <emooring@xilinx.com>
+Ed T. Mooring <ed.mooring@linaro.org>
 
 ### Xilinx Platform - Zynq UltraScale+ MPSoC
 Wendy Liang <wendy.liang@xilinx.com>
-Ed T. Mooring <emooring@xilinx.com>
+Ed T. Mooring <ed.mooring@linaro.org>


### PR DESCRIPTION
Today only one vdev status is available for the processors
status. To avoid overwrite, this status has to be updated
only by the master.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>