### PR TITLE
remoteproc: fix remoteproc get wrong memory when memory region are co…

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -55,14 +55,14 @@ remoteproc_get_mem(struct remoteproc *rproc, const char *name,
 
 			pa_start = mem->pa;
 			pa_end = pa_start + mem->size;
-			if (pa >= pa_start && (pa + size) <= pa_end)
+			if (pa >= pa_start && (pa + size) <= pa_end && pa < pa_end)
 				return mem;
 		} else if (da != METAL_BAD_PHYS) {
 			metal_phys_addr_t da_start, da_end;
 
 			da_start = mem->da;
 			da_end = da_start + mem->size;
-			if (da >= da_start && (da + size) <= da_end)
+			if (da >= da_start && (da + size) <= da_end && da < da_end)
 				return mem;
 		} else if (va) {
 			if (metal_io_virt_to_offset(mem->io, va) !=


### PR DESCRIPTION
when pa is equal to the end address of the memory region and size equal zero will get wrong memory region. So needto add check pa is smaller then end address,
Signed-off-by: Joshua Lin <jlin@petaio.com>