### PR TITLE
remoteproc: fix notifyid assignment in handle_vdev_rsc

### DIFF
--- a/lib/remoteproc/rsc_table_parser.c
+++ b/lib/remoteproc/rsc_table_parser.c
@@ -148,7 +148,7 @@ int handle_vdev_rsc(struct remoteproc *rproc, void *rsc)
 						  notifyid,
 						  notifyid + 1);
 		if (notifyid != RSC_NOTIFY_ID_ANY)
-			vdev_rsc->notifyid = notifyid;
+			vring_rsc->notifyid = notifyid;
 	}
 
 	return 0;


### PR DESCRIPTION
Fix the issue that it used vring_rsc->notifyid to allocate new IDs but
finally updated vdev_rsc->notifyid rather than vring_rsc->notifyid.

(See https://github.com/OpenAMP/open-amp/issues/314)

Signed-off-by: Junyan Lin <junyanlin@allwinnertech.com>