### PR TITLE
examples: Remove stray local change from Linux platform_info.c

### DIFF
--- a/apps/system/linux/machine/generic/platform_info.c
+++ b/apps/system/linux/machine/generic/platform_info.c
@@ -23,7 +23,6 @@
 #include <metal/io.h>
 #include <metal/irq.h>
 #include <metal/shmem.h>
-#include <metal/scatterlist.h>
 #include <metal/utilities.h>
 #include <openamp/remoteproc.h>
 #include <openamp/rpmsg_virtio.h>
@@ -59,22 +58,20 @@ struct remoteproc_priv {
 	int shm_size;
 	struct metal_io_region *shm_old_io;
 	struct metal_io_region shm_new_io;
-	struct metal_generic_shmem *metal_shm;
-	struct metal_scatter_list *sg;
 	struct remoteproc_mem shm;
 	struct vring_ipi_info ipi;
 };
 
 static struct remoteproc_priv rproc_priv_table [] = {
 	{
-		.shm_file = "linux_shm/openamp.shm",
+		.shm_file = "openamp.shm",
 		.shm_size = 0x80000,
 		.ipi = {
 			.path = "unixs:/tmp/openamp.event.0",
 		},
 	},
 	{
-		.shm_file = "linux_shm/openamp.shm",
+		.shm_file = "openamp.shm",
 		.shm_size = 0x80000,
 		.ipi = {
 			.path = "unix:/tmp/openamp.event.0",
@@ -231,8 +228,6 @@ linux_proc_init(struct remoteproc *rproc,
 	struct remoteproc_priv *prproc = arg;
 	struct metal_io_region *io;
 	struct remoteproc_mem *shm;
-	struct metal_generic_shmem *metal_shm = NULL;
-	struct metal_scatter_list *sg = NULL;
 	struct vring_ipi_info *ipi;
 	int ret;
 
@@ -240,20 +235,12 @@ linux_proc_init(struct remoteproc *rproc,
 		return NULL;
 	rproc->priv = prproc;
 	/* Create shared memory io */
-	ret = metal_shmem_open(prproc->shm_file, prproc->shm_size, 0, &metal_shm);
+	ret = metal_shmem_open(prproc->shm_file, prproc->shm_size, &io);
 	if (ret) {
 		printf("Failed to init rproc, failed to open shm %s.\r\n",
 		       prproc->shm_file);
 		return NULL;
 	}
-	prproc->metal_shm = metal_shm;
-	sg = metal_shmem_mmap(metal_shm, prproc->shm_size);
-	if (sg == NULL) {
-		printf("Failed mmap shmem with libmetal.\n");
-		goto err;
-	}
-	prproc->sg = sg;
-	io = sg->ios;
 	prproc->shm_old_io = io;
 	shm = &prproc->shm;
 	shm->pa = 0;
@@ -283,12 +270,6 @@ linux_proc_init(struct remoteproc *rproc,
 	return rproc;
 
 err:
-	if (sg != NULL) {
-		metal_shmem_munmap(metal_shm, sg);
-	}
-	if (metal_shm != NULL) {
-		metal_shmem_close(metal_shm);
-	}
 	return NULL;
 }
 
@@ -297,6 +278,7 @@ static void linux_proc_remove(struct remoteproc *rproc)
 {
 	struct remoteproc_priv *prproc;
 	struct vring_ipi_info *ipi;
+	struct metal_io_region *io;
 
 	if (!rproc)
 		return;
@@ -311,11 +293,10 @@ static void linux_proc_remove(struct remoteproc *rproc)
 	}
 
 	/* Close shared memory */
-	if (prproc->metal_shm) {
-		if (prproc->sg) {
-			metal_shmem_munmap(prproc->metal_shm, prproc->sg);
-		}
-		metal_shmem_close(prproc->metal_shm);
+	io = prproc->shm_old_io;
+	if (io && io->ops.close) {
+		io->ops.close(io);
+		prproc->shm_old_io = NULL;
 	}
 }
 
@@ -390,29 +371,19 @@ static int platform_slave_setup_resource_table(const char *shm_file,
 					       metal_phys_addr_t rsc_pa)
 {
 	struct metal_io_region *io;
-	struct metal_generic_shmem *metal_shm = NULL;
-	struct metal_scatter_list *sg = NULL;
 	void *rsc_shm;
 	int ret;
 
-	/* Get shared memory io */
-	ret = metal_shmem_open(shm_file, shm_size, 0, &metal_shm);
+	ret = metal_shmem_open(shm_file, shm_size, &io);
 	if (ret) {
-		printf("Failed to setup rsc table, failed to open shm %s.\r\n",
+		printf("Failed to init rproc, failed to open shm %s.\r\n",
 		       shm_file);
 		return -1;
 	}
-	sg = metal_shmem_mmap(metal_shm, shm_size);
-	if (sg == NULL) {
-		printf("Failed to setup rsc table, mmap with libmetal failed.\r\n");
-		metal_shmem_close(metal_shm);
-		return -1;
-	}
-	io = sg->ios;
 	rsc_shm = metal_io_virt(io, rsc_pa);
 	memcpy(rsc_shm, rsc_table, rsc_size);
-	metal_shmem_munmap(metal_shm, sg);
-	metal_shmem_close(metal_shm);
+	io->ops.close(io);
+	free(io);
 	return 0;
 }
 


### PR DESCRIPTION
This change caused a compilation failure when compiling the OpenAMP examples on Linux due to a missing include file and some experimental changes to the libmetal shared memory API.

Signed-off-by: Ed Mooring <ed.mooring@linaro.org>