### PR TITLE
Fix compilation error.Add missing semicolon.

### DIFF
--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -146,7 +146,7 @@ typedef void (*vq_notify)(struct virtqueue *);
 			(vq)->vq_inuse = true;               \
 		else                                         \
 			VQASSERT(vq, !(vq)->vq_inuse,\
-				"VirtQueue already in use")  \
+				"VirtQueue already in use");  \
 	} while (0)
 
 #define VQUEUE_IDLE(vq)            ((vq)->vq_inuse = false)


### PR DESCRIPTION
Fix compilation error when defining macro ”VQUEUE_DEBUG“.