### PR TITLE
assert only when status < 0 in rpmsg_virtio_rx_callback

### DIFF
--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -45,6 +45,7 @@ extern "C" {
 struct rpmsg_endpoint;
 struct rpmsg_device;
 
+/* Returns positive value on success or negative error value on failure */
 typedef int (*rpmsg_ept_cb)(struct rpmsg_endpoint *ept, void *data,
 			    size_t len, uint32_t src, void *priv);
 typedef void (*rpmsg_ns_unbind_cb)(struct rpmsg_endpoint *ept);

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -411,7 +411,7 @@ static void rpmsg_virtio_rx_callback(struct virtqueue *vq)
 			status = ept->cb(ept, RPMSG_LOCATE_DATA(rp_hdr),
 					 rp_hdr->len, rp_hdr->src, ept->priv);
 
-			RPMSG_ASSERT(status == RPMSG_SUCCESS,
+			RPMSG_ASSERT(status >= 0,
 				     "unexpected callback status\r\n");
 		}
 


### PR DESCRIPTION
since the successful return value from many function is greater than zero

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>