### PR TITLE
Enable OpenAMP Demo configuration via CMake

### DIFF
--- a/apps/machine/zynqmp/platform_info.c
+++ b/apps/machine/zynqmp/platform_info.c
@@ -36,12 +36,20 @@
                                * one CPU in the exmaple. We set the CPU
                                * index to 0. */
 #ifdef versal
+#ifndef IPI_CHN_BITMASK
 #define IPI_CHN_BITMASK     0x08 /* IPI channel bit mask for IPI
 					* from/to RPU0 */
+#endif /* !IPI_CHN_BITMASK */
+#ifndef IPI_DEV_NAME
 #define IPI_DEV_NAME        "ff360000.ipi" /* IPI device name */
+#endif /* !IPI_DEV_NAME */
 #else
+#ifndef IPI_CHN_BITMASK
 #define IPI_CHN_BITMASK	    0x00000100
+#endif /* !IPI_CHN_BITMASK */
+#ifndef IPI_DEV_NAME
 #define IPI_DEV_NAME	    "ff340000.ipi"
+#endif /* !IPI_DEV_NAME */
 #endif /* versal */
 #define DEV_BUS_NAME        "platform" /* device bus name. "platform" bus
                                         * is used in Linux kernel for generic
@@ -49,15 +57,27 @@
 /* libmetal devices names used in the examples.
  * They are platform devices, you find them in Linux sysfs
  * sys/bus/platform/devices */
+#ifndef SHM_DEV_NAME
 #define SHM_DEV_NAME        "3ed20000.shm" /* shared device name */
-
+#endif /* SHM_DEV_NAME */
+#ifndef RSC_MEM_PA
 #define RSC_MEM_PA          0x3ED20000UL
+#endif /* !RSC_MEM_PA */
+#ifndef RSC_MEM_SIZE
 #define RSC_MEM_SIZE        0x2000UL
+#endif /* !RSC_MEM_SIZE */
+#ifndef VRING_MEM_PA
 #define VRING_MEM_PA        0x3ED40000UL
+#endif /* !VRING_MEM_PA */
+#ifndef VRING_MEM_SIZE
 #define VRING_MEM_SIZE      0x8000UL
+#endif /* !VRING_MEM_SIZE */
+#ifndef SHARED_BUF_PA
 #define SHARED_BUF_PA       0x3ED48000UL
+#endif /* !SHARED_BUF_PA */
+#ifndef SHARED_BUF_SIZE
 #define SHARED_BUF_SIZE     0x40000UL
