### PR TITLE
cmake: fix zephyr library abstraction violation

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -34,8 +34,8 @@ set_property (SOURCE ${_sources}
 # Build a shared library if so configured.
 if (WITH_ZEPHYR)
   zephyr_library_named(${OPENAMP_LIB})
-  add_dependencies(${OPENAMP_LIB} offsets_h)
-  target_sources (${OPENAMP_LIB} PRIVATE ${_sources})
+  add_dependencies(${ZEPHYR_CURRENT_LIBRARY} ${OFFSETS_H_TARGET})
+  zephyr_library_sources(${_sources})
   zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 else (WITH_ZEPHYR)
   if (WITH_SHARED_LIB)


### PR DESCRIPTION
All that the zephyr_library_named(foo) function guarantees is that
after calling it, the variable ${ZEPHYR_CURRENT_LIBRARY} evaluates to
the target name for the library named foo. In particular, it does not
guarantee that the name of the target is also foo, which the open-amp
build system currently assumes.

(It happens to be true right now, but it's an abstraction violation.)

Fix things by using the ZEPHYR_CURRENT_LIBRARY and one of its helpers.

Signed-off-by: Marti Bolivar <marti.bolivar@nordicsemi.no>