### PR TITLE
Xilinx A53 to R5 Demos without ipi

### DIFF
--- a/apps/machine/zynqmp/platform_info.h
+++ b/apps/machine/zynqmp/platform_info.h
@@ -28,11 +28,18 @@ struct remoteproc_priv {
 	struct metal_device *ipi_dev; /**< pointer to IPI device */
 	struct metal_io_region *ipi_io; /**< pointer to IPI i/o region */
 	struct metal_device *shm_dev; /**< pointer to shared memory device */
-	struct metal_io_region *shm_io; /**< pointer to shared memory i/o
-						 region */
+	struct metal_io_region *shm_io; /**< pointer to sh mem i/o region */
+
 	struct remoteproc_mem shm_mem; /**< shared memory */
 	unsigned int ipi_chn_mask; /**< IPI channel mask */
 	atomic_int ipi_nokick;
+#ifdef RPMSG_NO_IPI
+	const char *shm_poll_name; /**< shared memory device name */
+	const char *shm_poll_bus_name; /**< shared memory bus name */
+	struct metal_device *shm_poll_dev; /**< pointer to poll mem device */
+	struct metal_io_region *shm_poll_io; /**< pointer to poll mem i/o */
+#endif /* RPMSG_NO_IPI */
+
 };
 
 

--- a/apps/machine/zynqmp_r5/platform_info.c
+++ b/apps/machine/zynqmp_r5/platform_info.c
@@ -45,20 +45,21 @@
 #define SHARED_MEM_SIZE 0x100000UL
 #define SHARED_BUF_OFFSET 0x8000UL
 
-
+#ifndef RPMSG_NO_IPI
 #define _rproc_wait() asm volatile("wfi")
+#endif /* !RPMSG_NO_IPI */
 
-/* IPI information used by remoteproc operations.
+/* Polling information used by remoteproc operations.
  */
