### PR TITLE
_rpmsg_virtio_get_buffer_size should return error on failure

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -276,11 +276,12 @@ static int _rpmsg_virtio_get_buffer_size(struct rpmsg_virtio_device *rvdev)
 		length =
 		    (int)virtqueue_get_desc_size(rvdev->svq) -
 		    sizeof(struct rpmsg_hdr);
-		if (length < 0) {
-			length = 0;
-		}
 	}
 #endif /*!VIRTIO_MASTER_ONLY*/
+
+	if (length <= 0) {
+		length = RPMSG_ERR_NO_BUFF;
+	}
 
 	return length;
 }


### PR DESCRIPTION
The code wrongly returns 0 if a descriptor is not available.
Signed-off-by: Tammy Leino <tammy_leino@mentor.com>