### PR TITLE
Fix various typo with codespell

### DIFF
--- a/.github/actions/build_ci/README.md
+++ b/.github/actions/build_ci/README.md
@@ -7,7 +7,7 @@ This action test builds for a specified target.
 ### `target`
 
 **Required** the build target. Default `"linux"`.
-The supported taget are:
+The supported targets are:
   linux
   generic arm
   zephyr

--- a/apps/examples/echo/rpmsg-ping.c
+++ b/apps/examples/echo/rpmsg-ping.c
@@ -104,7 +104,7 @@ int app (struct rpmsg_device *rdev, void *priv)
 
 	max_size = rpmsg_virtio_get_buffer_size(rdev);
 	if (max_size < 0) {
-		LPERROR("No avaiable buffer size.\r\n");
+		LPERROR("No available buffer size.\r\n");
 		return -1;
 	}
 	max_size -= sizeof(struct _payload);

--- a/apps/examples/load_fw/load_fw.c
+++ b/apps/examples/load_fw/load_fw.c
@@ -145,7 +145,7 @@ int main(void)
 	unsigned int cpu_id = LOAD_FW_TARGET;
 	int ret;
 
-	LPRINTF("Loading Exectuable Demo\n");
+	LPRINTF("Loading Executable Demo\n");
 	rproc = app_init(cpu_id);
 	if (!rproc) {
 		LPERROR("app_init failed\r\n");

--- a/apps/examples/load_fw/zynqmp_apu_lcm_rproc_example.c
+++ b/apps/examples/load_fw/zynqmp_apu_lcm_rproc_example.c
@@ -52,7 +52,7 @@ static void *apu_rproc_mmap(struct remoteproc *rproc,
 	if ((!da || !pa) || (*da == METAL_BAD_PHYS && *pa == METAL_BAD_PHYS))
 		return NULL;
 
-	LPRINTF("%s: pa=0x%x, da=0x%x, size=0x%x, atrribute=0x%x\n\r",
+	LPRINTF("%s: pa=0x%x, da=0x%x, size=0x%x, attribute=0x%x\n\r",
 		__func__, *pa, *da, size, attribute);
 	lda = *da;
 	lpa = *pa;

--- a/apps/examples/load_fw/zynqmp_r5_lcm_rproc_example.c
+++ b/apps/examples/load_fw/zynqmp_r5_lcm_rproc_example.c
@@ -103,7 +103,7 @@ struct remoteproc *r5_rproc_init(struct remoteproc *rproc,
 	unsigned int cpu_id = *((unsigned int *)arg);
 
 	if (cpu_id < NODE_RPU_0 || cpu_id > NODE_RPU_1) {
-		xil_printf("rproc init: invalide node id: %d\r\n", cpu_id);
+		xil_printf("rproc init: invalid node id: %d\r\n", cpu_id);
 		return NULL;
 	}
 
@@ -150,7 +150,7 @@ void *r5_rproc_mmap(struct remoteproc *rproc,
 
 	if (!da || !pa)
 		return NULL;
-	LPRINTF("%s: pa=0x%x, da=0x%x, size=0x%x, atrribute=0x%x\r\n",
+	LPRINTF("%s: pa=0x%x, da=0x%x, size=0x%x, attribute=0x%x\r\n",
 		__func__, *pa, *da, size, attribute);
 	lda = *da;
 	lpa = *pa;

--- a/apps/examples/load_fw/zynqmp_rpu_lcm_rproc_example.c
+++ b/apps/examples/load_fw/zynqmp_rpu_lcm_rproc_example.c
@@ -54,7 +54,7 @@ static void *rpu_rproc_mmap(struct remoteproc *rproc,
 
 	if ((!da || !pa) || (*da == METAL_BAD_PHYS && *pa == METAL_BAD_PHYS))
 		return NULL;
-	LPRINTF("%s: pa=0x%x, da=0x%x, size=0x%x, atrribute=0x%x\n\r",
+	LPRINTF("%s: pa=0x%x, da=0x%x, size=0x%x, attribute=0x%x\n\r",
 		__func__, *pa, *da, size, attribute);
 	lda = *da;
 	lpa = *pa;

--- a/apps/examples/matrix_multiply/matrix_multiply.c
+++ b/apps/examples/matrix_multiply/matrix_multiply.c
@@ -220,7 +220,7 @@ int app (struct rpmsg_device *rdev, void *priv)
 	LPRINTF(" Test Results: Error count = %d \r\n", err_cnt);
 	LPRINTF("**********************************\r\n");
 
-	/* Detroy RPMsg endpoint */
+	/* Destroy RPMsg endpoint */
 	rpmsg_destroy_ept(&lept);
 	LPRINTF("Quitting application .. Matrix multiplication end\r\n");
 

--- a/apps/examples/rpc_demo/rpc_demo.c
+++ b/apps/examples/rpc_demo/rpc_demo.c
@@ -58,7 +58,7 @@ int app(struct rpmsg_device *rdev, void *priv)
 			     priv, platform_poll, rpmsg_rpc_shutdown);
 	rpmsg_set_default_rpc(&rpc);
 	if (ret) {
-		LPRINTF("Failed to intialize rpmsg rpc\r\n");
+		LPRINTF("Failed to initialize rpmsg rpc\r\n");
 		return -1;
 	}
 

--- a/apps/machine/microblaze_generic/zynqmp_mb_a53_rproc.c
+++ b/apps/machine/microblaze_generic/zynqmp_mb_a53_rproc.c
@@ -12,7 +12,7 @@
  * DESCRIPTION
  *
  *      OpenAMP remoteproc implementation for Xilinx MicroBlaze design
- *      example. The design instanciates Xilinx MicroBlaze soft proccesor
+ *      example. The design instantiates Xilinx MicroBlaze soft processor
  *      in ZynqMP's programmable logic and uses processing system (PS)
  *      DDR memory for its text and data. The APU in PS runs Linux with
  *      reserved-memory nodes in its device tree toaccommodat the

--- a/apps/machine/zynq7/platform_info.c
+++ b/apps/machine/zynq7/platform_info.c
@@ -123,7 +123,7 @@ platform_create_proc(int proc_index, int rsc_index)
 	/* parse resource table to remoteproc */
 	ret = remoteproc_set_rsc_table(&rproc_inst, rsc_table, rsc_size);
 	if (ret) {
-		xil_printf("Failed to intialize remoteproc\r\n");
+		xil_printf("Failed to initialize remoteproc\r\n");
 		remoteproc_remove(&rproc_inst);
 		return NULL;
 	}

--- a/apps/machine/zynq7/platform_info.h
+++ b/apps/machine/zynq7/platform_info.h
@@ -56,7 +56,7 @@ struct remoteproc_priv {
  * It will initialize the platform.
  *
  * @argc: number of arguments
- * @argv: array of the input arguements
+ * @argv: array of the input arguments
  * @platform: pointer to store the platform data pointer
  *
  * return 0 for success or negative value for failure

--- a/apps/machine/zynq7/platform_info_remoteproc_master.c
+++ b/apps/machine/zynq7/platform_info_remoteproc_master.c
@@ -36,9 +36,9 @@ extern struct hil_platform_ops zynq_a9_proc_ops;
 
 /**
  * This array provdes defnition of CPU nodes for master and remote
- * context. It contains two nodes beacuse the same file is intended
+ * context. It contains two nodes because the same file is intended
  * to use with both master and remote configurations. On zynq platform
- * only one node defintion is required for master/remote as there
+ * only one node definition is required for master/remote as there
  * are only two cores present in the platform.
  *
  * Only platform specific info is populated here. Rest of information

--- a/apps/machine/zynq7/zynq_a9_rproc.c
+++ b/apps/machine/zynq7/zynq_a9_rproc.c
@@ -72,7 +72,7 @@ zynq_a9_proc_init(struct remoteproc *rproc,
 	irq_vect = prproc->irq_notification;
 	metal_irq_register(irq_vect, zynq_a9_proc_irq_handler, rproc);
 	metal_irq_enable(irq_vect);
-	xil_printf("Successfully intialize remoteproc.\r\n");
+	xil_printf("Successfully initialize remoteproc.\r\n");
 	return rproc;
 err1:
 	metal_device_close(dev);

--- a/apps/machine/zynqmp/platform_info.c
+++ b/apps/machine/zynqmp/platform_info.c
@@ -33,8 +33,9 @@
 #include "platform_info.h"
 
 #define RPU_CPU_ID          0 /* RPU remote CPU Index. We only talk to
-                               * one CPU in the exmaple. We set the CPU
-                               * index to 0. */
+			       * one CPU in the example. We set the CPU
+			       * index to 0.
+			       */
 #ifdef versal
 #define IPI_CHN_BITMASK     0x08 /* IPI channel bit mask for IPI
 					* from/to RPU0 */
@@ -120,7 +121,7 @@ platform_create_proc(int proc_index, int rsc_index)
 	/* parse resource table to remoteproc */
 	ret = remoteproc_set_rsc_table(&rproc_inst, rsc_table, rsc_size);
 	if (ret) {
-		printf("Failed to intialize remoteproc\r\n");
+		printf("Failed to initialize remoteproc\r\n");
 		remoteproc_remove(&rproc_inst);
 		return NULL;
 	}

--- a/apps/machine/zynqmp/platform_info.h
+++ b/apps/machine/zynqmp/platform_info.h
@@ -54,7 +54,7 @@ struct remoteproc_priv {
  * It will initialize the platform.
  *
  * @argc: number of arguments
- * @argv: array of the input arguements
+ * @argv: array of the input arguments
  * @platform: pointer to store the platform data pointer
  *
  * return 0 for success or negative value for failure

--- a/apps/machine/zynqmp_r5/platform_info.c
+++ b/apps/machine/zynqmp_r5/platform_info.c
@@ -136,7 +136,7 @@ platform_create_proc(int proc_index, int rsc_index)
 	/* parse resource table to remoteproc */
 	ret = remoteproc_set_rsc_table(&rproc_inst, rsc_table, rsc_size);
 	if (ret) {
-		xil_printf("Failed to intialize remoteproc\r\n");
+		xil_printf("Failed to initialize remoteproc\r\n");
 		remoteproc_remove(&rproc_inst);
 		return NULL;
 	}

--- a/apps/machine/zynqmp_r5/platform_info.h
+++ b/apps/machine/zynqmp_r5/platform_info.h
@@ -59,7 +59,7 @@ struct remoteproc_priv {
  * It will initialize the platform.
  *
  * @argc: number of arguments
- * @argv: array of the input arguements
+ * @argv: array of the input arguments
  * @platform: pointer to store the platform data pointer
  *
  * return 0 for success or negative value for failure

--- a/apps/system/linux/machine/generic/platform_info.h
+++ b/apps/system/linux/machine/generic/platform_info.h
@@ -24,7 +24,7 @@ extern "C" {
  * It will initialize the platform.
  *
  * @argc: number of arguments
- * @argv: array of the input arguements
+ * @argv: array of the input arguments
  * @platform: pointer to store the platform data pointer
  *
  * return 0 for success or negative value for failure

--- a/apps/tests/msg/rpmsg-flood-ping.c
+++ b/apps/tests/msg/rpmsg-flood-ping.c
@@ -117,7 +117,7 @@ int app (struct rpmsg_device *rdev, void *priv)
 	num_pkgs = NUMS_PACKAGES;
 	max_size = rpmsg_virtio_get_buffer_size(rdev);
 	if (max_size < 0) {
-		LPERROR("No avaiable buffer size.\r\n");
+		LPERROR("No available buffer size.\r\n");
 		return -1;
 	}
 	i_payload = (struct _payload *)metal_allocate_memory(max_size);

--- a/apps/tests/msg/rpmsg-ping.c
+++ b/apps/tests/msg/rpmsg-ping.c
@@ -108,7 +108,7 @@ int app (struct rpmsg_device *rdev, void *priv)
 
 	max_size = rpmsg_virtio_get_buffer_size(rdev);
 	if (max_size < 0) {
-		LPERROR("No avaiable buffer size.\r\n");
+		LPERROR("No available buffer size.\r\n");
 		return -1;
 	}
 	max_size -= sizeof(struct _payload);

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -50,8 +50,8 @@ string (TOUPPER ${MACHINE}                PROJECT_MACHINE_UPPER)
 
 # Select which components are in the openamp lib
 option (WITH_PROXY          "Build with proxy(access device controlled by other processor)" ON)
-option (WITH_APPS           "Build with sample applicaitons" OFF)
-option (WITH_PROXY_APPS     "Build with proxy sample applicaitons" OFF)
+option (WITH_APPS           "Build with sample applications" OFF)
+option (WITH_PROXY_APPS     "Build with proxy sample applications" OFF)
 if (WITH_APPS)
   if (WITH_PROXY)
     set (WITH_PROXY_APPS ON)

--- a/cmake/platforms/zynqmp_r5_generic.cmake
+++ b/cmake/platforms/zynqmp_r5_generic.cmake
@@ -2,7 +2,7 @@ set (CMAKE_SYSTEM_PROCESSOR "arm" CACHE STRING "")
 set (MACHINE                "zynqmp_r5" CACHE STRING "")
 set (CROSS_PREFIX           "armr5-none-eabi-" CACHE STRING "")
 
-# Xilinx SDK version earlier than 2017.2 use mfloat-abi=soft by default to generat libxil
+# Xilinx SDK version earlier than 2017.2 use mfloat-abi=soft by default to generate libxil
 set (CMAKE_C_FLAGS          "-mfloat-abi=hard -mfpu=vfpv3-d16 -mcpu=cortex-r5" CACHE STRING "")
 
 include (cross_generic_gcc)

--- a/docs/apps/echo_test/README.md
+++ b/docs/apps/echo_test/README.md
@@ -34,7 +34,7 @@ You will need to manually compile the following kernel modules with your Linux k
 
 ### Load the Demo
 After Linux boots,
-* Load the machine remoteproc. If Linux runs as remoteproc master, you will need to pass the other processor's echo_test binary as firmware arguement to the remoteproc module.
+* Load the machine remoteproc. If Linux runs as remoteproc master, you will need to pass the other processor's echo_test binary as firmware argument to the remoteproc module.
 * If you run the Linux kernel application demo, load the `rpmsg_echo_test_kern_app` module. You will see the kernel application send the message to remote and the remote reply back and the kernel application will verify the result.
 * If you run the userspace application demo, load the `rpmsg_user_dev_driver` module.
 * If you run the userspace application demo, you will see the similar output on the console:

--- a/docs/apps/matrix_multiply/README.md
+++ b/docs/apps/matrix_multiply/README.md
@@ -1,7 +1,7 @@
 
 # matrix_multiply 
 This readme is about the OpenAMP matrix_multiply demo.
-The matrix_multiply is about one processor generates two matrices, and send them to the one, and the other one calcuate the matrix multiplicaiton and return the result matrix.
+The matrix_multiply is about one processor generates two matrices, and send them to the one, and the other one calculate the matrix multiplicaiton and return the result matrix.
 
 For now, it implements Linux generates the matrices, and the baremetal calculate the matrix mulitplication and send back the result.
 
@@ -34,7 +34,7 @@ You will need to manually compile the following kernel modules with your Linux k
 
 ### Load the Demo
 After Linux boots,
-* Load the machine remoteproc. If Linux runs as remoteproc master, you will need to pass the other processor's matrix_multiply binary as firmware arguement to the remoteproc module.
+* Load the machine remoteproc. If Linux runs as remoteproc master, you will need to pass the other processor's matrix_multiply binary as firmware argument to the remoteproc module.
 * If you run the Linux kernel application demo, load the `rpmsg_mat_mul_kern_app` module, you will see the kernel app will generate two matrices to the other processor, and output the result matrix returned by the other processor.
 * If you run the userspace application demo, load the `rpmsg_user_dev_driver` module.
 * If you run the userspace application demo `mat_mul_demo`, you will see the similar output on the console:

--- a/docs/apps/rpc_demo/README.md
+++ b/docs/apps/rpc_demo/README.md
@@ -3,7 +3,7 @@
 This readme is about the OpenAMP rpc_demo demo.
 The rpc_demo is about one processor uses the UART on the other processor and create file on the other processor's filesystem with file operations.
 
-For now, It implements the processor running generic(baremetal) applicaiton access the devices on the Linux.
+For now, It implements the processor running generic(baremetal) application access the devices on the Linux.
 
 ## Compilation
 

--- a/docs/data-structure.md
+++ b/docs/data-structure.md
@@ -162,7 +162,7 @@ struct rpmsg_endpoint {
 	uint32_t addr;                                                                                            /**< endpoint local address */
 	uint32_t dest_addr;                                                                                       /**< endpoint default target address */
 	int (*cb)(struct rpmsg_endpoint *ept, void *data, struct metal_io_region *io, size_t len, uint32_t addr); /**< endpoint callback */
-	void (*destroy)(struct rpmsg_endpoint *ept);                                                              /**< user registerd endpoint destory callback */
+	void (*destroy)(struct rpmsg_endpoint *ept);                                                              /**< user registered endpoint destroy callback */
 	/* Whether we need another callback for ack ns announcement? */
 };
 ```

--- a/docs/img-src/coprocessor-rpmsg-ns-dynamic.gv
+++ b/docs/img-src/coprocessor-rpmsg-ns-dynamic.gv
@@ -24,7 +24,7 @@ digraph G {
     node [shape="box"];
     rank="same";
     m_remoteproc_init [label="rproc = remoteproc_init(&remoteproc_ops, &arg);"]
-    m_remoteproc_load [label="calls remoteproc_load() to load applicaiton"];
+    m_remoteproc_load [label="calls remoteproc_load() to load application"];
     m_remoteproc_boot [shape="box", label="ret=remoteproc_boot(&rproc)"];
     m_remoteproc_get_vdev [label="vdev=remoteproc_create_virtio(rproc, rpmsg_vdev_id, MASTER, NULL);"];
     m_rpmsg_shmpool_init[label="rpmsg_virtio_init_shm_pool(shpool, shbuf, shbuf_pool_size);"];
@@ -75,8 +75,8 @@ digraph G {
 
   master -> m_remoteproc_init [dir="none"];
   slave -> s_remoteproc_init [dir="none"];
-  s_rpmsg_create_ep -> m_rpmsg_ns_cb [label="NS annoucement"];
-  m_rpmsg_create_ep -> s_rpmsg_ns_cb [label="NS annoucement"];
+  s_rpmsg_create_ep -> m_rpmsg_ns_cb [label="NS announcement"];
+  m_rpmsg_create_ep -> s_rpmsg_ns_cb [label="NS announcement"];
   m_rpmsg_send -> s_rpmsg_rx_cb [label="RPMsg data"];
   s_rpmsg_send -> m_rpmsg_rx_cb [label="RPMsg data"];
   m_rpmsg_destroy_ep -> s_rpmsg_ns_unbind_cb [label="Endpoint destroy NS"];

--- a/docs/img-src/coprocessor-rpmsg-ns.gv
+++ b/docs/img-src/coprocessor-rpmsg-ns.gv
@@ -24,7 +24,7 @@ digraph G {
     node [shape="box"];
     rank="same";
     m_remoteproc_init [label="rproc = remoteproc_init(&remoteproc_ops, &arg);"]
-    m_remoteproc_load [label="calls remoteproc_load() to load applicaiton"];
+    m_remoteproc_load [label="calls remoteproc_load() to load application"];
     m_remoteproc_boot [shape="box", label="ret=remoteproc_boot(&rproc)"];
     m_remoteproc_get_vdev [label="vdev=remoteproc_create_virtio(rproc, rpmsg_vdev_id, MASTER, NULL);"];
     m_rpmsg_shmpool_init[label="rpmsg_virtio_init_shm_pool(shpool, shbuf, shbuf_pool_size);"];
@@ -73,8 +73,8 @@ digraph G {
 
   master -> m_remoteproc_init [dir="none"];
   slave -> s_remoteproc_init [dir="none"];
-  s_rpmsg_create_ep -> m_rpmsg_ns_cb [label="NS annoucement"];
-  m_rpmsg_create_ep -> s_rpmsg_ns_cb [label="NS annoucement"];
+  s_rpmsg_create_ep -> m_rpmsg_ns_cb [label="NS announcement"];
+  m_rpmsg_create_ep -> s_rpmsg_ns_cb [label="NS announcement"];
   m_rpmsg_send -> s_rpmsg_rx_cb [label="RPMsg data"];
   s_rpmsg_send -> m_rpmsg_rx_cb [label="RPMsg data"];
   m_rpmsg_destroy_ep -> s_rpmsg_ns_unbind_cb [label="Endpoint destroy NS"];

--- a/docs/img-src/coprocessor-rpmsg-static-ep.gv
+++ b/docs/img-src/coprocessor-rpmsg-static-ep.gv
@@ -22,7 +22,7 @@ digraph G {
     node [shape="box"];
     rank="same";
     m_remoteproc_init [label="rproc = remoteproc_init(&remoteproc_ops, &arg);"];
-    m_remoteproc_load [label="calls remoteproc_load() to load applicaiton"];
+    m_remoteproc_load [label="calls remoteproc_load() to load application"];
     m_remoteproc_boot [shape="box", label="ret=remoteproc_boot(&rproc)"];
     m_remoteproc_get_vdev [label="vdev=remoteproc_create_virtio(rproc, rpmsg_vdev_id, MASTER, NULL);"];
     m_rpmsg_shmpool_init[label="rpmsg_virtio_init_shm_pool(shpool, shbuf, shbuf_pool_size);"];

--- a/docs/remoteproc-design.md
+++ b/docs/remoteproc-design.md
@@ -8,8 +8,8 @@ It will extend to crash detection, suspend and resume.
 | State | State Description |
 |:------|:------------------|
 | Offline | Initial state of a remoteproc instance. The remote presented by the remoteproc instance and its resource has been powered off. |
-| Configured | The remote presented by the remoteproc instance has been configured. And ready to load applicaiton. |
-| Ready | The remote presented by the remoteproc instance has applicaiton loaded, and ready to run. |
+| Configured | The remote presented by the remoteproc instance has been configured. And ready to load application. |
+| Ready | The remote presented by the remoteproc instance has application loaded, and ready to run. |
 | Stopped | The remote presented by the remoteproc instance has stopped from running. But the remote is still powered on. And the remote's resource hasn't been released. |
 
 ![Rproc LCM States](img/rproc-lcm-state-machine.png)
@@ -64,7 +64,7 @@ It will extend to crash detection, suspend and resume.
 			       size_t rsc_size)
   ```
 * Configure the remote presented by the remoteproc instance to make it able
-  to load applicaiton:
+  to load application:
   ```
   int remoteproc_config(struct remoteproc *rproc, void *data)
   ```

--- a/docs/rpmsg-design.md
+++ b/docs/rpmsg-design.md
@@ -2,7 +2,7 @@
 RPMsg is a framework to allow communication between two processors.
 RPMsg implementation in OpenAMP library is based on virtio. It complies
 the RPMsg Linux kernel implementation. It defines the handshaking on
-setting up and tearing down the communication between applicaitons
+setting up and tearing down the communication between applications
 running on two processors.
 
 ## RPMsg User API Flow Chats

--- a/lib/include/openamp/remoteproc_virtio.h
+++ b/lib/include/openamp/remoteproc_virtio.h
@@ -20,7 +20,7 @@
 extern "C" {
 #endif
 
-/* define vdev notification funciton user should implement */
+/* define vdev notification function user should implement */
 typedef int (*rpvdev_notify_func)(void *priv, uint32_t id);
 
 /**


### PR DESCRIPTION
Found via `codespell -q 3 -S ./scripts/spelling.txt`

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>