### PR TITLE
rproc: zero len arrays cause invalid pointer access.

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -46,6 +46,9 @@ remoteproc_get_mem(struct remoteproc *rproc, const char *name,
 		return NULL;
 
 	metal_list_for_each(&rproc->mems, node) {
+		if(node == 0x0){
+			return NULL;
+		}
 		mem = metal_container_of(node, struct remoteproc_mem, node);
 		if (name) {
 			if (!strncmp(name, mem->name, strlen(name)))


### PR DESCRIPTION
When trying to setup a remote proc to load an elf file.
I was getting segfaults from having non initialized / empty rproc->mems.
Checking for null here would fix this issue
Unsure if this is the best place to put this patch or if a better place would be in libmetal, and have the list_for_each not return / enter the loop if the node was null.