### PR TITLE
apps: machine: Fix MicroBlaze compilation error

### DIFF
--- a/apps/machine/microblaze_generic/platform_info.c
+++ b/apps/machine/microblaze_generic/platform_info.c
@@ -205,12 +205,6 @@ void platform_release_rpmsg_vdev(struct rpmsg_device *rpdev, void *platform)
 	remoteproc_remove_virtio(rproc, rpvdev->vdev);
 }
 
-void platform_release_rpmsg_vdev(struct rpmsg_device *rpdev)
-{
-	if (rpdev->
-	(void)rpdev;
-}
-
 void platform_cleanup(void *platform)
 {
 	struct remoteproc *rproc = platform;


### PR DESCRIPTION
Fix duplicated function definition with bad code.
See https://github.com/OpenAMP/open-amp/issues/252

Signed-off-by: Sergei Korneichuk <sergei.korneichuk@xilinx.com>