### PR TITLE
remoteproc_get_mem could wrongly match on wrong name

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -48,7 +48,7 @@ remoteproc_get_mem(struct remoteproc *rproc, const char *name,
 	metal_list_for_each(&rproc->mems, node) {
 		mem = metal_container_of(node, struct remoteproc_mem, node);
 		if (name) {
-			if (!strncmp(name, mem->name, strlen(name)))
+			if (!strncmp(name, mem->name, RPROC_MAX_NAME_LEN))
 				return mem;
 		} else if (pa != METAL_BAD_PHYS) {
 			metal_phys_addr_t pa_start, pa_end;


### PR DESCRIPTION
Modified remoteproc_get_mem to bound the name comparison by RPROC_MAX_NAME_LEN instead of the length of the incoming search string
