### PR TITLE
Removed unused code from rpmsg_get_endpoint

### DIFF
--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -217,9 +217,6 @@ struct rpmsg_endpoint *rpmsg_get_endpoint(struct rpmsg_device *rdev,
 		/* try to get by local address only */
 		if (addr != RPMSG_ADDR_ANY && ept->addr == addr)
 			return ept;
-		/* try to find match on local end remote address */
-		if (addr == ept->addr && dest_addr == ept->dest_addr)
-			return ept;
 		/* else use name service and destination address */
 		if (name)
 			name_match = !strncmp(ept->name, name,


### PR DESCRIPTION
Case for src and dest address is unused since the first case matches src only.

Signed-off-by: Tammy Leino <tammy_leino@mentor.com>