### PR TITLE
rpmsg: merge rpmsg_initialize_ept into rpmsg_register_endpoint

### DIFF
--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -250,8 +250,17 @@ static void rpmsg_unregister_endpoint(struct rpmsg_endpoint *ept)
 }
 
 void rpmsg_register_endpoint(struct rpmsg_device *rdev,
-			     struct rpmsg_endpoint *ept)
+			     struct rpmsg_endpoint *ept,
+			     const char *name,
+			     uint32_t src, uint32_t dest,
+			     rpmsg_ept_cb cb,
+			     rpmsg_ns_unbind_cb ns_unbind_cb)
 {
+	strncpy(ept->name, name ? name : "", sizeof(ept->name));
+	ept->addr = src;
+	ept->dest_addr = dest;
+	ept->cb = cb;
+	ept->ns_unbind_cb = ns_unbind_cb;
 	ept->rdev = rdev;
 	metal_list_add_tail(&rdev->endpoints, &ept->node);
 }
@@ -293,8 +302,7 @@ int rpmsg_create_ept(struct rpmsg_endpoint *ept, struct rpmsg_device *rdev,
 		 */
 	}
 
-	rpmsg_initialize_ept(ept, name, addr, dest, cb, unbind_cb);
-	rpmsg_register_endpoint(rdev, ept);
+	rpmsg_register_endpoint(rdev, ept, name, addr, dest, cb, unbind_cb);
 	metal_mutex_release(&rdev->lock);
 
 	/* Send NS announcement to remote processor */

--- a/lib/rpmsg/rpmsg_internal.h
+++ b/lib/rpmsg/rpmsg_internal.h
@@ -85,40 +85,17 @@ struct rpmsg_ns_msg {
 	uint32_t flags;
 } METAL_PACKED_END;
 
-/**
- * rpmsg_initialize_ept - initialize rpmsg endpoint
- *
- * Initialize an RPMsg endpoint with a name, source address,
- * remoteproc address, endpoint callback, and destroy endpoint callback.
- *
- * @ept: pointer to rpmsg endpoint
- * @name: service name associated to the endpoint
- * @src: local address of the endpoint
- * @dest: target address of the endpoint
- * @cb: endpoint callback
- * @ns_unbind_cb: end point service unbind callback, called when remote ept is
- *                destroyed.
- */
-static inline void rpmsg_initialize_ept(struct rpmsg_endpoint *ept,
-					const char *name,
-					uint32_t src, uint32_t dest,
-					rpmsg_ept_cb cb,
-					rpmsg_ns_unbind_cb ns_unbind_cb)
-{
-	strncpy(ept->name, name ? name : "", sizeof(ept->name));
-	ept->addr = src;
-	ept->dest_addr = dest;
-	ept->cb = cb;
-	ept->ns_unbind_cb = ns_unbind_cb;
-}
-
 int rpmsg_send_ns_message(struct rpmsg_endpoint *ept, unsigned long flags);
 
 struct rpmsg_endpoint *rpmsg_get_endpoint(struct rpmsg_device *rvdev,
 					  const char *name, uint32_t addr,
 					  uint32_t dest_addr);
 void rpmsg_register_endpoint(struct rpmsg_device *rdev,
-			     struct rpmsg_endpoint *ept);
+			     struct rpmsg_endpoint *ept,
+			     const char *name,
+			     uint32_t src, uint32_t dest,
+			     rpmsg_ept_cb cb,
+			     rpmsg_ns_unbind_cb ns_unbind_cb);
 
 static inline struct rpmsg_endpoint *
 rpmsg_get_ept_from_addr(struct rpmsg_device *rdev, uint32_t addr)

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -763,10 +763,9 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 	 * service announcement feature.
 	 */
 	if (rdev->support_ns) {
-		rpmsg_initialize_ept(&rdev->ns_ept, "NS",
+		rpmsg_register_endpoint(rdev, &rdev->ns_ept, "NS",
 				     RPMSG_NS_EPT_ADDR, RPMSG_NS_EPT_ADDR,
 				     rpmsg_virtio_ns_callback, NULL);
-		rpmsg_register_endpoint(rdev, &rdev->ns_ept);
 	}
 
 #ifndef VIRTIO_SLAVE_ONLY


### PR DESCRIPTION
so the service with preserved address could call rpmsg_register_endpoint only