### PR TITLE
Fix errors

### DIFF
--- a/lib/include/openamp/remoteproc.h
+++ b/lib/include/openamp/remoteproc.h
@@ -106,8 +106,8 @@ enum fw_resource_type {
 	RSC_VENDOR_END = 512,
 };
 
-#define FW_RSC_ADDR_ANY (0xFFFFFFFFFFFFFFFF)
-#define FW_RSC_U32_ADDR_ANY (0xFFFFFFFF)
+#define FW_RSC_U64_ADDR_ANY 0xFFFFFFFFFFFFFFFFUL
+#define FW_RSC_U32_ADDR_ANY 0xFFFFFFFFUL
 
 /**
  * struct fw_rsc_carveout - physically contiguous memory request

--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -118,9 +118,6 @@ struct rpmsg_device {
  * the source @src address.
  * The message will be sent to the remote processor which the channel belongs
  * to.
- * In case there are no TX buffers available, the function will block until
- * one becomes available, or a timeout of 15 seconds elapses. When the latter
- * happens, -ERESTARTSYS is returned.
  *
  * Returns number of bytes it has sent or negative error value on failure.
  */

--- a/lib/proxy/rpmsg_retarget.c
+++ b/lib/proxy/rpmsg_retarget.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <metal/mutex.h>
 #include <metal/spinlock.h>
 #include <metal/utilities.h>

--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -418,7 +418,7 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 			if (*img_info == NULL) {
 				*img_info = metal_allocate_memory(infosize);
 				if (*img_info == NULL)
-					return -ENOMEM;
+					return -RPROC_ENOMEM;
 				memset(*img_info, 0, infosize);
 			}
 			memcpy(*img_info, img_data, tmpsize);
@@ -454,7 +454,7 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 		phdrs = (char **)elf_phtable_ptr(*img_info);
 		(*phdrs) = metal_allocate_memory(phdrs_size);
 		if (*phdrs == NULL)
-			return -ENOMEM;
+			return -RPROC_ENOMEM;
 		memcpy((void *)(*phdrs), img_phdrs, phdrs_size);
 		*load_state = ELF_STATE_WAIT_FOR_SHDRS |
 			       RPROC_LOADER_READY_TO_LOAD;
@@ -488,7 +488,7 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 		shdrs = (char **)elf_shtable_ptr(*img_info);
 		(*shdrs) = metal_allocate_memory(shdrs_size);
 		if (*shdrs == NULL)
-			return -ENOMEM;
+			return -RPROC_ENOMEM;
 		memcpy((void *)*shdrs, img_shdrs, shdrs_size);
 		*load_state = (*load_state & (~ELF_STATE_MASK)) |
 			       ELF_STATE_WAIT_FOR_SHSTRTAB;
@@ -523,7 +523,7 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 		shstrtab = elf_shstrtab_ptr(*img_info);
 		*shstrtab = metal_allocate_memory(shstrtab_size);
 		if (*shstrtab == NULL)
-			return -ENOMEM;
+			return -RPROC_ENOMEM;
 		memcpy(*shstrtab,
 		       (const void *)((const char *)img_data + shstrtab_offset),
 		       shstrtab_size);

--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -144,7 +144,7 @@ int remoteproc_set_rsc_table(struct remoteproc *rproc,
 
 	io = remoteproc_get_io_with_va(rproc, (void *)rsc_table);
 	if (!io)
-		return -EINVAL;
+		return -RPROC_EINVAL;
 	ret = remoteproc_parse_rsc_table(rproc, rsc_table, rsc_size);
 	if (!ret) {
 		rproc->rsc_table = rsc_table;
@@ -178,10 +178,10 @@ int remoteproc_remove(struct remoteproc *rproc)
 		if (rproc->state == RPROC_OFFLINE)
 			rproc->ops->remove(rproc);
 		else
-			ret = -EBUSY;
+			ret = -RPROC_EAGAIN;
 		metal_mutex_release(&rproc->lock);
 	} else {
-		ret = -EINVAL;
+		ret = -RPROC_EINVAL;
 	}
 	return ret;
 }
@@ -498,7 +498,7 @@ int remoteproc_load(struct remoteproc *rproc, const char *path,
 	metal_log(METAL_LOG_DEBUG, "%s: load executable data\r\n", __func__);
 	offset = 0;
 	len = 0;
-	ret = -EINVAL;
+	ret = -RPROC_EINVAL;
 	while(1) {
 		unsigned char padding;
 		size_t nmemsize;

--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -294,7 +294,7 @@ int rproc_virtio_notified(struct virtio_device *vdev, uint32_t notifyid)
 	struct virtqueue *vq;
 
 	if (!vdev)
-		return -EINVAL;
+		return -RPROC_EINVAL;
 	/* We do nothing for vdev notification in this implementation */
 	if (vdev->index == notifyid)
 		return 0;


### PR DESCRIPTION
The remoteproc implementation uses both error code from c library and remoteproc definition.
We should just use remoteproc defined error code for consistency.
For the rpmsg_retarget.c, it redefine c library file operations, it uses c library error code, it should include error.h header.