### PR TITLE
Maintainers: update project maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,8 @@ names to be CC'd when submitting a patch.
 
 ## Project Administration
 Wendy Liang <wendy.liang@xilinx.com>
+Ed T. Mooring <emooring@xilinx.com>
+Arnaud Pouliquen <arnaud.pouliquen@st.com>
 
 ### All patches CC here
 open-amp@googlegroups.com
@@ -17,6 +19,8 @@ open-amp@googlegroups.com
 ## Machines
 ### Xilinx Platform - Zynq-7000
 Wendy Liang <wendy.liang@xilinx.com>
+Ed T. Mooring <emooring@xilinx.com>
 
 ### Xilinx Platform - Zynq UltraScale+ MPSoC
 Wendy Liang <wendy.liang@xilinx.com>
+Ed T. Mooring <emooring@xilinx.com>


### PR DESCRIPTION
Add Arnaud and Ed as project maintainers
Add Ed as Xilinx platform maintainer

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>