### PR TITLE
CI: Zephyr test: copy whole libmetal directory for test

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -90,7 +90,7 @@ build_zephyr(){
 	cp ../CMakeLists.txt modules/lib/open-amp/open-amp/ || exit 1
 	cp ../VERSION modules/lib/open-amp/open-amp/ || exit 1
 	cp -r ../cmake modules/lib/open-amp/open-amp/ || exit 1
-	cp -r ../libmetal/lib modules/hal/libmetal/libmetal/lib || exit 1
+	cp -r ../libmetal modules/hal/libmetal/ || exit 1
 	cd ./zephyr || exit 1
 	source zephyr-env.sh || exit 1
 	echo  "build openamp sample"


### PR DESCRIPTION
When only the libmetal/lib is copied, some files such as VERSION or CmakeList.txt are not copied. This can lead to a test error or false positives.

This PR  fixes CI test that does not highlight issue resolved in the https://github.com/OpenAMP/libmetal/pull/154. 