### PR TITLE
Add <errno.h> explicitly to all files that use errno values.

### DIFF
--- a/apps/examples/load_fw/common.h
+++ b/apps/examples/load_fw/common.h
@@ -14,6 +14,7 @@
 #include <metal/utilities.h>
 #include <openamp/remoteproc.h>
 #include <openamp/remoteproc_loader.h>
+#include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
 /* Xilinx headers */

--- a/apps/examples/load_fw/mem_image_store.c
+++ b/apps/examples/load_fw/mem_image_store.c
@@ -8,6 +8,7 @@
  */
 
 #include <common.h>
+#include <errno.h>
 
 struct mem_file {
 	const void *base;

--- a/apps/examples/rpc_demo/rpc_demod.c
+++ b/apps/examples/rpc_demo/rpc_demod.c
@@ -2,6 +2,7 @@
  This application is meant to run on the remote CPU running baremetal.
  This applicationr can print to to master console and perform file I/O using proxy mechanism. */
 
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/apps/machine/zynq7/platform_info.c
+++ b/apps/machine/zynq7/platform_info.c
@@ -26,6 +26,7 @@
 #include <metal/sys.h>
 #include "platform_info.h"
 #include "rsc_table.h"
+#include <errno.h>
 #include <xparameters.h>
 
 /* Another APU core ID. In this demo, the other APU core is 0. */

--- a/apps/machine/zynqmp/platform_info.c
+++ b/apps/machine/zynqmp/platform_info.c
@@ -25,6 +25,7 @@
 #include <metal/utilities.h>
 #include <openamp/remoteproc.h>
 #include <openamp/rpmsg_virtio.h>
+#include <errno.h>
 #include <string.h>
 #include <stdio.h>
 #include <sys/types.h>

--- a/apps/machine/zynqmp_r5/platform_info.c
+++ b/apps/machine/zynqmp_r5/platform_info.c
@@ -24,6 +24,7 @@
 #include <metal/irq.h>
 #include <metal/utilities.h>
 #include <openamp/rpmsg_virtio.h>
+#include <errno.h>
 #include "platform_info.h"
 #include "rsc_table.h"
 

--- a/apps/system/linux/machine/generic/platform_info.c
+++ b/apps/system/linux/machine/generic/platform_info.c
@@ -26,6 +26,7 @@
 #include <metal/utilities.h>
 #include <openamp/remoteproc.h>
 #include <openamp/rpmsg_virtio.h>
+#include <errno.h>
 #include <poll.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
When building OpenAMP apps for FreeRTOS on Xilinx hardware, there
were compile errors due to EINVAL not being defined. On other
platforms, <errno.h> was implicitly included by OpenAMP header
files. This change explicitly includes it where it is needed
in the code.