### PR TITLE
compilation warnings and IAR c-stat reports

### DIFF
--- a/lib/include/openamp/elf_loader.h
+++ b/lib/include/openamp/elf_loader.h
@@ -300,13 +300,13 @@ struct elf64_info {
 	void *shstrtab;
 };
 
-#define ELF_STATE_INIT              0x0UL
-#define ELF_STATE_WAIT_FOR_PHDRS    0x100UL
-#define ELF_STATE_WAIT_FOR_SHDRS    0x200UL
-#define ELF_STATE_WAIT_FOR_SHSTRTAB 0x400UL
-#define ELF_STATE_HDRS_COMPLETE     0x800UL
-#define ELF_STATE_MASK              0xFF00UL
-#define ELF_NEXT_SEGMENT_MASK       0x00FFUL
+#define ELF_STATE_INIT              0x0L
+#define ELF_STATE_WAIT_FOR_PHDRS    0x100L
+#define ELF_STATE_WAIT_FOR_SHDRS    0x200L
+#define ELF_STATE_WAIT_FOR_SHSTRTAB 0x400L
+#define ELF_STATE_HDRS_COMPLETE     0x800L
+#define ELF_STATE_MASK              0xFF00L
+#define ELF_NEXT_SEGMENT_MASK       0x00FFL
 
 extern struct loader_ops elf_ops;
 

