### PR TITLE
lib: Remove warnings from -Wcast-align

### DIFF
--- a/lib/proxy/rpmsg_retarget.c
+++ b/lib/proxy/rpmsg_retarget.c
@@ -178,7 +178,7 @@ int _open(const char *filename, int flags, int mode)
 		return -EINVAL;
 
 	/* Construct rpc payload */
-	syscall = (struct rpmsg_rpc_syscall *)tmpbuf;
+	syscall = (void *)tmpbuf;
 	syscall->id = OPEN_SYSCALL_ID;
 	syscall->args.int_field1 = flags;
 	syscall->args.int_field2 = mode;
@@ -228,7 +228,7 @@ int _read(int fd, char *buffer, int buflen)
 	syscall.args.int_field2 = buflen;
 	syscall.args.data_len = 0;	/*not used */
 
-	resp = (struct rpmsg_rpc_syscall *)tmpbuf;
+	resp = (void *)tmpbuf;
 	resp->id = 0;
 	ret = rpmsg_rpc_send(rpc, (void *)&syscall, payload_size,
 			     tmpbuf, sizeof(tmpbuf));
@@ -281,7 +281,7 @@ int _write(int fd, const char *ptr, int len)
 	if (fd == 1)
 		null_term = 1;
 
-	syscall = (struct rpmsg_rpc_syscall *)tmpbuf;
+	syscall = (void *)tmpbuf;
 	syscall->id = WRITE_SYSCALL_ID;
 	syscall->args.int_field1 = fd;
 	syscall->args.int_field2 = len;


### PR DESCRIPTION
There were several places in the library where a char* was used to point
to a wider type (uint32_t or a struct). Casting the char* to the wider
type resulted in a compiler warning.

This commit adds a cast to void* to remove the compiler warnings. This
results in no functional change.

Signed-off-by: Ed Mooring <ed.mooring@gmail.com>