-static metal_phys_addr_t ipi_phys_addr = IPI_BASE_ADDR;
-struct metal_device ipi_device = {
-	.name = "ipi_dev",
+static metal_phys_addr_t poll_phys_addr = POLL_BASE_ADDR;
+struct metal_device poll_device = {
+	.name = "poll_dev",
 	.bus = NULL,
 	.num_regions = 1,
 	.regions = {
 		{
-			.virt = (void*)IPI_BASE_ADDR,
-			.physmap = &ipi_phys_addr,
+			.virt = (void *)POLL_BASE_ADDR,
+			.physmap = &poll_phys_addr,
 			.size = 0x1000,
 			.page_shift = -1UL,
 			.page_mask = -1UL,
@@ -67,14 +68,18 @@ struct metal_device ipi_device = {
 		}
 	},
 	.node = {NULL},
+#ifndef RPMSG_NO_IPI
 	.irq_num = 1,
 	.irq_info = (void *)IPI_IRQ_VECT_ID,
+#endif /* !RPMSG_NO_IPI */
 };
 
 static struct remoteproc_priv rproc_priv = {
-	.ipi_name = IPI_DEV_NAME,
-	.ipi_bus_name = IPI_BUS_NAME,
+	.poll_dev_name = IPI_DEV_NAME,
+	.poll_dev_bus_name = IPI_BUS_NAME,
+#ifndef RPMSG_NO_IPI
 	.ipi_chn_mask = IPI_CHN_BITMASK,
+#endif /* !RPMSG_NO_IPI */
 };
 
 static struct remoteproc rproc_inst;
@@ -100,9 +105,13 @@ platform_create_proc(int proc_index, int rsc_index)
 
 	(void) proc_index;
 	rsc_table = get_resource_table(rsc_index, &rsc_size);
-
+#ifndef RPMSG_NO_IPI
 	/* Register IPI device */
-	(void)metal_register_generic_device(&ipi_device);
+	ret = metal_register_generic_device(&ipi_device);
+	if (ret)
+		return ret;
+#endif /* !RPMSG_NO_IPI */
+
 	/* Initialize remoteproc instance */
 	if (!remoteproc_init(&rproc_inst, &zynqmp_r5_a53_proc_ops, &rproc_priv))
 		return NULL;
@@ -226,17 +235,31 @@ int platform_poll(void *priv)
 	struct remoteproc *rproc = priv;
 	struct remoteproc_priv *prproc;
 	unsigned int flags;
+	int ret;
 
 	prproc = rproc->priv;
 	while(1) {
+#ifdef RPMSG_NO_IPI
+		if (metal_io_read32(prproc->poll_io, 0)) {
+			ret = remoteproc_get_notification(rproc,
+							  RSC_NOTIFY_ID_ANY);
+			if (ret)
+				return ret;
+			break;
+		}
+#else /* !RPMSG_NO_IPI */
 		flags = metal_irq_save_disable();
 		if (!(atomic_flag_test_and_set(&prproc->ipi_nokick))) {
 			metal_irq_restore_enable(flags);
-			remoteproc_get_notification(rproc, RSC_NOTIFY_ID_ANY);
+			ret = remoteproc_get_notification(rproc,
+							  RSC_NOTIFY_ID_ANY);
+			if (ret)
+				return ret;
 			break;
 		}
 		_rproc_wait();
 		metal_irq_restore_enable(flags);
+#endif /* RPMSG_NO_IPI */
 	}
 	return 0;
 }

--- a/apps/machine/zynqmp_r5/platform_info.h
+++ b/apps/machine/zynqmp_r5/platform_info.h
@@ -19,22 +19,30 @@ extern "C" {
 /* Interrupt vectors */
 #ifdef versal
 #define IPI_IRQ_VECT_ID     63
-#define IPI_BASE_ADDR       0xFF340000 /* IPI base address*/
+#define POLL_BASE_ADDR       0xFF340000 /* IPI base address*/
 #define IPI_CHN_BITMASK     0x0000020 /* IPI channel bit mask for IPI from/to
 					   APU */
 #else
 #define IPI_IRQ_VECT_ID     XPAR_XIPIPSU_0_INT_ID
-#define IPI_BASE_ADDR       XPAR_XIPIPSU_0_BASE_ADDRESS
+#define POLL_BASE_ADDR      XPAR_XIPIPSU_0_BASE_ADDRESS
 #define IPI_CHN_BITMASK     0x01000000
 #endif /* versal */
 
+#ifdef RPMSG_NO_IPI
+#undef POLL_BASE_ADDR
+#define POLL_BASE_ADDR 0x3EE40000
+#define POLL_STOP 0x1U
+#endif /* RPMSG_NO_IPI */
+
 struct remoteproc_priv {
-	const char *ipi_name; /**< IPI device name */
-	const char *ipi_bus_name; /**< IPI bus name */
-	struct metal_device *ipi_dev; /**< pointer to IPI device */
-	struct metal_io_region *ipi_io; /**< pointer to IPI i/o region */
+	const char *poll_dev_name;
+	const char *poll_dev_bus_name;
+	struct metal_device *poll_dev;
+	struct metal_io_region *poll_io;
+#ifndef RPMSG_NO_IPI
 	unsigned int ipi_chn_mask; /**< IPI channel mask */
 	atomic_int ipi_nokick;
+#endif /* !RPMSG_NO_IPI */
 };
 
 /**

--- a/apps/machine/zynqmp_r5/zynqmp_r5_a53_rproc.c
+++ b/apps/machine/zynqmp_r5/zynqmp_r5_a53_rproc.c
@@ -25,7 +25,7 @@
 #include <metal/utilities.h>
 #include <openamp/rpmsg_virtio.h>
 #include "platform_info.h"
-
+#ifndef RPMSG_NO_IPI
 /* IPI REGs OFFSET */
 #define IPI_TRIG_OFFSET          0x00000000    /* IPI trigger register offset */
 #define IPI_OBS_OFFSET           0x00000004    /* IPI observation register offset */
@@ -44,51 +44,57 @@ static int zynqmp_r5_a53_proc_irq_handler(int vect_id, void *data)
 	if (!rproc)
 		return METAL_IRQ_NOT_HANDLED;
 	prproc = rproc->priv;
-	ipi_intr_status = (unsigned int)metal_io_read32(prproc->ipi_io,
+	ipi_intr_status = (unsigned int)metal_io_read32(prproc->poll_io,
 							IPI_ISR_OFFSET);
 	if (ipi_intr_status & prproc->ipi_chn_mask) {
 		atomic_flag_clear(&prproc->ipi_nokick);
-		metal_io_write32(prproc->ipi_io, IPI_ISR_OFFSET,
+		metal_io_write32(prproc->poll_io, IPI_ISR_OFFSET,
 				 prproc->ipi_chn_mask);
 		return METAL_IRQ_HANDLED;
 	}
 	return METAL_IRQ_NOT_HANDLED;
 }
+#endif /* !RPMSG_NO_IPI */
 
 static struct remoteproc *
 zynqmp_r5_a53_proc_init(struct remoteproc *rproc,
             struct remoteproc_ops *ops, void *arg)
 {
 	struct remoteproc_priv *prproc = arg;
-	struct metal_device *ipi_dev;
+	struct metal_device *poll_dev;
 	unsigned int irq_vect;
 	int ret;
 
 	if (!rproc || !prproc || !ops)
 		return NULL;
-	ret = metal_device_open(prproc->ipi_bus_name, prproc->ipi_name,
-				&ipi_dev);
+	ret = metal_device_open(prproc->poll_dev_bus_name,
+				prproc->poll_dev_name,
+				&poll_dev);
 	if (ret) {
-		xil_printf("failed to open ipi device: %d.\r\n", ret);
+		xil_printf("failed to open polling device: %d.\r\n", ret);
 		return NULL;
 	}
 	rproc->priv = prproc;
-	prproc->ipi_dev = ipi_dev;
-	prproc->ipi_io = metal_device_io_region(ipi_dev, 0);
-	if (!prproc->ipi_io)
+	prproc->poll_dev = poll_dev;
+	prproc->poll_io = metal_device_io_region(poll_dev, 0);
+	if (!prproc->poll_io)
 		goto err1;
+#ifndef RPMSG_NO_IPI
 	atomic_store(&prproc->ipi_nokick, 1);
-	rproc->ops = ops;
-
 	/* Register interrupt handler and enable interrupt */
 	irq_vect = (uintptr_t)ipi_dev->irq_info;
 	metal_irq_register(irq_vect, zynqmp_r5_a53_proc_irq_handler, rproc);
 	metal_irq_enable(irq_vect);
-	metal_io_write32(prproc->ipi_io, IPI_IER_OFFSET,
+	metal_io_write32(prproc->poll_io, IPI_IER_OFFSET,
 			 prproc->ipi_chn_mask);
+#else
+	metal_io_write32(prproc->poll_io, 0, !POLL_STOP);
+#endif /* !RPMSG_NO_IPI */
+	rproc->ops = ops;
+
 	return rproc;
 err1:
-	metal_device_close(ipi_dev);
+	metal_device_close(poll_dev);
 	return NULL;
 }
 
@@ -100,13 +106,16 @@ static void zynqmp_r5_a53_proc_remove(struct remoteproc *rproc)
 	if (!rproc)
 		return;
 	prproc = rproc->priv;
-	metal_io_write32(prproc->ipi_io, IPI_IDR_OFFSET, prproc->ipi_chn_mask);
-	dev = prproc->ipi_dev;
+#ifndef RPMSG_NO_IPI
+	metal_io_write32(prproc->poll_io, IPI_IDR_OFFSET,
+			 prproc->ipi_chn_mask);
+	dev = prproc->poll_dev;
 	if (dev) {
 		metal_irq_disable((uintptr_t)dev->irq_info);
 		metal_irq_unregister((uintptr_t)dev->irq_info);
-		metal_device_close(dev);
 	}
+#endif /* !RPMSG_NO_IPI */
+	metal_device_close(prproc->poll_dev);
 }
 
 static void *
@@ -141,7 +150,7 @@ zynqmp_r5_a53_proc_mmap(struct remoteproc *rproc, metal_phys_addr_t *pa,
 	remoteproc_init_mem(mem, NULL, lpa, lda, size, tmpio);
 	/* va is the same as pa in this platform */
 	metal_io_init(tmpio, (void *)lpa, &mem->pa, size,
-			  sizeof(metal_phys_addr_t)<<3, attribute, NULL);
+		      sizeof(metal_phys_addr_t) << 3, attribute, NULL);
 	remoteproc_add_mem(rproc, mem);
 	*pa = lpa;
 	*da = lda;
@@ -159,9 +168,12 @@ static int zynqmp_r5_a53_proc_notify(struct remoteproc *rproc, uint32_t id)
 		return -1;
 	prproc = rproc->priv;
 
-	/* TODO: use IPI driver instead and pass ID */
-	metal_io_write32(prproc->ipi_io, IPI_TRIG_OFFSET,
-			  prproc->ipi_chn_mask);
+#ifdef RPMSG_NO_IPI
+	metal_io_write32(prproc->poll_io, 0, POLL_STOP);
+#else
+	metal_io_write32(prproc->poll_io, IPI_TRIG_OFFSET,
+			 prproc->ipi_chn_mask);
+#endif /* RPMSG_NO_IPI */
 	return 0;
 }
 


### PR DESCRIPTION
There are use cases where IPI is not available so add switch in Xilinx R5 demos to run without the use of IPI and instead only poll via shared memory.