### PR TITLE
apps: update memory management

### DIFF
--- a/apps/examples/echo/rpmsg-ping.c
+++ b/apps/examples/echo/rpmsg-ping.c
@@ -121,6 +121,7 @@ int app (struct rpmsg_device *rdev, void *priv)
 
 	if (ret) {
 		LPERROR("Failed to create RPMsg endpoint.\r\n");
+		metal_free_memory(i_payload);
 		return ret;
 	}
 

--- a/apps/machine/zynq7/platform_info.c
+++ b/apps/machine/zynq7/platform_info.c
@@ -184,7 +184,7 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 		return NULL;
 	shbuf_io = remoteproc_get_io_with_pa(rproc, SHARED_MEM_PA);
 	if (!shbuf_io)
-		return NULL;
+		goto err1;
 	shbuf = metal_io_phys_to_virt(shbuf_io,
 				      SHARED_MEM_PA + SHARED_BUF_OFFSET);
 

--- a/apps/machine/zynqmp/platform_info.c
+++ b/apps/machine/zynqmp/platform_info.c
@@ -178,7 +178,7 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 		return NULL;
 	shbuf_io = remoteproc_get_io_with_pa(rproc, SHARED_BUF_PA);
 	if (!shbuf_io)
-		return NULL;
+		goto err1;
 	shbuf = metal_io_phys_to_virt(shbuf_io,
 				      SHARED_BUF_PA);
 

--- a/apps/machine/zynqmp_r5/platform_info.c
+++ b/apps/machine/zynqmp_r5/platform_info.c
@@ -194,7 +194,7 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 		return NULL;
 	shbuf_io = remoteproc_get_io_with_pa(rproc, SHARED_MEM_PA);
 	if (!shbuf_io)
-		return NULL;
+		goto err1;
 	shbuf = metal_io_phys_to_virt(shbuf_io,
 				      SHARED_MEM_PA + SHARED_BUF_OFFSET);
 

--- a/apps/system/linux/machine/generic/platform_info.c
+++ b/apps/system/linux/machine/generic/platform_info.c
@@ -485,7 +485,7 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 		return NULL;
 	shbuf_io = remoteproc_get_io_with_pa(rproc, SHARED_BUF_PA);
 	if (!shbuf_io)
-		return NULL;
+		goto err1;
 	shbuf = metal_io_phys_to_virt(shbuf_io, SHARED_BUF_PA);
 
 	printf("creating remoteproc virtio\r\n");

--- a/apps/tests/msg/rpmsg-flood-ping.c
+++ b/apps/tests/msg/rpmsg-flood-ping.c
@@ -130,6 +130,7 @@ int app (struct rpmsg_device *rdev, void *priv)
 			       rpmsg_endpoint_cb, rpmsg_service_unbind);
 	if (ret) {
 		LPERROR("Failed to create RPMsg endpoint.\r\n");
+		metal_free_memory(i_payload);
 		return ret;
 	}
 

--- a/apps/tests/msg/rpmsg-ping.c
+++ b/apps/tests/msg/rpmsg-ping.c
@@ -125,6 +125,7 @@ int app (struct rpmsg_device *rdev, void *priv)
 
 	if (ret) {
 		LPERROR("Failed to create RPMsg endpoint.\r\n");
+		metal_free_memory(i_payload);
 		return ret;
 	}
 


### PR DESCRIPTION
For each metal_allocate_memory call, make sure there are
subsequent metal_free_memory calls

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>

for https://github.com/OpenAMP/open-amp/issues/230 