### PR TITLE
Ensure C++ compatibility of headers

### DIFF
--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -205,7 +205,7 @@ static inline struct virtqueue *virtqueue_allocate(unsigned int num_desc_extra)
 	uint32_t vq_size = sizeof(struct virtqueue) +
 		 num_desc_extra * sizeof(struct vq_desc_extra);
 
-	vqs = metal_allocate_memory(vq_size);
+	vqs = (struct virtqueue *)metal_allocate_memory(vq_size);
 	if (vqs) {
 		memset(vqs, 0x00, vq_size);
 	}


### PR DESCRIPTION
Merging this ensures that all open-amp headers can be included in a C++ translation unit without the compiler throwing errors.

This was tested with GCC 7.3.1 for arm64 with `std=c++17`.