### PR TITLE
checkpatch: Increase the default limit to 100 characters

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -2,7 +2,7 @@
 --no-tree
 --summary-file
 --show-types
---max-line-length=80
+--max-line-length=100
 --min-conf-desc-length=1
 
 --ignore BRACES


### PR DESCRIPTION
The 80 character limit is a warning which sometime affect the readability.
let's relax this limit to 100 as done in some other projects

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>