### PR TITLE
rpmsg: virtio: fix get buffer size return

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -271,6 +271,9 @@ static int _rpmsg_virtio_get_buffer_size(struct rpmsg_virtio_device *rvdev)
 		length =
 		    (int)virtqueue_get_desc_size(rvdev->svq) -
 		    sizeof(struct rpmsg_hdr);
+		if (length < 0) {
+			length = 0;
+		}
 	}
 #endif /*!VIRTIO_MASTER_ONLY*/
 


### PR DESCRIPTION
If the length in buffer descriptor is 0 or less then the
RPMsg header, return 0.

Signed-off-by: Wendy Liang <wendy.liang@xilinx.com>