### PR TITLE
CI: enable codespell check

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install python dependencies
       run: |
         pip3 install setuptools
-        pip3 install junitparser==1.6.3 gitlint
+        pip3 install junitparser==1.6.3 gitlint codespell
     - name: Run Compliance Tests
       continue-on-error: true
       id: compliance

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -22,6 +22,7 @@ jobs:
         pip3 install setuptools
         pip3 install junitparser==1.6.3 gitlint
     - name: Run Compliance Tests
+      continue-on-error: true
       id: compliance
       env:
         BASE_REF: ${{ github.base_ref }}
@@ -31,7 +32,6 @@ jobs:
         git config --global user.email "you@example.com"
         git config --global user.name "Your Name"
         git rebase origin/${BASE_REF}
-        export
         ./scripts/ci/check_compliance.py -m checkpatch  -m Gitlint -m Identity -c origin/${BASE_REF}..
 
     - name: upload-results
@@ -46,30 +46,18 @@ jobs:
         if [[ ! -s "compliance.xml" ]]; then
           exit 1;
         fi
-        if [ -s checkpatch.txt ]; then
-           errors=$(cat checkpatch.txt)
-           errors="${errors//'%'/'%25'}"
-           errors="${errors//$'\n'/'%0A'}"
-           errors="${errors//$'\r'/'%0D'}"
-           echo "::error file=Checkpatch.txt::$errors"
-           exit=1
-        fi
-        if [ -s Identity.txt ]; then
-           errors=$(cat Identity.txt)
-           errors="${errors//'%'/'%25'}"
-           errors="${errors//$'\n'/'%0A'}"
-           errors="${errors//$'\r'/'%0D'}"
-           echo "::error file=Identity.txt::$errors"
-           exit=1
-        fi
-        if [ -s Gitlint.txt ]; then
-           errors=$(cat Gitlint.txt)
-           errors="${errors//'%'/'%25'}"
-           errors="${errors//$'\n'/'%0A'}"
-           errors="${errors//$'\r'/'%0D'}"
-           echo "::error file=Gitlint.txt::$errors"
-           exit=1
-        fi
-        if [ ${exit} == 1 ]; then
+
+        for file in checkpatch.txt Identity.txt Gitlint.txt; do
+          if [[ -s $file ]]; then
+            errors=$(cat $file)
+            errors="${errors//'%'/'%25'}"
+            errors="${errors//$'\n'/'%0A'}"
+            errors="${errors//$'\r'/'%0D'}"
+            echo "::error file=${file}::$errors"
+            exit=1
+          fi
+        done
+
+        if [ "${exit}" == "1" ]; then
           exit 1;
         fi

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -194,7 +194,8 @@ class CheckPatch(ComplianceTest):
         diff = subprocess.Popen(('git', 'diff', COMMIT_RANGE),
                                 stdout=subprocess.PIPE)
         try:
-            subprocess.check_output(checkpatch + ' --mailback' + ' --no-tree' + ' -',
+            subprocess.check_output(checkpatch + ' --mailback' + ' --codespell' +
+                                    ' --no-tree' + ' -',
                                     stdin=diff.stdout,
                                     stderr=subprocess.STDOUT,
                                     shell=True, cwd=GIT_TOP)


### PR DESCRIPTION
The checkpatch.pl allows to run codespell on patches to highlight typo error.
Rebase the CI and checkpatch script on recent version and enable "codespell" tool 