### PR TITLE
rpmsg: send RPMSG_NS_DESTROY only when addr >= 1024

### DIFF
--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -271,7 +271,8 @@ void rpmsg_destroy_ept(struct rpmsg_endpoint *ept)
 	if (!rdev)
 		return;
 
-	if (ept->name[0] && rdev->support_ns && ept->addr != RPMSG_NS_EPT_ADDR)
+	if (ept->name[0] && rdev->support_ns &&
+	    ept->addr >= RPMSG_RESERVED_ADDRESSES)
 		(void)rpmsg_send_ns_message(ept, RPMSG_NS_DESTROY);
 	rpmsg_unregister_endpoint(ept);
 }


### PR DESCRIPTION
since the NS message shouldn't use for all well known services

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>