### PR TITLE
Document buf argument in get_mem for remoteproc_ops structure

### DIFF
--- a/lib/include/openamp/remoteproc.h
+++ b/lib/include/openamp/remoteproc.h
@@ -423,6 +423,7 @@ struct remoteproc_ops {
 	 * @da - device address
 	 * @va - virtual address
 	 * @size - memory size
+	 * @buf - pointer to remoteproc_mem struct object to store result
 	 *
 	 * @returns remoteproc memory pointed by buf if success, otherwise NULL
 	 */


### PR DESCRIPTION
Added a description of the buf parameter to get_mem.
Signed-off-by: Tammy Leino <tammy_leino@mentor.com>