### PR TITLE
apps: Remove leading space in CMake linker directive variables.

### DIFF
--- a/apps/system/generic/machine/zynqmp_r5/CMakeLists.txt
+++ b/apps/system/generic/machine/zynqmp_r5/CMakeLists.txt
@@ -8,9 +8,9 @@ if(NOT DEFINED ${RSC_TABLE})
 endif(NOT DEFINED ${RSC_TABLE})
 
 set (_linker_script "${CMAKE_CURRENT_SOURCE_DIR}/linker_remote.ld")
-set_property (GLOBAL PROPERTY APP_LINKER_OPT " -Wl,--defsym,_rsc_table=${RSC_TABLE} -T\"${_linker_script}\"")
+set_property (GLOBAL PROPERTY APP_LINKER_OPT "-Wl,--defsym,_rsc_table=${RSC_TABLE} -T\"${_linker_script}\"")
 set (_linker_large_text_script "${CMAKE_CURRENT_SOURCE_DIR}/linker_large_text.ld")
-set_property (GLOBAL PROPERTY APP_LINKER_LARGE_TEXT_OPT " -Wl,--defsym,_rsc_table=${RSC_TABLE} -T\"${_linker_large_text_script}\"")
+set_property (GLOBAL PROPERTY APP_LINKER_LARGE_TEXT_OPT "-Wl,--defsym,_rsc_table=${RSC_TABLE} -T\"${_linker_large_text_script}\"")
 
 find_path(XIL_INCLUDE_DIR NAMES xparameters.h PATHS ${CMAKE_FIND_ROOT_PATH})
 collect (PROJECT_INC_DIRS "${XIL_INCLUDE_DIR}")


### PR DESCRIPTION
While building the Xilinx R5 demo apps, the following error message
occurs:

CMake Error at apps/examples/echo/CMakeLists.txt:38 (add_executable):
  Target "rpmsg-echo.out" links to item " -Wl,--defsym,_rsc_table=0x3ed20000
  -T"/OpenAMP-Project/gh3/open-amp/apps/system/generic/machine/zynqmp_r5/linker_remote.ld""
  which has leading or trailing whitespace.  This is now an error according
  to policy CMP0004.

Remove the leading space.

Signed-off-by: Ed Mooring <ed.mooring@gmail.com>