### PR TITLE
apps: zynqmp userspace: update dts shared mem node

### DIFF
--- a/apps/machine/zynqmp/openamp-linux-userspace.dtsi
+++ b/apps/machine/zynqmp/openamp-linux-userspace.dtsi
@@ -16,7 +16,7 @@
 		};
 		shm0: shm@0 {
 			compatible = "shm_uio";
-			reg = <0x0 0x3ed80000 0x0 0x80000>;
+			reg = <0x0 0x3ed20000 0x0 0x0100000>;
 		};
 		ipi0: ipi@0 {
 			compatible = "ipi_uio";


### PR DESCRIPTION
Update to match default shared memory configuration.

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>