### PR TITLE
Fix CMake Deprecation Warnings

### DIFF
--- a/cmake/platforms/cross_generic_gcc.cmake
+++ b/cmake/platforms/cross_generic_gcc.cmake
@@ -1,9 +1,10 @@
 set (CMAKE_SYSTEM_NAME      "Generic" CACHE STRING "")
 
-include (CMakeForceCompiler)
-
-CMAKE_FORCE_C_COMPILER   ("${CROSS_PREFIX}gcc" GNU)
-CMAKE_FORCE_CXX_COMPILER ("${CROSS_PREFIX}g++" GNU)
+set (CMAKE_C_COMPILER   "${CROSS_PREFIX}gcc")
+set (CMAKE_CXX_COMPILER "${CROSS_PREFIX}g++")
+# _exit is in the BSP rather than in libgcc, leaving this out
+# causes errors in try_compile on ARM generic.
+set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM	NEVER CACHE STRING "")
 set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY	NEVER CACHE STRING "")


### PR DESCRIPTION
Building OpenAMP for standalone ARM R5, the following warning occurs:

CMake Deprecation Warning at
/usr/share/cmake-3.16/Modules/CMakeForceCompiler.cmake:75 (message):
  The CMAKE_FORCE_C_COMPILER macro is deprecated.  Instead just set
  CMAKE_C_COMPILER and allow CMake to identify the compiler.
Call Stack (most recent call first):
  cmake/platforms/cross_generic_gcc.cmake:5 (CMAKE_FORCE_C_COMPILER)
  /home/mooring/build-oa/toolchain.r5-oa.sa:18 (include)
  /usr/share/cmake-3.16/Modules/CMakeDetermineSystem.cmake:93 (include)
  CMakeLists.txt:19 (project)

Follow the suggestions in the above error message, and add
CMAKE_TRY_COMPILE_TARGET_TYPE = STATIC LIBRARY, which makes try_compile()
not try to link the cross-compiled binary. This is necessary because the
arm-none-eabi toolchain libgcc doesn't have an implementation of _exit(),
leaving that to the BSP. This results in a CMake error because it can't
build the test executable.

Signed-off-by: Ed Mooring <ed.mooring@gmail.com>