### PR TITLE
rpmsg: move rpmsg_init_ept to lib/rpmsg/rpmsg_internal.h

### DIFF
--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -266,33 +266,6 @@ static inline int rpmsg_trysend_offchannel(struct rpmsg_endpoint *ept,
 }
 
 /**
- * rpmsg_init_ept - initialize rpmsg endpoint
- *
- * Initialize an RPMsg endpoint with a name, source address,
- * remoteproc address, endpoint callback, and destroy endpoint callback.
- *
- * @ept: pointer to rpmsg endpoint
- * @name: service name associated to the endpoint
- * @src: local address of the endpoint
- * @dest: target address of the endpoint
- * @cb: endpoint callback
- * @ns_unbind_cb: end point service unbind callback, called when remote ept is
- *                destroyed.
- */
-static inline void rpmsg_init_ept(struct rpmsg_endpoint *ept,
-				  const char *name,
-				  uint32_t src, uint32_t dest,
-				  rpmsg_ept_cb cb,
-				  rpmsg_ns_unbind_cb ns_unbind_cb)
-{
-	strncpy(ept->name, name ? name : "", sizeof(ept->name));
-	ept->addr = src;
-	ept->dest_addr = dest;
-	ept->cb = cb;
-	ept->ns_unbind_cb = ns_unbind_cb;
-}
-
-/**
  * rpmsg_create_ept - create rpmsg endpoint and register it to rpmsg device
  *
  * Create a RPMsg endpoint, initialize it with a name, source address,

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -190,9 +190,18 @@ static void rpmsg_unregister_endpoint(struct rpmsg_endpoint *ept)
 	metal_mutex_release(&rdev->lock);
 }
 
-void rpmsg_register_endpoint(struct rpmsg_device *rdev,
-			     struct rpmsg_endpoint *ept)
+void rpmsg_init_ept(struct rpmsg_endpoint *ept,
+		    struct rpmsg_device *rdev,
+		    const char *name,
+		    uint32_t src, uint32_t dest,
+		    rpmsg_ept_cb cb,
+		    rpmsg_ns_unbind_cb ns_unbind_cb)
 {
+	strncpy(ept->name, name ? name : "", sizeof(ept->name));
+	ept->addr = src;
+	ept->dest_addr = dest;
+	ept->cb = cb;
+	ept->ns_unbind_cb = ns_unbind_cb;
 	ept->rdev = rdev;
 	metal_list_add_tail(&rdev->endpoints, &ept->node);
 }
@@ -234,8 +243,7 @@ int rpmsg_create_ept(struct rpmsg_endpoint *ept, struct rpmsg_device *rdev,
 		 */
 	}
 
-	rpmsg_init_ept(ept, name, addr, dest, cb, unbind_cb);
-	rpmsg_register_endpoint(rdev, ept);
+	rpmsg_init_ept(ept, rdev, name, addr, dest, cb, unbind_cb);
 	metal_mutex_release(&rdev->lock);
 
 	/* Send NS announcement to remote processor */

--- a/lib/rpmsg/rpmsg_internal.h
+++ b/lib/rpmsg/rpmsg_internal.h
@@ -92,8 +92,28 @@ int rpmsg_send_ns_message(struct rpmsg_endpoint *ept, unsigned long flags);
 struct rpmsg_endpoint *rpmsg_get_endpoint(struct rpmsg_device *rvdev,
 					  const char *name, uint32_t addr,
 					  uint32_t dest_addr);
-void rpmsg_register_endpoint(struct rpmsg_device *rdev,
-			     struct rpmsg_endpoint *ept);
+
+/**
+ * rpmsg_init_ept - initialize rpmsg endpoint
+ *
+ * Initialize an RPMsg endpoint with a name, source address,
+ * remoteproc address, endpoint callback, and destroy endpoint callback.
+ *
+ * @ept: pointer to rpmsg endpoint
+ * @rdev: pointer to the rpmsg device
+ * @name: service name associated to the endpoint
+ * @src: local address of the endpoint
+ * @dest: target address of the endpoint
+ * @cb: endpoint callback
+ * @ns_unbind_cb: end point service unbind callback, called when remote ept is
+ *                destroyed.
+ */
+void rpmsg_init_ept(struct rpmsg_endpoint *ept,
+		    struct rpmsg_device *rdev,
+		    const char *name,
+		    uint32_t src, uint32_t dest,
+		    rpmsg_ept_cb cb,
+		    rpmsg_ns_unbind_cb ns_unbind_cb);
 
 static inline struct rpmsg_endpoint *
 rpmsg_get_ept_from_addr(struct rpmsg_device *rdev, uint32_t addr)

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -636,10 +636,9 @@ int rpmsg_init_vdev(struct rpmsg_virtio_device *rvdev,
 	 * service announcement feature.
 	 */
 	if (rdev->support_ns) {
-		rpmsg_init_ept(&rdev->ns_ept, "NS",
+		rpmsg_init_ept(&rdev->ns_ept, rdev, "NS",
 			       RPMSG_NS_EPT_ADDR, RPMSG_NS_EPT_ADDR,
 			       rpmsg_virtio_ns_callback, NULL);
-		rpmsg_register_endpoint(rdev, &rdev->ns_ept);
 	}
 
 #ifndef VIRTIO_SLAVE_ONLY


### PR DESCRIPTION
and merge rpmsg_register_endpoint into rpmsg_init_ept so the
service which use preserved address could call rpmsg_init_ept

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>