### PR TITLE
rpmsg: set rpmsg_init_ept API as deprecated

### DIFF
--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -271,6 +271,8 @@ static inline int rpmsg_trysend_offchannel(struct rpmsg_endpoint *ept,
  * Initialize an RPMsg endpoint with a name, source address,
  * remoteproc address, endpoint callback, and destroy endpoint callback.
  *
+ * API deprecated since release v2020.10
+ *
  * @ept: pointer to rpmsg endpoint
  * @name: service name associated to the endpoint
  * @src: local address of the endpoint
@@ -279,11 +281,11 @@ static inline int rpmsg_trysend_offchannel(struct rpmsg_endpoint *ept,
  * @ns_unbind_cb: end point service unbind callback, called when remote ept is
  *                destroyed.
  */
-static inline void rpmsg_init_ept(struct rpmsg_endpoint *ept,
-				  const char *name,
-				  uint32_t src, uint32_t dest,
-				  rpmsg_ept_cb cb,
-				  rpmsg_ns_unbind_cb ns_unbind_cb)
+__deprecated static inline void rpmsg_init_ept(struct rpmsg_endpoint *ept,
+					       const char *name,
+					       uint32_t src, uint32_t dest,
+					       rpmsg_ept_cb cb,
+					       rpmsg_ns_unbind_cb ns_unbind_cb)
 {
 	strncpy(ept->name, name ? name : "", sizeof(ept->name));
 	ept->addr = src;

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -234,7 +234,7 @@ int rpmsg_create_ept(struct rpmsg_endpoint *ept, struct rpmsg_device *rdev,
 		 */
 	}
 
-	rpmsg_init_ept(ept, name, addr, dest, cb, unbind_cb);
+	rpmsg_initialize_ept(ept, name, addr, dest, cb, unbind_cb);
 	rpmsg_register_endpoint(rdev, ept);
 	metal_mutex_release(&rdev->lock);
 

--- a/lib/rpmsg/rpmsg_internal.h
+++ b/lib/rpmsg/rpmsg_internal.h
@@ -87,6 +87,33 @@ struct rpmsg_ns_msg {
 	uint32_t flags;
 } METAL_PACKED_END;
 
+/**
+ * rpmsg_initialize_ept - initialize rpmsg endpoint
+ *
+ * Initialize an RPMsg endpoint with a name, source address,
+ * remoteproc address, endpoint callback, and destroy endpoint callback.
+ *
+ * @ept: pointer to rpmsg endpoint
+ * @name: service name associated to the endpoint
+ * @src: local address of the endpoint
+ * @dest: target address of the endpoint
+ * @cb: endpoint callback
+ * @ns_unbind_cb: end point service unbind callback, called when remote ept is
+ *                destroyed.
+ */
+static inline void rpmsg_initialize_ept(struct rpmsg_endpoint *ept,
+					const char *name,
+					uint32_t src, uint32_t dest,
+					rpmsg_ept_cb cb,
+					rpmsg_ns_unbind_cb ns_unbind_cb)
+{
+	strncpy(ept->name, name ? name : "", sizeof(ept->name));
+	ept->addr = src;
+	ept->dest_addr = dest;
+	ept->cb = cb;
+	ept->ns_unbind_cb = ns_unbind_cb;
+}
+
 int rpmsg_send_ns_message(struct rpmsg_endpoint *ept, unsigned long flags);
 
 struct rpmsg_endpoint *rpmsg_get_endpoint(struct rpmsg_device *rvdev,

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -636,9 +636,9 @@ int rpmsg_init_vdev(struct rpmsg_virtio_device *rvdev,
 	 * service announcement feature.
 	 */
 	if (rdev->support_ns) {
-		rpmsg_init_ept(&rdev->ns_ept, "NS",
-			       RPMSG_NS_EPT_ADDR, RPMSG_NS_EPT_ADDR,
-			       rpmsg_virtio_ns_callback, NULL);
+		rpmsg_initialize_ept(&rdev->ns_ept, "NS",
+				     RPMSG_NS_EPT_ADDR, RPMSG_NS_EPT_ADDR,
+				     rpmsg_virtio_ns_callback, NULL);
 		rpmsg_register_endpoint(rdev, &rdev->ns_ept);
 	}
 


### PR DESCRIPTION
This PR is related to the issue OpenAMP/open-amp#220

The rpmsg_init_ept does not seem to be usable by application
but is used internally. This patch mark this API deprecated
and in at least two full release, to remove this API as the
standard API to use is rpmsg_create_ept.
In addition, move the rpmsg_init_ept to rpmsg_internal.h and rename it.