### PR TITLE
virtqueue:  Introduce cache helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ library for it project:
 * **WITH_SHARED_LIB** (default ON): Build with a shared library.
 * **WITH_ZEPHYR** (default OFF): Build open-amp as a zephyr library. This option
   is mandatory in a Zephyr environment.
+* **WITH_DCACHE_VRINGS** (default OFF): Build with data cache operations
+  enabled on vrings.
+* **WITH_DCACHE_BUFFERS** (default OFF): Build with data cache operations
+  enabled on buffers.
 * **RPMSG_BUFFER_SIZE** (default 512): adjust the size of the RPMsg buffers.
   The default value of the RPMsg size is compatible with the Linux Kernel hard
   coded value. If you AMP configuration is Linux kernel master/ OpenAMP remote,

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -74,6 +74,18 @@ if (NOT WITH_VIRTIO_SLAVE)
   add_definitions(-DVIRTIO_MASTER_ONLY)
 endif (NOT WITH_VIRTIO_SLAVE)
 
+option (WITH_DCACHE_VRINGS "Build with vrings cache operations enabled" OFF)
+
+if (WITH_DCACHE_VRINGS)
+  add_definitions(-DVIRTIO_CACHED_VRINGS)
+endif (WITH_DCACHE_VRINGS)
+
+option (WITH_DCACHE_BUFFERS "Build with vrings cache operations enabled" OFF)
+
+if (WITH_DCACHE_BUFFERS)
+  add_definitions(-DVIRTIO_CACHED_BUFFERS)
+endif (WITH_DCACHE_BUFFERS)
+
 # Set the complication flags
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -8,6 +8,7 @@
  */
 
 #include <metal/alloc.h>
+#include <metal/cache.h>
 #include <metal/sleep.h>
 #include <metal/utilities.h>
 #include <openamp/rpmsg_virtio.h>
@@ -102,6 +103,11 @@ static int rpmsg_virtio_enqueue_buffer(struct rpmsg_virtio_device *rvdev,
 				       uint16_t idx)
 {
 	unsigned int role = rpmsg_virtio_get_role(rvdev);
+
+#ifdef VIRTIO_CACHED_BUFFERS
+	metal_cache_flush(buffer, len);
+#endif /* VIRTIO_CACHED_BUFFERS */
+
 #ifndef VIRTIO_SLAVE_ONLY
 	if (role == RPMSG_MASTER) {
 		struct virtqueue_buf vqbuf;
@@ -191,6 +197,11 @@ static void *rpmsg_virtio_get_rx_buffer(struct rpmsg_virtio_device *rvdev,
 		    virtqueue_get_available_buffer(rvdev->rvq, idx, len);
 	}
 #endif /*!VIRTIO_MASTER_ONLY*/
+
+#ifdef VIRTIO_CACHED_BUFFERS
+	/* Invalidate the buffer before returning it */
+	metal_cache_invalidate(data, *len);
+#endif /* VIRTIO_CACHED_BUFFERS */
 
 	return data;
 }


### PR DESCRIPTION
On some platforms the VirtQueue and Vring structures could be stored in cacheable memory. When a data cache is present OpenAPM should take care of flushing / invalidating vring structures and control block when needed to keep consistency, this should be done using the metal_cache_* APIs.

This is an RFC and I'm open to any comment / suggestion on how to address this issue the proper way.

Fixes: #292

Signed-off-by: Carlo Caione <ccaione@baylibre.com>