### PR TITLE
zero out ept in rpmsg_destroy_ept

### DIFF
--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -111,6 +111,20 @@ struct rpmsg_device {
 };
 
 /**
+ * is_rpmsg_ept_ready - check if the rpmsg endpoint ready to send
+ *
+ * @ept: pointer to rpmsg endpoint
+ *
+ * Returns 1 if the rpmsg endpoint has both local addr and destination
+ * addr set, 0 otherwise
+ */
+static inline unsigned int is_rpmsg_ept_ready(struct rpmsg_endpoint *ept)
+{
+	return (ept->dest_addr != RPMSG_ADDR_ANY) &&
+		(ept->addr != 0) && (ept->addr != RPMSG_ADDR_ANY);
+}
+
+/**
  * rpmsg_send_offchannel_raw() - send a message across to the remote processor,
  * specifying source and destination address.
  * @ept: the rpmsg endpoint
@@ -146,7 +160,7 @@ int rpmsg_send_offchannel_raw(struct rpmsg_endpoint *ept, uint32_t src,
 static inline int rpmsg_send(struct rpmsg_endpoint *ept, const void *data,
 			     int len)
 {
-	if (ept->dest_addr == RPMSG_ADDR_ANY)
+	if (!is_rpmsg_ept_ready(ept))
 		return RPMSG_ERR_ADDR;
 	return rpmsg_send_offchannel_raw(ept, ept->addr, ept->dest_addr, data,
 					 len, true);
@@ -216,7 +230,7 @@ static inline int rpmsg_send_offchannel(struct rpmsg_endpoint *ept,
 static inline int rpmsg_trysend(struct rpmsg_endpoint *ept, const void *data,
 				int len)
 {
-	if (ept->dest_addr == RPMSG_ADDR_ANY)
+	if (!is_rpmsg_ept_ready(ept))
 		return RPMSG_ERR_ADDR;
 	return rpmsg_send_offchannel_raw(ept, ept->addr, ept->dest_addr, data,
 					 len, false);
@@ -335,20 +349,6 @@ int rpmsg_create_ept(struct rpmsg_endpoint *ept, struct rpmsg_device *rdev,
  * destroy endpoint callback if it is provided.
  */
 void rpmsg_destroy_ept(struct rpmsg_endpoint *ept);
-
-/**
- * is_rpmsg_ept_ready - check if the rpmsg endpoint ready to send
- *
- * @ept: pointer to rpmsg endpoint
- *
- * Returns 1 if the rpmsg endpoint has both local addr and destination
- * addr set, 0 otherwise
- */
-static inline unsigned int is_rpmsg_ept_ready(struct rpmsg_endpoint *ept)
-{
-	return (ept->dest_addr != RPMSG_ADDR_ANY) &&
-		(ept->addr != 0) && (ept->addr != RPMSG_ADDR_ANY);
-}
 
 #if defined __cplusplus
 }

--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -347,7 +347,7 @@ void rpmsg_destroy_ept(struct rpmsg_endpoint *ept);
 static inline unsigned int is_rpmsg_ept_ready(struct rpmsg_endpoint *ept)
 {
 	return (ept->dest_addr != RPMSG_ADDR_ANY) &&
-		(ept->addr != RPMSG_ADDR_ANY);
+		(ept->addr != 0) && (ept->addr != RPMSG_ADDR_ANY);
 }
 
 #if defined __cplusplus

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -112,7 +112,8 @@ int rpmsg_send_offchannel_raw(struct rpmsg_endpoint *ept, uint32_t src,
 {
 	struct rpmsg_device *rdev;
 
-	if (!ept || !ept->rdev || !data || dst == RPMSG_ADDR_ANY)
+	if (!ept || !ept->rdev || !data || src == 0 ||
+	    src == RPMSG_ADDR_ANY || dst == RPMSG_ADDR_ANY)
 		return RPMSG_ERR_PARAM;
 
 	rdev = ept->rdev;

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -27,7 +27,7 @@ static uint32_t rpmsg_get_address(unsigned long *bitmap, int size)
 	unsigned int addr = RPMSG_ADDR_ANY;
 	unsigned int nextbit;
 
-	nextbit = metal_bitmap_next_clear_bit(bitmap, 0, size);
+	nextbit = metal_bitmap_next_clear_bit(bitmap, 1, size);
 	if (nextbit < (uint32_t)size) {
 		addr = nextbit;
 		metal_bitmap_set_bit(bitmap, nextbit);
@@ -203,7 +203,7 @@ int rpmsg_create_ept(struct rpmsg_endpoint *ept, struct rpmsg_device *rdev,
 	int status = RPMSG_SUCCESS;
 	uint32_t addr = src;
 
-	if (!ept)
+	if (!ept || !src)
 		return RPMSG_ERR_PARAM;
 
 	metal_mutex_acquire(&rdev->lock);
@@ -262,4 +262,5 @@ void rpmsg_destroy_ept(struct rpmsg_endpoint *ept)
 	metal_mutex_acquire(&rdev->lock);
 	rpmsg_unregister_endpoint(ept);
 	metal_mutex_release(&rdev->lock);
+	memset(ept, 0, sizeof(*ept));
 }

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -8,7 +8,6 @@
  */
 
 #include <metal/alloc.h>
-#include <metal/sleep.h>
 #include <metal/utilities.h>
 #include <openamp/rpmsg_virtio.h>
 #include <openamp/virtqueue.h>
@@ -16,12 +15,6 @@
 #include "rpmsg_internal.h"
 
 #define RPMSG_NUM_VRINGS                        2
-
-/* Total tick count for 15secs - 1usec tick. */
-#define RPMSG_TICK_COUNT                        15000000
-
-/* Time to wait - In multiple of 1 msecs. */
-#define RPMSG_TICKS_PER_INTERVAL                1000
 
 #ifndef VIRTIO_SLAVE_ONLY
 metal_weak void *


### PR DESCRIPTION
and don't use zero as the local address, so
it's easier to detect the uninitialized case.

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>