--- a/lib/include/openamp/remoteproc.h
+++ b/lib/include/openamp/remoteproc.h
@@ -22,6 +22,8 @@ extern "C" {
 
 #define RSC_NOTIFY_ID_ANY 0xFFFFFFFFUL
 
+#define RPROC_MAX_NAME_LEN 32
+
 /**
  * struct resource_table - firmware resource table header
  * @ver: version number
@@ -158,7 +160,7 @@ struct fw_rsc_carveout {
 	uint32_t len;
 	uint32_t flags;
 	uint32_t reserved;
-	uint8_t name[32];
+	uint8_t name[RPROC_MAX_NAME_LEN];
 } METAL_PACKED_END;
 
 /**
@@ -198,7 +200,7 @@ struct fw_rsc_devmem {
 	uint32_t len;
 	uint32_t flags;
 	uint32_t reserved;
-	uint8_t name[32];
+	uint8_t name[RPROC_MAX_NAME_LEN];
 } METAL_PACKED_END;
 
 /**
@@ -223,7 +225,7 @@ struct fw_rsc_trace {
 	uint32_t da;
 	uint32_t len;
 	uint32_t reserved;
-	uint8_t name[32];
+	uint8_t name[RPROC_MAX_NAME_LEN];
 } METAL_PACKED_END;
 
 /**
@@ -336,7 +338,7 @@ struct remoteproc_mem {
 	metal_phys_addr_t da;
 	metal_phys_addr_t pa;
 	size_t size;
-	char name[32];
+	char name[RPROC_MAX_NAME_LEN];
 	struct metal_io_region *io;
 	struct metal_list node;
 };

--- a/lib/include/openamp/remoteproc_loader.h
+++ b/lib/include/openamp/remoteproc_loader.h
@@ -40,19 +40,19 @@ extern "C" {
 
 /* Remoteproc loader Executable Image Parsing States */
 /* Remoteproc loader parser initial state */
-#define RPROC_LOADER_NOT_READY      0x0UL
+#define RPROC_LOADER_NOT_READY      0x0L
 /* Remoteproc loader ready to load, even it can be not finish parsing */
-#define RPROC_LOADER_READY_TO_LOAD  0x10000UL
+#define RPROC_LOADER_READY_TO_LOAD  0x10000L
 /* Remoteproc loader post data load */
-#define RPROC_LOADER_POST_DATA_LOAD 0x20000UL
+#define RPROC_LOADER_POST_DATA_LOAD 0x20000L
 /* Remoteproc loader finished loading */
-#define RPROC_LOADER_LOAD_COMPLETE  0x40000UL
+#define RPROC_LOADER_LOAD_COMPLETE  0x40000L
 /* Remoteproc loader state mask */
-#define RPROC_LOADER_MASK           0x00FF0000UL
+#define RPROC_LOADER_MASK           0x00FF0000L
 /* Remoteproc loader private mask */
-#define RPROC_LOADER_PRIVATE_MASK   0x0000FFFFUL
+#define RPROC_LOADER_PRIVATE_MASK   0x0000FFFFL
 /* Remoteproc loader reserved mask */
-#define RPROC_LOADER_RESERVED_MASK  0x0F000000UL
+#define RPROC_LOADER_RESERVED_MASK  0x0F000000L
 
 /**
  * struct image_store_ops - user defined image store operations

--- a/lib/proxy/rpmsg_retarget.c
+++ b/lib/proxy/rpmsg_retarget.c
@@ -162,7 +162,7 @@ int _open(const char *filename, int flags, int mode)
 	struct rpmsg_rpc_syscall *syscall;
 	struct rpmsg_rpc_syscall resp;
 	int filename_len = strlen(filename) + 1;
-	int payload_size = sizeof(*syscall) + filename_len;
+	unsigned int payload_size = sizeof(*syscall) + filename_len;
 	unsigned char tmpbuf[MAX_BUF_LEN];
 	int ret;
 

--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -358,7 +358,7 @@ static const void *elf_next_load_segment(void *elf_info, int *nseg,
 				   size_t *noffset, size_t *nfsize,
 				   size_t *nmsize)
 {
-	const void *phdr;
+	const void *phdr = PT_NULL;
 	unsigned int p_type = PT_NULL;
 
 	if (elf_info == NULL || nseg == NULL)

--- a/lib/remoteproc/rsc_table_parser.c
+++ b/lib/remoteproc/rsc_table_parser.c
@@ -49,7 +49,7 @@ int handle_rsc_table(struct remoteproc *rproc,
 	}
 
 	/* Reserved fields - must be zero */
-	if ((rsc_table->reserved[0] != 0 || rsc_table->reserved[1]) != 0) {
+	if (rsc_table->reserved[0] != 0 || rsc_table->reserved[1] != 0) {
 		return -RPROC_ERR_RSC_TAB_RSVD;
 	}
 

--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -21,8 +21,12 @@ static int vq_ring_enable_interrupt(struct virtqueue *, uint16_t);
 static void vq_ring_free_chain(struct virtqueue *, uint16_t);
 static int vq_ring_must_notify(struct virtqueue *vq);
 static void vq_ring_notify(struct virtqueue *vq);
+#ifndef VIRTIO_SLAVE_ONLY
 static int virtqueue_nused(struct virtqueue *vq);
+#endif
+#ifndef VIRTIO_MASTER_ONLY
 static int virtqueue_navail(struct virtqueue *vq);
+#endif
 
 /* Default implementation of P2V based on libmetal */
 static inline void *virtqueue_phys_to_virt(struct virtqueue *vq,
@@ -504,7 +508,7 @@ static void vq_ring_free_chain(struct virtqueue *vq, uint16_t desc_idx)
 static void vq_ring_init(struct virtqueue *vq, void *ring_mem, int alignment)
 {
 	struct vring *vr;
-	int i, size;
+	int size;
 
 	size = vq->vq_nentries;
 	vr = &vq->vq_ring;
@@ -513,6 +517,8 @@ static void vq_ring_init(struct virtqueue *vq, void *ring_mem, int alignment)
 
 #ifndef VIRTIO_SLAVE_ONLY
 	if (vq->vq_dev->role == VIRTIO_DEV_MASTER) {
+		int i;
+
 		for (i = 0; i < size - 1; i++)
 			vr->desc[i].next = i + 1;
 		vr->desc[i].next = VQ_RING_DESC_CHAIN_END;


### PR DESCRIPTION
This series proposes corrections for few compilation issues and issues reported by IAR c-stat tools  (alignment with MISRA C 2012)
Only one c-stat report as not been fixed, as seems related to a false positive:
rsc_table_parser.c	52	Array pointer `rsc_table' is accessed with index [8,8] which may be out of array bounds [0,UNKNOWN]
rsc_table_parser.c	52	array pointer `rsc_table' is accessed with index [9,9] which may be out of array bounds [0,UNKNOWN] 
This seems not possible as 'reserved' 2 word array is defined in the resource table header.  
