### PR TITLE
Replace potentially objectionable terms in OpenAMP variable names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ library for it project:
 * **WITH_PROXY** (default OFF): Include proxy support in the library.
 * **WITH APPS** (default OFF): Build with sample applications.
 * **WITH_PROXY_APPS** (default OFF):Build with proxy sample applications.
-* **WITH_VIRTIO_MASTER** (default ON): Build with virtio master enabled.
+* **WITH_VIRTIO_DRIVER** (default ON): Build with virtio driver enabled.
   This option can be set to OFF if the only the remote mode is implemented.
-* **WITH_VIRTIO_SLAVE** (default ON): Build with virtio slave enabled.
-  This option can be set to OFF if the only the master mode is implemented.
+* **WITH_VIRTIO_DEVICE** (default ON): Build with virtio device enabled.
+  This option can be set to OFF if the only the driver mode is implemented.
 * **WITH_STATIC_LIB** (default ON): Build with a static library.
 * **WITH_SHARED_LIB** (default ON): Build with a shared library.
 * **WITH_ZEPHYR** (default OFF): Build open-amp as a zephyr library. This option

--- a/apps/examples/echo/rpmsg-echo.c
+++ b/apps/examples/echo/rpmsg-echo.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						   VIRTIO_DEV_SLAVE,
+						   VIRTIO_DEV_DEVICE,
 						   NULL, NULL);
 		if (!rpdev) {
 			LPERROR("Failed to create rpmsg virtio device.\r\n");

--- a/apps/examples/echo/rpmsg-ping.c
+++ b/apps/examples/echo/rpmsg-ping.c
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						  VIRTIO_DEV_MASTER,
+						  VIRTIO_DEV_DRIVER,
 						  NULL,
 						  rpmsg_name_service_bind_cb);
 		if (!rpdev) {

--- a/apps/examples/linux_rpc_demo/linux_rpc_demo.c
+++ b/apps/examples/linux_rpc_demo/linux_rpc_demo.c
@@ -580,7 +580,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						   VIRTIO_DEV_SLAVE,
+						   VIRTIO_DEV_DEVICE,
 						   NULL, NULL);
 		if (!rpdev) {
 			LPERROR("Failed to create rpmsg virtio device.\r\n");

--- a/apps/examples/linux_rpc_demo/linux_rpc_demod.c
+++ b/apps/examples/linux_rpc_demo/linux_rpc_demod.c
@@ -297,7 +297,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						   VIRTIO_DEV_MASTER,
+						   VIRTIO_DEV_DRIVER,
 						   NULL, NULL);
 		if (!rpdev) {
 			LPERROR("Failed to create rpmsg virtio device.\r\n");

--- a/apps/examples/matrix_multiply/matrix_multiply.c
+++ b/apps/examples/matrix_multiply/matrix_multiply.c
@@ -240,7 +240,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						  VIRTIO_DEV_MASTER,
+						  VIRTIO_DEV_DRIVER,
 						  NULL,
 						  rpmsg_name_service_bind_cb);
 		if (!rpdev) {

--- a/apps/examples/matrix_multiply/matrix_multiplyd.c
+++ b/apps/examples/matrix_multiply/matrix_multiplyd.c
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						   VIRTIO_DEV_SLAVE,
+						   VIRTIO_DEV_DEVICE,
 						   NULL, NULL);
 		if (!rpdev) {
 			LPERROR("Failed to create rpmsg virtio device.\r\n");

--- a/apps/examples/nocopy_echo/rpmsg-nocopy-echo.c
+++ b/apps/examples/nocopy_echo/rpmsg-nocopy-echo.c
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						   VIRTIO_DEV_SLAVE,
+						   VIRTIO_DEV_DEVICE,
 						   NULL, NULL);
 		if (!rpdev) {
 			LPERROR("Failed to create rpmsg virtio device.\r\n");

--- a/apps/examples/nocopy_echo/rpmsg-nocopy-ping.c
+++ b/apps/examples/nocopy_echo/rpmsg-nocopy-ping.c
@@ -207,7 +207,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						   VIRTIO_DEV_MASTER,
+						   VIRTIO_DEV_DRIVER,
 						   NULL,
 						   rpmsg_name_service_bind_cb);
 		if (!rpdev) {

--- a/apps/examples/rpc_demo/rpc_demo.c
+++ b/apps/examples/rpc_demo/rpc_demo.c
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						   VIRTIO_DEV_SLAVE,
+						   VIRTIO_DEV_DEVICE,
 						   NULL, NULL);
 		if (!rpdev) {
 			LPERROR("Failed to create rpmsg virtio device.\r\n");

--- a/apps/examples/rpc_demo/rpc_demod.c
+++ b/apps/examples/rpc_demo/rpc_demod.c
@@ -357,7 +357,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						   VIRTIO_DEV_MASTER,
+						   VIRTIO_DEV_DRIVER,
 						   NULL, NULL);
 		if (!rpdev) {
 			LPERROR("Failed to create rpmsg virtio device.\r\n");

--- a/apps/examples/rpmsg_sample_echo/rpmsg-sample-echo.c
+++ b/apps/examples/rpmsg_sample_echo/rpmsg-sample-echo.c
@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						   VIRTIO_DEV_SLAVE,
+						   VIRTIO_DEV_DEVICE,
 						   NULL, NULL);
 		if (!rpdev) {
 			LPERROR("Failed to create rpmsg virtio device.\r\n");

--- a/apps/examples/rpmsg_sample_echo/rpmsg-sample-ping.c
+++ b/apps/examples/rpmsg_sample_echo/rpmsg-sample-ping.c
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						  VIRTIO_DEV_MASTER,
+						  VIRTIO_DEV_DRIVER,
 						  NULL,
 						  rpmsg_name_service_bind_cb);
 		if (!rpdev) {

--- a/apps/machine/zynq7/platform_info.c
+++ b/apps/machine/zynq7/platform_info.c
@@ -197,7 +197,7 @@ platform_create_rpmsg_vdev(void *platform, unsigned int vdev_index,
 	}
 
 	xil_printf("initializing rpmsg vdev\r\n");
-	if (role == VIRTIO_DEV_MASTER) {
+	if (role == VIRTIO_DEV_DRIVER) {
 		/* Only RPMsg virtio master needs to initialize the
 		 * shared buffers pool
 		 */

--- a/apps/system/linux/machine/generic/platform_info.c
+++ b/apps/system/linux/machine/generic/platform_info.c
@@ -366,7 +366,7 @@ static struct remoteproc_ops linux_proc_ops = {
 /* RPMsg virtio shared buffer pool */
 static struct rpmsg_virtio_shm_pool shpool;
 
-static int platform_slave_setup_resource_table(const char *shm_file,
+static int platform_device_setup_resource_table(const char *shm_file,
 					       int shm_size,
 					       void *rsc_table, int rsc_size,
 					       metal_phys_addr_t rsc_pa)
@@ -405,7 +405,7 @@ platform_create_proc(int proc_index, int rsc_index)
 	 * This step can be done out of the application.
 	 * Assumes the unix server side setup resource table. */
 	if (is_sk_unix_server(prproc->ipi.path)) {
-		ret = platform_slave_setup_resource_table(prproc->shm_file,
+		ret = platform_device_setup_resource_table(prproc->shm_file,
 							  prproc->shm_size,
 							  rsc_table, rsc_size,
 							  RSC_MEM_PA);

--- a/apps/tests/msg/rpmsg-flood-ping.c
+++ b/apps/tests/msg/rpmsg-flood-ping.c
@@ -203,7 +203,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						  VIRTIO_DEV_MASTER,
+						  VIRTIO_DEV_DRIVER,
 						  NULL,
 						  rpmsg_name_service_bind_cb);
 		if (!rpdev) {

--- a/apps/tests/msg/rpmsg-ping.c
+++ b/apps/tests/msg/rpmsg-ping.c
@@ -189,7 +189,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						  VIRTIO_DEV_MASTER,
+						  VIRTIO_DEV_DRIVER,
 						  NULL,
 						  rpmsg_name_service_bind_cb);
 		if (!rpdev) {

--- a/apps/tests/msg/rpmsg-update.c
+++ b/apps/tests/msg/rpmsg-update.c
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 		ret = -1;
 	} else {
 		rpdev = platform_create_rpmsg_vdev(platform, 0,
-						   VIRTIO_DEV_SLAVE,
+						   VIRTIO_DEV_DEVICE,
 						   NULL, NULL);
 		if (!rpdev) {
 			LPERROR("Failed to create rpmsg virtio device.\r\n");

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -63,16 +63,25 @@ if (NOT ${MACHINE} STREQUAL "zynqmp_r5")
  set (WITH_LOAD_FW OFF)
 endif(NOT ${MACHINE} STREQUAL "zynqmp_r5")
 
-option (WITH_VIRTIO_MASTER "Build with virtio master enabled" ON)
-option (WITH_VIRTIO_SLAVE "Build with virtio slave enabled" ON)
+option (WITH_VIRTIO_DRIVER "Build with virtio driver (front end)  enabled" ON)
+option (WITH_VIRTIO_DEVICE "Build with virtio device (back end)  enabled" ON)
+option (WITH_VIRTIO_MASTER "Build with virtio driver (front end)  enabled" OFF)
+option (WITH_VIRTIO_SLAVE "Build with virtio device (back end)  enabled" OFF)
 
-if (NOT WITH_VIRTIO_MASTER)
-  add_definitions(-DVIRTIO_SLAVE_ONLY)
-endif (NOT WITH_VIRTIO_MASTER)
+if (WITH_VIRTIO_MASTER)
+  message(DEPRECATION "deprecated cmake option replaced by WITH_VIRTIO_DRIVER" ...)
+endif (WITH_VIRTIO_MASTER)
+if (WITH_VIRTIO_SLAVE)
+  message(DEPRECATION "deprecated cmake option replaced by WITH_VIRTIO_DEVICE" ...)
+endif (WITH_VIRTIO_SLAVE)
 
-if (NOT WITH_VIRTIO_SLAVE)
-  add_definitions(-DVIRTIO_MASTER_ONLY)
-endif (NOT WITH_VIRTIO_SLAVE)
+if (NOT WITH_VIRTIO_DRIVER AND NOT WITH_VIRTIO_MASTER)
+	add_definitions(-DVIRTIO_DEVICE_ONLY)
+endif (NOT WITH_VIRTIO_DRIVER AND NOT WITH_VIRTIO_MASTER)
+
+if (NOT WITH_VIRTIO_DEVICE AND NOT WITH_VIRTIO_SLAVE)
+	add_definitions(-DVIRTIO_DRIVER_ONLY)
+endif (NOT WITH_VIRTIO_DEVICE AND NOT WITH_VIRTIO_SLAVE)
 
 option (WITH_DCACHE_VRINGS "Build with vrings cache operations enabled" OFF)
 

--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -75,8 +75,23 @@ struct rpmsg_virtio_device {
 	struct rpmsg_virtio_shm_pool *shpool;
 };
 
-#define RPMSG_REMOTE	VIRTIO_DEV_SLAVE
-#define RPMSG_MASTER	VIRTIO_DEV_MASTER
+#define RPMSG_REMOTE	VIRTIO_DEV_DEVICE
+#define RPMSG_HOST	VIRTIO_DEV_DRIVER
+
+#define RPMSG_SLAVE        deprecated_rpmsg_slave()
+#define RPMSG_MASTER       deprecated_rpmsg_master()
+
+__deprecated static inline int deprecated_rpmsg_master(void)
+{
+	/* "RPMSG_MASTER is deprecated, please use RPMSG_HOST" */
+	return RPMSG_HOST;
+}
+
+__deprecated static inline int deprecated_rpmsg_slave(void)
+{
+	/* "RPMSG_SLAVE is deprecated, please use RPMSG_REMOTE" */
+	return RPMSG_REMOTE;
+}
 
 static inline unsigned int
 rpmsg_virtio_get_role(struct rpmsg_virtio_device *rvdev)

--- a/lib/include/openamp/virtio.h
+++ b/lib/include/openamp/virtio.h
@@ -34,8 +34,33 @@ extern "C" {
 #define VIRTIO_CONFIG_STATUS_FAILED    0x80
 
 /* Virtio device role */
-#define VIRTIO_DEV_MASTER	0UL
-#define VIRTIO_DEV_SLAVE	1UL
+#define VIRTIO_DEV_DRIVER	0UL
+#define VIRTIO_DEV_DEVICE	1UL
+
+#define VIRTIO_DEV_MASTER	deprecated_virtio_dev_master()
+#define VIRTIO_DEV_SLAVE	deprecated_virtio_dev_slave()
+
+__deprecated static inline int deprecated_virtio_dev_master(void)
+{
+	/* "VIRTIO_DEV_MASTER is deprecated, please use VIRTIO_DEV_DRIVER" */
+	return VIRTIO_DEV_DRIVER;
+}
+
+__deprecated static inline int deprecated_virtio_dev_slave(void)
+{
+	/* "VIRTIO_DEV_SLAVE is deprecated, please use VIRTIO_DEV_DEVICE" */
+	return VIRTIO_DEV_DEVICE;
+}
+
+#ifdef VIRTIO_MASTER_ONLY
+#define VIRTIO_DRIVER_ONLY
+#warning "VIRTIO_MASTER_ONLY is deprecated, please use VIRTIO_DRIVER_ONLY"
+#endif
+
+#ifdef VIRTIO_SLAVE_ONLY
+#define VIRTIO_DEVICE_ONLY
+#warning "VIRTIO_SLAVE_ONLY is deprecated, please use VIRTIO_DEVICE_ONLY"
+#endif
 
 struct virtio_device_id {
 	uint32_t device;

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -27,7 +27,7 @@
 
 
 /* Default configuration */
-#ifndef VIRTIO_SLAVE_ONLY
+#ifndef VIRTIO_DEVICE_ONLY
 #define RPMSG_VIRTIO_DEFAULT_CONFIG                \
 	(&(const struct rpmsg_virtio_config) {     \
 		.h2r_buf_size = RPMSG_BUFFER_SIZE, \
@@ -37,7 +37,7 @@
 #define RPMSG_VIRTIO_DEFAULT_CONFIG          NULL
 #endif
 
-#ifndef VIRTIO_SLAVE_ONLY
+#ifndef VIRTIO_DEVICE_ONLY
 metal_weak void *
 rpmsg_virtio_shm_pool_get_buffer(struct rpmsg_virtio_shm_pool *shpool,
 				 size_t size)
@@ -51,7 +51,7 @@ rpmsg_virtio_shm_pool_get_buffer(struct rpmsg_virtio_shm_pool *shpool,
 
 	return buffer;
 }
-#endif /*!VIRTIO_SLAVE_ONLY*/
+#endif /*!VIRTIO_DEVICE_ONLY*/
 
 void rpmsg_virtio_init_shm_pool(struct rpmsg_virtio_shm_pool *shpool,
 				void *shb, size_t size)
@@ -79,8 +79,8 @@ static void rpmsg_virtio_return_buffer(struct rpmsg_virtio_device *rvdev,
 				       uint16_t idx)
 {
 	unsigned int role = rpmsg_virtio_get_role(rvdev);
-#ifndef VIRTIO_SLAVE_ONLY
-	if (role == RPMSG_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+	if (role == RPMSG_HOST) {
 		struct virtqueue_buf vqbuf;
 
 		(void)idx;
@@ -89,14 +89,14 @@ static void rpmsg_virtio_return_buffer(struct rpmsg_virtio_device *rvdev,
 		vqbuf.len = len;
 		virtqueue_add_buffer(rvdev->rvq, &vqbuf, 0, 1, buffer);
 	}
-#endif /*VIRTIO_SLAVE_ONLY*/
+#endif /*VIRTIO_DEVICE_ONLY*/
 
-#ifndef VIRTIO_MASTER_ONLY
+#ifndef VIRTIO_DRIVER_ONLY
 	if (role == RPMSG_REMOTE) {
 		(void)buffer;
 		virtqueue_add_consumed_buffer(rvdev->rvq, idx, len);
 	}
-#endif /*VIRTIO_MASTER_ONLY*/
+#endif /*VIRTIO_DRIVER_ONLY*/
 }
 
 /**
@@ -121,8 +121,8 @@ static int rpmsg_virtio_enqueue_buffer(struct rpmsg_virtio_device *rvdev,
 	metal_cache_flush(buffer, len);
 #endif /* VIRTIO_CACHED_BUFFERS */
 
-#ifndef VIRTIO_SLAVE_ONLY
-	if (role == RPMSG_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+	if (role == RPMSG_HOST) {
 		struct virtqueue_buf vqbuf;
 		(void)idx;
 
@@ -131,14 +131,14 @@ static int rpmsg_virtio_enqueue_buffer(struct rpmsg_virtio_device *rvdev,
 		vqbuf.len = len;
 		return virtqueue_add_buffer(rvdev->svq, &vqbuf, 1, 0, buffer);
 	}
-#endif /*!VIRTIO_SLAVE_ONLY*/
+#endif /*!VIRTIO_DEVICE_ONLY*/
 
-#ifndef VIRTIO_MASTER_ONLY
+#ifndef VIRTIO_DRIVER_ONLY
 	if (role == RPMSG_REMOTE) {
 		(void)buffer;
 		return virtqueue_add_consumed_buffer(rvdev->svq, idx, len);
 	}
-#endif /*!VIRTIO_MASTER_ONLY*/
+#endif /*!VIRTIO_DRIVER_ONLY*/
 	return 0;
 }
 
@@ -159,8 +159,8 @@ static void *rpmsg_virtio_get_tx_buffer(struct rpmsg_virtio_device *rvdev,
 	unsigned int role = rpmsg_virtio_get_role(rvdev);
 	void *data = NULL;
 
-#ifndef VIRTIO_SLAVE_ONLY
-	if (role == RPMSG_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+	if (role == RPMSG_HOST) {
 		data = virtqueue_get_buffer(rvdev->svq, len, idx);
 		if (!data && rvdev->svq->vq_free_cnt) {
 			data = rpmsg_virtio_shm_pool_get_buffer(rvdev->shpool,
@@ -169,13 +169,13 @@ static void *rpmsg_virtio_get_tx_buffer(struct rpmsg_virtio_device *rvdev,
 			*idx = 0;
 		}
 	}
-#endif /*!VIRTIO_SLAVE_ONLY*/
+#endif /*!VIRTIO_DEVICE_ONLY*/
 
-#ifndef VIRTIO_MASTER_ONLY
+#ifndef VIRTIO_DRIVER_ONLY
 	if (role == RPMSG_REMOTE) {
 		data = virtqueue_get_available_buffer(rvdev->svq, idx, len);
 	}
-#endif /*!VIRTIO_MASTER_ONLY*/
+#endif /*!VIRTIO_DRIVER_ONLY*/
 
 	return data;
 }
@@ -198,18 +198,18 @@ static void *rpmsg_virtio_get_rx_buffer(struct rpmsg_virtio_device *rvdev,
 	unsigned int role = rpmsg_virtio_get_role(rvdev);
 	void *data = NULL;
 
-#ifndef VIRTIO_SLAVE_ONLY
-	if (role == RPMSG_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+	if (role == RPMSG_HOST) {
 		data = virtqueue_get_buffer(rvdev->rvq, len, idx);
 	}
-#endif /*!VIRTIO_SLAVE_ONLY*/
+#endif /*!VIRTIO_DEVICE_ONLY*/
 
-#ifndef VIRTIO_MASTER_ONLY
+#ifndef VIRTIO_DRIVER_ONLY
 	if (role == RPMSG_REMOTE) {
 		data =
 		    virtqueue_get_available_buffer(rvdev->rvq, idx, len);
 	}
-#endif /*!VIRTIO_MASTER_ONLY*/
+#endif /*!VIRTIO_DRIVER_ONLY*/
 
 #ifdef VIRTIO_CACHED_BUFFERS
 	/* Invalidate the buffer before returning it */
@@ -219,7 +219,7 @@ static void *rpmsg_virtio_get_rx_buffer(struct rpmsg_virtio_device *rvdev,
 	return data;
 }
 
-#ifndef VIRTIO_MASTER_ONLY
+#ifndef VIRTIO_DRIVER_ONLY
 /**
  * check if the remote is ready to start RPMsg communication
  */
@@ -240,7 +240,7 @@ static int rpmsg_virtio_wait_remote_ready(struct rpmsg_virtio_device *rvdev)
 		metal_cpu_yield();
 	}
 }
-#endif /*!VIRTIO_MASTER_ONLY*/
+#endif /*!VIRTIO_DRIVER_ONLY*/
 
 /**
  * _rpmsg_virtio_get_buffer_size
@@ -257,17 +257,17 @@ static int _rpmsg_virtio_get_buffer_size(struct rpmsg_virtio_device *rvdev)
 	unsigned int role = rpmsg_virtio_get_role(rvdev);
 	int length = 0;
 
-#ifndef VIRTIO_SLAVE_ONLY
-	if (role == RPMSG_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+	if (role == RPMSG_HOST) {
 		/*
 		 * If device role is Master then buffers are provided by us,
 		 * so just provide the macro.
 		 */
 		length = rvdev->config.h2r_buf_size - sizeof(struct rpmsg_hdr);
 	}
-#endif /*!VIRTIO_SLAVE_ONLY*/
+#endif /*!VIRTIO_DEVICE_ONLY*/
 
-#ifndef VIRTIO_MASTER_ONLY
+#ifndef VIRTIO_DRIVER_ONLY
 	if (role == RPMSG_REMOTE) {
 		/*
 		 * If other core is Master then buffers are provided by it,
@@ -280,7 +280,7 @@ static int _rpmsg_virtio_get_buffer_size(struct rpmsg_virtio_device *rvdev)
 			length = 0;
 		}
 	}
-#endif /*!VIRTIO_MASTER_ONLY*/
+#endif /*!VIRTIO_DRIVER_ONLY*/
 
 	return length;
 }
@@ -395,11 +395,11 @@ static int rpmsg_virtio_send_offchannel_nocopy(struct rpmsg_device *rdev,
 
 	metal_mutex_acquire(&rdev->lock);
 
-#ifndef VIRTIO_SLAVE_ONLY
-	if (rpmsg_virtio_get_role(rvdev) == RPMSG_MASTER)
+#ifndef VIRTIO_DEVICE_ONLY
+	if (rpmsg_virtio_get_role(rvdev) == RPMSG_HOST)
 		buff_len = rvdev->config.h2r_buf_size;
 	else
-#endif /*!VIRTIO_SLAVE_ONLY*/
+#endif /*!VIRTIO_DEVICE_ONLY*/
 		buff_len = virtqueue_get_buffer_length(rvdev->svq, idx);
 
 	/* Enqueue buffer on virtqueue. */
@@ -654,8 +654,8 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 	rdev->ops.send_offchannel_nocopy = rpmsg_virtio_send_offchannel_nocopy;
 	role = rpmsg_virtio_get_role(rvdev);
 
-#ifndef VIRTIO_SLAVE_ONLY
-	if (role == RPMSG_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+	if (role == RPMSG_HOST) {
 		/*
 		 * The virtio configuration contains only options applicable to
 		 * a virtio driver, implying rpmsg host role.
@@ -665,23 +665,23 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 		}
 		rvdev->config = *config;
 	}
-#else /*!VIRTIO_SLAVE_ONLY*/
+#else /*!VIRTIO_DEVICE_ONLY*/
 	/* Ignore passed config in the virtio-device-only configuration. */
 	(void)config;
-#endif /*!VIRTIO_SLAVE_ONLY*/
+#endif /*!VIRTIO_DEVICE_ONLY*/
 
 
-#ifndef VIRTIO_MASTER_ONLY
+#ifndef VIRTIO_DRIVER_ONLY
 	if (role == RPMSG_REMOTE) {
 		/* wait synchro with the master */
 		rpmsg_virtio_wait_remote_ready(rvdev);
 	}
-#endif /*!VIRTIO_MASTER_ONLY*/
+#endif /*!VIRTIO_DRIVER_ONLY*/
 	vdev->features = rpmsg_virtio_get_features(rvdev);
 	rdev->support_ns = !!(vdev->features & (1 << VIRTIO_RPMSG_F_NS));
 
-#ifndef VIRTIO_SLAVE_ONLY
-	if (role == RPMSG_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+	if (role == RPMSG_HOST) {
 		/*
 		 * Since device is RPMSG Remote so we need to manage the
 		 * shared buffers. Create shared memory pool to handle buffers.
@@ -699,9 +699,9 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 		rvdev->rvq  = vdev->vrings_info[0].vq;
 		rvdev->svq  = vdev->vrings_info[1].vq;
 	}
-#endif /*!VIRTIO_SLAVE_ONLY*/
+#endif /*!VIRTIO_DEVICE_ONLY*/
 
-#ifndef VIRTIO_MASTER_ONLY
+#ifndef VIRTIO_DRIVER_ONLY
 	(void)shpool;
 	if (role == RPMSG_REMOTE) {
 		vq_names[0] = "tx_vq";
@@ -711,7 +711,7 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 		rvdev->rvq  = vdev->vrings_info[1].vq;
 		rvdev->svq  = vdev->vrings_info[0].vq;
 	}
-#endif /*!VIRTIO_MASTER_ONLY*/
+#endif /*!VIRTIO_DRIVER_ONLY*/
 	rvdev->shbuf_io = shm_io;
 
 	/* Create virtqueues for remote device */
@@ -734,8 +734,8 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 		vq->shm_io = shm_io;
 	}
 
-#ifndef VIRTIO_SLAVE_ONLY
-	if (role == RPMSG_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+	if (role == RPMSG_HOST) {
 		struct virtqueue_buf vqbuf;
 		unsigned int idx;
 		void *buffer;
@@ -765,7 +765,7 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 			}
 		}
 	}
-#endif /*!VIRTIO_SLAVE_ONLY*/
+#endif /*!VIRTIO_DEVICE_ONLY*/
 
 	/* Initialize channels and endpoints list */
 	metal_list_init(&rdev->endpoints);
@@ -780,10 +780,10 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 				     rpmsg_virtio_ns_callback, NULL);
 	}
 
-#ifndef VIRTIO_SLAVE_ONLY
-	if (role == RPMSG_MASTER)
+#ifndef VIRTIO_DEVICE_ONLY
+	if (role == RPMSG_HOST)
 		rpmsg_virtio_set_status(rvdev, VIRTIO_CONFIG_STATUS_DRIVER_OK);
-#endif /*!VIRTIO_SLAVE_ONLY*/
+#endif /*!VIRTIO_DEVICE_ONLY*/
 
 	return status;
 }

--- a/lib/virtio/virtio.c
+++ b/lib/virtio/virtio.c
@@ -101,8 +101,8 @@ int virtio_create_virtqueues(struct virtio_device *vdev, unsigned int flags,
 		vring_info = &vdev->vrings_info[i];
 
 		vring_alloc = &vring_info->info;
-#ifndef VIRTIO_SLAVE_ONLY
-		if (vdev->role == VIRTIO_DEV_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+		if (vdev->role == VIRTIO_DEV_DRIVER) {
 			size_t offset;
 			struct metal_io_region *io = vring_info->io;
 

--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -22,10 +22,10 @@ static int vq_ring_enable_interrupt(struct virtqueue *, uint16_t);
 static void vq_ring_free_chain(struct virtqueue *, uint16_t);
 static int vq_ring_must_notify(struct virtqueue *vq);
 static void vq_ring_notify(struct virtqueue *vq);
-#ifndef VIRTIO_SLAVE_ONLY
+#ifndef VIRTIO_DEVICE_ONLY
 static int virtqueue_nused(struct virtqueue *vq);
 #endif
-#ifndef VIRTIO_MASTER_ONLY
+#ifndef VIRTIO_DRIVER_ONLY
 static int virtqueue_navail(struct virtqueue *vq);
 #endif
 
@@ -355,33 +355,33 @@ void virtqueue_disable_cb(struct virtqueue *vq)
 	VQUEUE_BUSY(vq);
 
 	if (vq->vq_dev->features & VIRTIO_RING_F_EVENT_IDX) {
-#ifndef VIRTIO_SLAVE_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DRIVER) {
 			vring_used_event(&vq->vq_ring) =
 			    vq->vq_used_cons_idx - vq->vq_nentries - 1;
 			VRING_FLUSH(vring_used_event(&vq->vq_ring));
 		}
-#endif /*VIRTIO_SLAVE_ONLY*/
-#ifndef VIRTIO_MASTER_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_SLAVE) {
+#endif /*VIRTIO_DEVICE_ONLY*/
+#ifndef VIRTIO_DRIVER_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DEVICE) {
 			vring_avail_event(&vq->vq_ring) =
 			    vq->vq_available_idx - vq->vq_nentries - 1;
 			VRING_FLUSH(vring_avail_event(&vq->vq_ring));
 		}
-#endif /*VIRTIO_MASTER_ONLY*/
+#endif /*VIRTIO_DRIVER_ONLY*/
 	} else {
-#ifndef VIRTIO_SLAVE_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DRIVER) {
 			vq->vq_ring.avail->flags |= VRING_AVAIL_F_NO_INTERRUPT;
 			VRING_FLUSH(vq->vq_ring.avail->flags);
 		}
-#endif /*VIRTIO_SLAVE_ONLY*/
-#ifndef VIRTIO_MASTER_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_SLAVE) {
+#endif /*VIRTIO_DEVICE_ONLY*/
+#ifndef VIRTIO_DRIVER_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DEVICE) {
 			vq->vq_ring.used->flags |= VRING_USED_F_NO_NOTIFY;
 			VRING_FLUSH(vq->vq_ring.used->flags);
 		}
-#endif /*VIRTIO_MASTER_ONLY*/
+#endif /*VIRTIO_DRIVER_ONLY*/
 	}
 
 	VQUEUE_IDLE(vq);
@@ -581,15 +581,15 @@ static void vq_ring_init(struct virtqueue *vq, void *ring_mem, int alignment)
 
 	vring_init(vr, size, ring_mem, alignment);
 
-#ifndef VIRTIO_SLAVE_ONLY
-	if (vq->vq_dev->role == VIRTIO_DEV_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+	if (vq->vq_dev->role == VIRTIO_DEV_DRIVER) {
 		int i;
 
 		for (i = 0; i < size - 1; i++)
 			vr->desc[i].next = i + 1;
 		vr->desc[i].next = VQ_RING_DESC_CHAIN_END;
 	}
-#endif /*VIRTIO_SLAVE_ONLY*/
+#endif /*VIRTIO_DEVICE_ONLY*/
 }
 
 /**
@@ -639,33 +639,33 @@ static int vq_ring_enable_interrupt(struct virtqueue *vq, uint16_t ndesc)
 	 * what's already been consumed.
 	 */
 	if (vq->vq_dev->features & VIRTIO_RING_F_EVENT_IDX) {
-#ifndef VIRTIO_SLAVE_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DRIVER) {
 			vring_used_event(&vq->vq_ring) =
 				vq->vq_used_cons_idx + ndesc;
 			VRING_FLUSH(vring_used_event(&vq->vq_ring));
 		}
-#endif /*VIRTIO_SLAVE_ONLY*/
-#ifndef VIRTIO_MASTER_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_SLAVE) {
+#endif /*VIRTIO_DEVICE_ONLY*/
+#ifndef VIRTIO_DRIVER_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DEVICE) {
 			vring_avail_event(&vq->vq_ring) =
 				vq->vq_available_idx + ndesc;
 			VRING_FLUSH(vring_avail_event(&vq->vq_ring));
 		}
-#endif /*VIRTIO_MASTER_ONLY*/
+#endif /*VIRTIO_DRIVER_ONLY*/
 	} else {
-#ifndef VIRTIO_SLAVE_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DRIVER) {
 			vq->vq_ring.avail->flags &= ~VRING_AVAIL_F_NO_INTERRUPT;
 			VRING_FLUSH(vq->vq_ring.avail->flags);
 		}
-#endif /*VIRTIO_SLAVE_ONLY*/
-#ifndef VIRTIO_MASTER_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_SLAVE) {
+#endif /*VIRTIO_DEVICE_ONLY*/
+#ifndef VIRTIO_DRIVER_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DEVICE) {
 			vq->vq_ring.used->flags &= ~VRING_USED_F_NO_NOTIFY;
 			VRING_FLUSH(vq->vq_ring.used->flags);
 		}
-#endif /*VIRTIO_MASTER_ONLY*/
+#endif /*VIRTIO_DRIVER_ONLY*/
 	}
 
 	atomic_thread_fence(memory_order_seq_cst);
@@ -675,20 +675,20 @@ static int vq_ring_enable_interrupt(struct virtqueue *vq, uint16_t ndesc)
 	 * since we last checked. Let our caller know so it processes the new
 	 * entries.
 	 */
-#ifndef VIRTIO_SLAVE_ONLY
-	if (vq->vq_dev->role == VIRTIO_DEV_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+	if (vq->vq_dev->role == VIRTIO_DEV_DRIVER) {
 		if (virtqueue_nused(vq) > ndesc) {
 			return 1;
 		}
 	}
-#endif /*VIRTIO_SLAVE_ONLY*/
-#ifndef VIRTIO_MASTER_ONLY
-	if (vq->vq_dev->role == VIRTIO_DEV_SLAVE) {
+#endif /*VIRTIO_DEVICE_ONLY*/
+#ifndef VIRTIO_DRIVER_ONLY
+	if (vq->vq_dev->role == VIRTIO_DEV_DEVICE) {
 		if (virtqueue_navail(vq) > ndesc) {
 			return 1;
 		}
 	}
-#endif /*VIRTIO_MASTER_ONLY*/
+#endif /*VIRTIO_DRIVER_ONLY*/
 
 	return 0;
 }
@@ -715,8 +715,8 @@ static int vq_ring_must_notify(struct virtqueue *vq)
 	uint16_t new_idx, prev_idx, event_idx;
 
 	if (vq->vq_dev->features & VIRTIO_RING_F_EVENT_IDX) {
-#ifndef VIRTIO_SLAVE_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DRIVER) {
 			/* CACHE: no need to invalidate avail */
 			new_idx = vq->vq_ring.avail->idx;
 			prev_idx = new_idx - vq->vq_queued_cnt;
@@ -725,9 +725,9 @@ static int vq_ring_must_notify(struct virtqueue *vq)
 			return vring_need_event(event_idx, new_idx,
 						prev_idx) != 0;
 		}
-#endif /*VIRTIO_SLAVE_ONLY*/
-#ifndef VIRTIO_MASTER_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_SLAVE) {
+#endif /*VIRTIO_DEVICE_ONLY*/
+#ifndef VIRTIO_DRIVER_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DEVICE) {
 			/* CACHE: no need to invalidate used */
 			new_idx = vq->vq_ring.used->idx;
 			prev_idx = new_idx - vq->vq_queued_cnt;
@@ -736,22 +736,22 @@ static int vq_ring_must_notify(struct virtqueue *vq)
 			return vring_need_event(event_idx, new_idx,
 						prev_idx) != 0;
 		}
-#endif /*VIRTIO_MASTER_ONLY*/
+#endif /*VIRTIO_DRIVER_ONLY*/
 	} else {
-#ifndef VIRTIO_SLAVE_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_MASTER) {
+#ifndef VIRTIO_DEVICE_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DRIVER) {
 			VRING_INVALIDATE(vq->vq_ring.used->flags);
 			return (vq->vq_ring.used->flags &
 				VRING_USED_F_NO_NOTIFY) == 0;
 		}
-#endif /*VIRTIO_SLAVE_ONLY*/
-#ifndef VIRTIO_MASTER_ONLY
-		if (vq->vq_dev->role == VIRTIO_DEV_SLAVE) {
+#endif /*VIRTIO_DEVICE_ONLY*/
+#ifndef VIRTIO_DRIVER_ONLY
+		if (vq->vq_dev->role == VIRTIO_DEV_DEVICE) {
 			VRING_INVALIDATE(vq->vq_ring.avail->flags);
 			return (vq->vq_ring.avail->flags &
 				VRING_AVAIL_F_NO_INTERRUPT) == 0;
 		}
-#endif /*VIRTIO_MASTER_ONLY*/
+#endif /*VIRTIO_DRIVER_ONLY*/
 	}
 
 	return 0;
@@ -773,7 +773,7 @@ static void vq_ring_notify(struct virtqueue *vq)
  * virtqueue_nused
  *
  */
-#ifndef VIRTIO_SLAVE_ONLY
+#ifndef VIRTIO_DEVICE_ONLY
 static int virtqueue_nused(struct virtqueue *vq)
 {
 	uint16_t used_idx, nused;
@@ -787,14 +787,14 @@ static int virtqueue_nused(struct virtqueue *vq)
 
 	return nused;
 }
-#endif /*VIRTIO_SLAVE_ONLY*/
+#endif /*VIRTIO_DEVICE_ONLY*/
 
 /**
  *
  * virtqueue_navail
  *
  */
-#ifndef VIRTIO_MASTER_ONLY
+#ifndef VIRTIO_DRIVER_ONLY
 static int virtqueue_navail(struct virtqueue *vq)
 {
 	uint16_t avail_idx, navail;
@@ -809,4 +809,4 @@ static int virtqueue_navail(struct virtqueue *vq)
 
 	return navail;
 }
-#endif /*VIRTIO_MASTER_ONLY*/
+#endif /*VIRTIO_DRIVER_ONLY*/


### PR DESCRIPTION
The OpenAMP project Technical Steering Committee has requested that potentially objectionable terms be removed from the OpenAMP code base. This is the first step in removing them. It replaces these terms in variable/identifier names within the code base. 

Further pull requests will fix the documentation and comments in the code.

