### PR TITLE
openamp: fix scenario case

### DIFF
--- a/lib/include/openamp/remoteproc.h
+++ b/lib/include/openamp/remoteproc.h
@@ -432,6 +432,16 @@ struct remoteproc_ops {
 					  metal_phys_addr_t da,
 					  void *va, size_t size,
 					  struct remoteproc_mem *buf);
+	/**
+	 * wait_tx_buffer
+	 *
+	 * Wait tx buffer available
+	 *
+	 * @rproc - pointer to remoteproc instance
+	 *
+	 * return none
+	 */
+	int (*wait_tx_buffer)(struct remoteproc *rproc);
 };
 
 /* Remoteproc error codes */

--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -109,6 +109,12 @@ rpmsg_virtio_create_virtqueues(struct rpmsg_virtio_device *rvdev,
 					callbacks);
 }
 
+static inline int rpmsg_virtio_wait_tx_buffer(struct rpmsg_virtio_device *rvdev)
+{
+	return rvdev->vdev->func->wait_tx_buffer ?
+			rvdev->vdev->func->wait_tx_buffer(rvdev->vdev) : -EAGAIN;
+}
+
 /**
  * rpmsg_virtio_get_buffer_size - get rpmsg virtio buffer size
  *

--- a/lib/include/openamp/virtio.h
+++ b/lib/include/openamp/virtio.h
@@ -137,6 +137,7 @@ struct virtio_dispatch {
 			     void *src, int length);
 	void (*reset_device)(struct virtio_device *dev);
 	void (*notify)(struct virtqueue *vq);
+	int (*wait_tx_buffer)(struct virtio_device *dev);
 };
 
 int virtio_create_virtqueues(struct virtio_device *vdev, unsigned int flags,

--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -30,6 +30,17 @@ static void rproc_virtio_virtqueue_notify(struct virtqueue *vq)
 	rpvdev->notify(rpvdev->priv, vring_info->notifyid);
 }
 
+static int rproc_virtio_wait_tx_buffer(struct virtio_device *vdev)
+{
+	struct remoteproc_virtio *rpvdev;
+	struct remoteproc *rproc;
+
+	rpvdev = metal_container_of(vdev, struct remoteproc_virtio, vdev);
+	rproc  = rpvdev->priv;
+
+	return rproc->ops->wait_tx_buffer ? rproc->ops->wait_tx_buffer(rproc) : -EAGAIN;
+}
+
 static unsigned char rproc_virtio_get_status(struct virtio_device *vdev)
 {
 	struct remoteproc_virtio *rpvdev;
@@ -179,6 +190,7 @@ static const struct virtio_dispatch remoteproc_virtio_dispatch_funcs = {
 	.get_features = rproc_virtio_get_features,
 	.read_config = rproc_virtio_read_config,
 	.notify = rproc_virtio_virtqueue_notify,
+	.wait_tx_buffer = rproc_virtio_wait_tx_buffer,
 #ifndef VIRTIO_SLAVE_ONLY
 	/*
 	 * We suppose here that the vdev is in a shared memory so that can


### PR DESCRIPTION
description:
There are two CPUs use IPC.
Each cpu has one thread to handle RX callback.
When meet scenario case, both CPU0 & CPU1 can't get tx buffer.
IPC can't do communication any more.

rootcase:
CPU0                               CPU1
TX thread0 send msg         -->
RX thread get ack           <--  RX thread get msg, send ack
                            <--  TX thread0 send msg
RX thread get msg, send ack -->  RX thread get ack

TX thread1 send msg         -->
RX thread get ack           <--  RX thread get msg, send ack
                            <--  TX thread1 send msg
RX thread get msg, send ack -->  RX thread get ack

TX thread2 send msg         -->
TX thread3 send msg         -->
....
                            <--  TX thread2 send msg
                            <--  TX thread3 send msg
                                 ...

when CPU0 & CPU1 msg send too quickly, then CPU0 RX thread can't
get tx buffer(ack), wait CPU1 RX thread return buffer. But at this time,
CPU1 RX thread also can't get tx buffer(ack), wait CPU0 RX thread
return buffer. So, you will find two cpu locked.

last call stack:

CPU0 RX thread:                     CPU1 RX thread:
wait tx buffer                      wait tx buffer
can't handle rx buffer              can't handle rx buffer

Resolve:
add recursive call rpmsg_virtio_rx_callback() when get_tx_buffer() failed

Signed-off-by: Guiding Li <liguiding1@xiaomi.com>