### PR TITLE
apps: rpc_demo: fix compilation warning

### DIFF
--- a/apps/examples/rpc_demo/rpc_demod.c
+++ b/apps/examples/rpc_demo/rpc_demod.c
@@ -240,7 +240,7 @@ static int rpmsg_endpoint_cb(struct rpmsg_endpoint *ept, void *data, size_t len,
 	(void)src;
 
 	if (len < (int)sizeof(*syscall)) {
-		LPERROR("Received data is less than the rpc structure: %d\r\n",
+		LPERROR("Received data is less than the rpc structure: %zd\r\n",
 			len);
 		err_cnt++;
 		return RPMSG_SUCCESS;


### PR DESCRIPTION
The GCC compiler complains about the printf of a size_t variable.
add 'z' length modifier to fix the warning.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>