### PR TITLE
rpmsg: Make RPMSG_BUFFER_SIZE a fixed define

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -101,9 +101,7 @@ endif (WITH_ZEPHYR)
 
 option (WITH_LIBMETAL_FIND "Check Libmetal library can be found" ON)
 
-if (DEFINED RPMSG_BUFFER_SIZE)
-  add_definitions( -DRPMSG_BUFFER_SIZE=${RPMSG_BUFFER_SIZE} )
-endif (DEFINED RPMSG_BUFFER_SIZE)
+set (RPMSG_BUFFER_SIZE 512 CACHE STRING "Adjust the size of the RPMsg buffers")
 
 message ("-- C_FLAGS : ${CMAKE_C_FLAGS}")
 # vim: expandtab:ts=2:sw=2:smartindent

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -3,6 +3,7 @@ set_property (GLOBAL PROPERTY "PROJECT_LIB_EXTRA_CFLAGS")
 
 collector_create (PROJECT_LIB_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}")
 collect (PROJECT_LIB_DIRS "${CMAKE_CURRENT_BINARY_DIR}")
+collect (PROJECT_INC_DIRS "${PROJECT_BINARY_DIR}/include/generated")
 collect (PROJECT_INC_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include")
 collect (PROJECT_LIB_SOURCES version.c)
 
@@ -18,8 +19,9 @@ endif (WITH_PROXY)
 
 set (OPENAMP_LIB open_amp)
 
+configure_file(include/openamp/rpmsg_virtio.h
+               ${PROJECT_BINARY_DIR}/include/generated/openamp/rpmsg_virtio.h @ONLY)
 configure_file(version.h.in ${PROJECT_BINARY_DIR}/include/generated/openamp/version_def.h)
-collect (PROJECT_INC_DIRS " ${PROJECT_BINARY_DIR}/include/generated/openamp")
 
 if (NOT CMAKE_INSTALL_LIBDIR)
 	set (CMAKE_INSTALL_LIBDIR "lib")
@@ -65,7 +67,8 @@ else (WITH_ZEPHYR)
   endif (WITH_STATIC_LIB)
 endif (WITH_ZEPHYR)
 
-install (DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/openamp" DESTINATION include)
+install (DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/openamp" DESTINATION include
+         PATTERN "rpmsg_virtio.h" EXCLUDE)
 install (DIRECTORY "${PROJECT_BINARY_DIR}/include/generated/openamp" DESTINATION include)
 
 # vim: expandtab:ts=2:sw=2:smartindent

--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -22,9 +22,7 @@ extern "C" {
 #endif
 
 /* Configurable parameters */
-#ifndef RPMSG_BUFFER_SIZE
-#define RPMSG_BUFFER_SIZE	(512)
-#endif
+#define RPMSG_BUFFER_SIZE	@RPMSG_BUFFER_SIZE@
 
 /* The feature bitmap for virtio rpmsg */
 #define VIRTIO_RPMSG_F_NS	0 /* RP supports name service notifications */


### PR DESCRIPTION
Since the rpmsg_virtio.h file is exported, it was possible to have
different values for RPMSG_BUFFER_SIZE when open-amp is built and
when the library is included in an application.
By making this parameter a CMake option and hard-coding the value
in rpmsg_virtio.h, it will make sure this parameter cannot differ
between building of open-amp and the user application.

Signed-off-by: Gaute Nilsson <gaute.nilsson@siemens-energy.com>