### PR TITLE
rpmsg: virito: limit the buffer allocate from shared memory pool

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -143,7 +143,7 @@ static void *rpmsg_virtio_get_tx_buffer(struct rpmsg_virtio_device *rvdev,
 #ifndef VIRTIO_SLAVE_ONLY
 	if (role == RPMSG_MASTER) {
 		data = virtqueue_get_buffer(rvdev->svq, len, idx);
-		if (!data) {
+		if (!data && rvdev->svq->vq_free_cnt) {
 			data = rpmsg_virtio_shm_pool_get_buffer(rvdev->shpool,
 							RPMSG_BUFFER_SIZE);
 			*len = RPMSG_BUFFER_SIZE;


### PR DESCRIPTION
rpmsg_virtio_get_tx_buffer shouldn't allocate the number of
buffer bigger than the virtio ring length of sending
report here: https://github.com/OpenAMP/open-amp/pull/162#discussion_r513496611