### PR TITLE
CI Fix compliance  test

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install python dependencies
       run: |
         pip3 install setuptools
-        pip3 install junitparser gitlint
+        pip3 install junitparser==1.6.3 gitlint
     - name: Run Compliance Tests
       id: compliance
       env:

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -32,7 +32,7 @@ jobs:
         git config --global user.name "Your Name"
         git rebase origin/${BASE_REF}
         export
-        ./scripts/ci/check_compliance.py -m checkpatch  -m Gitlint -m Identity -c origin/${BASE_REF}.. || true
+        ./scripts/ci/check_compliance.py -m checkpatch  -m Gitlint -m Identity -c origin/${BASE_REF}..
 
     - name: upload-results
       uses: actions/upload-artifact@master
@@ -43,6 +43,9 @@ jobs:
 
     - name: check-warns
       run: |
+        if [[ ! -s "compliance.xml" ]]; then
+          exit 1;
+        fi
         if [ -s checkpatch.txt ]; then
            errors=$(cat checkpatch.txt)
            errors="${errors//'%'/'%25'}"


### PR DESCRIPTION
A false positive is returned by the compliance check when the script crashes.

This pull request is a cherry-pick of the Zephyr project that already fixes the issue
- fix the script to return fail, in case of crash,
- fix the crash linked to junitparser library version compatibility.