### PR TITLE
fix remoteproc get wrong memory when memory region are continuous and Invalidate the ring region but use non initialize ring index.

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -55,14 +55,14 @@ remoteproc_get_mem(struct remoteproc *rproc, const char *name,
 
 			pa_start = mem->pa;
 			pa_end = pa_start + mem->size;
-			if (pa >= pa_start && (pa + size) <= pa_end)
+			if (pa >= pa_start && (pa + size) <= pa_end && pa < pa_end)
 				return mem;
 		} else if (da != METAL_BAD_PHYS) {
 			metal_phys_addr_t da_start, da_end;
 
 			da_start = mem->da;
 			da_end = da_start + mem->size;
-			if (da >= da_start && (da + size) <= da_end)
+			if (da >= da_start && (da + size) <= da_end && da < da_end)
 				return mem;
 		} else if (va) {
 			if (metal_io_virt_to_offset(mem->io, va) !=

--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -271,10 +271,10 @@ void *virtqueue_get_available_buffer(struct virtqueue *vq, uint16_t *avail_idx,
 
 	VQUEUE_BUSY(vq);
 
+	head_idx = vq->vq_available_idx++ & (vq->vq_nentries - 1);
+
 	/* Avail.ring is updated by master, invalidate it */
 	VRING_INVALIDATE(vq->vq_ring.avail->ring[head_idx]);
-
-	head_idx = vq->vq_available_idx++ & (vq->vq_nentries - 1);
 	*avail_idx = vq->vq_ring.avail->ring[head_idx];
 
 	/* Invalidate the desc entry written by master before accessing it */
@@ -453,10 +453,10 @@ uint32_t virtqueue_get_desc_size(struct virtqueue *vq)
 
 	VQUEUE_BUSY(vq);
 
+	head_idx = vq->vq_available_idx & (vq->vq_nentries - 1);
+
 	/* Avail.ring is updated by master, invalidate it */
 	VRING_INVALIDATE(vq->vq_ring.avail->ring[head_idx]);
-
-	head_idx = vq->vq_available_idx & (vq->vq_nentries - 1);
 	avail_idx = vq->vq_ring.avail->ring[head_idx];
 
 	/* Invalidate the desc entry written by master before accessing it */


### PR DESCRIPTION
1. fix remoteproc get wrong memory when memory region are continuous.
2. fix Invalidate the ring region but use non initialize ring index.

Signed-off-by: Joshua Lin <jlin@petaio.com>