-
+#endif /* !SHARED_BUF_SIZE */
 
 struct remoteproc_priv rproc_priv = {
 	.shm_name = SHM_DEV_NAME,

--- a/apps/machine/zynqmp/platform_info.h
+++ b/apps/machine/zynqmp/platform_info.h
@@ -43,7 +43,9 @@ struct remoteproc_priv {
 };
 
 #ifdef RPMSG_NO_IPI
+#ifndef POLL_DEV_NAME
 #define POLL_DEV_NAME        "3ee40000.poll" /* shared device name */
+#endif /* !POLL_DEV_NAME */
 #define POLL_STOP 0x1U
 #endif /* RPMSG_NO_IPI */
 

--- a/apps/machine/zynqmp_r5/platform_info.c
+++ b/apps/machine/zynqmp_r5/platform_info.c
@@ -38,13 +38,21 @@
 #define NORM_SHARED_NCACHE	0x0000000CU /* Non cacheable shareable */
 #define	PRIV_RW_USER_RW		(0x00000003U<<8U) /* Full Access */
 
+#ifndef SHARED_MEM_PA
 #if XPAR_CPU_ID == 0
 #define SHARED_MEM_PA  0x3ED40000UL
 #else
 #define SHARED_MEM_PA  0x3EF40000UL
 #endif /* XPAR_CPU_ID */
+#endif /* !SHARED_MEM_PA */
+
+#ifndef SHARED_MEM_SIZE
 #define SHARED_MEM_SIZE 0x100000UL
+#endif /* !SHARED_MEM_SIZE */
+
+#ifndef SHARED_BUF_OFFSET
 #define SHARED_BUF_OFFSET 0x8000UL
+#endif /* !SHARED_BUF_OFFSET */
 
 #ifndef RPMSG_NO_IPI
 #define _rproc_wait() asm volatile("wfi")

--- a/apps/machine/zynqmp_r5/platform_info.h
+++ b/apps/machine/zynqmp_r5/platform_info.h
@@ -26,14 +26,34 @@ extern "C" {
 
 /* Interrupt vectors */
 #ifdef versal
+
+#ifndef IPI_IRQ_VECT_ID
 #define IPI_IRQ_VECT_ID     63
+#endif /* !IPI_IRQ_VECT_ID */
+
+#ifndef POLL_BASE_ADDR
 #define POLL_BASE_ADDR       0xFF340000 /* IPI base address*/
+#endif /* !POLL_BASE_ADDR */
+
+#ifndef IPI_CHN_BITMASK
 #define IPI_CHN_BITMASK     0x0000020 /* IPI channel bit mask for IPI from/to
 					   APU */
+#endif /* !IPI_CHN_BITMASK */
+
 #else
+
+#ifndef IPI_IRQ_VECT_ID
 #define IPI_IRQ_VECT_ID     XPAR_XIPIPSU_0_INT_ID
+#endif /* !IPI_IRQ_VECT_ID */
+
+#ifndef POLL_BASE_ADDR
 #define POLL_BASE_ADDR      XPAR_XIPIPSU_0_BASE_ADDRESS
+#endif /* !POLL_BASE_ADDR */
+
+#ifndef IPI_CHN_BITMASK
 #define IPI_CHN_BITMASK     0x01000000
+#endif /* !IPI_CHN_BITMASK */
+
 #endif /* versal */
 
 #ifdef RPMSG_NO_IPI

--- a/apps/machine/zynqmp_r5/rsc_table.c
+++ b/apps/machine/zynqmp_r5/rsc_table.c
@@ -26,8 +26,12 @@
 
 #define NUM_VRINGS                  0x02
 #define VRING_ALIGN                 0x1000
+#ifndef RING_TX
 #define RING_TX                     FW_RSC_U32_ADDR_ANY
+#endif /* !RING_TX */
+#ifndef RING_RX
 #define RING_RX                     FW_RSC_U32_ADDR_ANY
+#endif /* RING_RX */
 #define VRING_SIZE                  256
 
 #define NUM_TABLE_ENTRIES           1

--- a/apps/system/generic/machine/zynqmp_r5/CMakeLists.txt
+++ b/apps/system/generic/machine/zynqmp_r5/CMakeLists.txt
@@ -2,10 +2,15 @@ include(CheckSymbolExists)
 
 collect (APP_COMMON_SOURCES helper.c)
 
+# If not provided, add default value for resource table
+if(NOT DEFINED ${RSC_TABLE})
+  set(RSC_TABLE 0x3ed20000 CACHE STRING "")
+endif(NOT DEFINED ${RSC_TABLE})
+
 set (_linker_script "${CMAKE_CURRENT_SOURCE_DIR}/linker_remote.ld")
-set_property (GLOBAL PROPERTY APP_LINKER_OPT "-T\"${_linker_script}\"")
+set_property (GLOBAL PROPERTY APP_LINKER_OPT " -Wl,--defsym,_rsc_table=${RSC_TABLE} -T\"${_linker_script}\"")
 set (_linker_large_text_script "${CMAKE_CURRENT_SOURCE_DIR}/linker_large_text.ld")
-set_property (GLOBAL PROPERTY APP_LINKER_LARGE_TEXT_OPT "-T\"${_linker_large_text_script}\"")
+set_property (GLOBAL PROPERTY APP_LINKER_LARGE_TEXT_OPT " -Wl,--defsym,_rsc_table=${RSC_TABLE} -T\"${_linker_large_text_script}\"")
 
 find_path(XIL_INCLUDE_DIR NAMES xparameters.h PATHS ${CMAKE_FIND_ROOT_PATH})
 collect (PROJECT_INC_DIRS "${XIL_INCLUDE_DIR}")

--- a/apps/system/generic/machine/zynqmp_r5/helper.c
+++ b/apps/system/generic/machine/zynqmp_r5/helper.c
@@ -16,7 +16,7 @@
 #include <metal/irq.h>
 #include "platform_info.h"
 
-#define INTC_DEVICE_ID		XPAR_SCUGIC_0_DEVICE_ID
+#define INTC_DEVICE_ID		XPAR_SCUGIC_SINGLE_DEVICE_ID
 
 static XScuGic xInterruptController;
 

--- a/apps/system/generic/machine/zynqmp_r5/linker_large_text.ld
+++ b/apps/system/generic/machine/zynqmp_r5/linker_large_text.ld
@@ -312,10 +312,10 @@ _SDA2_BASE_ = __sdata2_start + ((__sbss2_end - __sdata2_start) / 2 );
    __undef_stack = .;
 } > psu_r5_tcm_ram_0_S_AXI_BASEADDR
 
-.resource_table 0x3ed20000 : {
+.resource_table _rsc_table : {
 	. = ALIGN(4);
 	*(.resource_table)
-} > psu_ddr_S_AXI_BASEADDR
+}
 
 _end = .;
 }

--- a/apps/system/generic/machine/zynqmp_r5/linker_remote.ld
+++ b/apps/system/generic/machine/zynqmp_r5/linker_remote.ld
@@ -312,10 +312,10 @@ _SDA2_BASE_ = __sdata2_start + ((__sbss2_end - __sdata2_start) / 2 );
    __undef_stack = .;
 } > psu_r5_tcm_ram_0_S_AXI_BASEADDR
 
-.resource_table 0x3ed20000 : {
+.resource_table _rsc_table : {
 	. = ALIGN(4);
 	*(.resource_table)
-} > psu_ddr_S_AXI_BASEADDR
+}
 
 _end = .;
 }


### PR DESCRIPTION
Currently the demos' interrupt, shared memory and IPC structure values are hard-coded.

Allow these to configured via CMake configure by 
(a) wrapping C symbols in #ifdef / #ifndef
(b) enabling linker script defined resource table location to be set in CMake.