### PR TITLE
rpmsg: modified rpmsg_get_endpoint to remove unused code

### DIFF
--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -217,9 +217,6 @@ struct rpmsg_endpoint *rpmsg_get_endpoint(struct rpmsg_device *rdev,
 		/* try to get by local address only */
 		if (addr != RPMSG_ADDR_ANY && ept->addr == addr)
 			return ept;
-		/* try to find match on local end remote address */
-		if (addr == ept->addr && dest_addr == ept->dest_addr)
-			return ept;
 		/* else use name service and destination address */
 		if (name)
 			name_match = !strncmp(ept->name, name,


### PR DESCRIPTION
Modified rpmsg_get_endpoint to remove unused code per issue #341 .  The case to find the endpoint by source and destination address will never get executed, because the first case in the function checks for source address only and will return.  This is not an API function, and there is no caller searching by source and destination, so this code can be removed.