### PR TITLE
remoteproc_virtio_notify could use null notify operation

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -874,7 +874,10 @@ static int remoteproc_virtio_notify(void *priv, uint32_t id)
 {
 	struct remoteproc *rproc = priv;
 
-	return rproc->ops->notify(rproc, id);
+	if (rproc->ops->notify)
+		return rproc->ops->notify(rproc, id);
+
+	return 0;
 }
 
 struct virtio_device *


### PR DESCRIPTION
remoteproc_virtio_notify updated to check notify operation before invoking.
Signed-off-by: Tammy Leino <tammy_leino@mentor.com>