### PR TITLE
Openamp bug fix on RPMSG_NS_DESTROY & rpmsg_send failed

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -559,7 +559,7 @@ static int rpmsg_virtio_ns_callback(struct rpmsg_endpoint *ept, void *data,
 			_ept->dest_addr = RPMSG_ADDR_ANY;
 		metal_mutex_release(&rdev->lock);
 		if (_ept && _ept->ns_unbind_cb)
-			_ept->ns_unbind_cb(ept);
+			_ept->ns_unbind_cb(_ept);
 	} else {
 		if (!_ept) {
 			/*

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -322,6 +322,7 @@ static void *rpmsg_virtio_get_tx_payload_buffer(struct rpmsg_device *rdev,
 		metal_mutex_release(&rdev->lock);
 		if (rp_hdr || !tick_count)
 			break;
+
 		metal_sleep_usec(RPMSG_TICKS_PER_INTERVAL);
 		tick_count--;
 	}


### PR DESCRIPTION

    openamp: rpmsg_send() shouldn't check buffer size when get buffer failed
    
    cause _rpmsg_virtio_get_buffer_size() always return size > 0,
    when role is RPMSG_MASTER.


   openamp: fix ns_unbind_cb error when meet RPMSG_NS_DESTROY
