### PR TITLE
openamp: add ns_unbind_cb to rpmsg_device

### DIFF
--- a/docs/rpmsg-design.md
+++ b/docs/rpmsg-design.md
@@ -101,6 +101,12 @@ running on two processors.
   void (*rpmsg_ns_bind_cb)(struct rpmsg_device *rdev,
 			   const char *name, uint32_t dest)
   ```
+* RPMsg name service unbind callback. If user defines such callback, when
+  there is name service destroy arrives, it will call this callback.:
+  ```
+  void (*rpmsg_ns_unbind_cb)(struct rpmsg_device *rdev,
+			   const char *name, uint32_t dest)
+  ```
 * RPMsg endpoint name service unbind callback. If user defines such callback,
   when there is name service destroy arrives, it will call this callback to
   notify the user application about the remote has destroyed the service.:

--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -109,6 +109,8 @@ struct rpmsg_device_ops {
  * @lock: mutex lock for rpmsg management
  * @ns_bind_cb: callback handler for name service announcement without local
  *              endpoints waiting to bind.
+ * @ns_unbind_cb: callback handler for name service announcement, called when
+ *                remote ept is destroyed.
  * @ops: RPMsg device operations
  * @support_ns: create/destroy namespace message
  */
@@ -118,6 +120,7 @@ struct rpmsg_device {
 	unsigned long bitmap[metal_bitmap_longs(RPMSG_ADDR_BMP_SIZE)];
 	metal_mutex_t lock;
 	rpmsg_ns_bind_cb ns_bind_cb;
+	rpmsg_ns_bind_cb ns_unbind_cb;
 	struct rpmsg_device_ops ops;
 	bool support_ns;
 };

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -585,6 +585,8 @@ static int rpmsg_virtio_ns_callback(struct rpmsg_endpoint *ept, void *data,
 		metal_mutex_release(&rdev->lock);
 		if (_ept && _ept->ns_unbind_cb)
 			_ept->ns_unbind_cb(_ept);
+		if (rdev->ns_unbind_cb)
+			rdev->ns_unbind_cb(rdev, name, dest);
 	} else {
 		if (!_ept) {
 			/*


### PR DESCRIPTION
it's useful to notify the port layer and also symmetry with ns_bind_cb callback.
