### PR TITLE
rpmsg: don't return error when no more buffer available but wait

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -308,7 +308,7 @@ static int rpmsg_virtio_send_offchannel_raw(struct rpmsg_device *rdev,
 		/* Lock the device to enable exclusive access to virtqueues */
 		metal_mutex_acquire(&rdev->lock);
 		avail_size = _rpmsg_virtio_get_buffer_size(rvdev);
-		if (size > avail_size) {
+		if (avail_size && size > avail_size) {
 			metal_mutex_release(&rdev->lock);
 			return RPMSG_ERR_BUFF_SIZE;
 		}


### PR DESCRIPTION
This PR fixes the "run flood" test fails ovbserved on x86 machine

- Issue:

"rpmsg_send failed" message 

- to reproduce the issue:

1) compile libmetal
rm -r build
cmake . -Bbuild 
cd build
make

2) compile OpenAMP lib
cmake . -DWITH_APPS=on -DWITH_PROXY=on -Bbuild -DCMAKE_INCLUDE_PATH="../libmetal/build/lib/include" -DCMAKE_LIBRARY_PATH="../libmetal/build/lib"
cd build
make install DESTDIR=./bin

3) run test
LD_LIBRARY_PATH=./bin/usr/local/lib:../../libmetal/build/lib/  ./bin/usr/local/bin/rpmsg-echo-shared &
sleep 1
LD_LIBRARY_PATH=./bin/usr/local/lib:../../libmetal/build/lib/  ./bin/usr/local/bin/msg-test-rpmsg-flood-ping-shared 1

