### PR TITLE
remoteproc_allocate_id not treating notifyid as 32-bits

### DIFF
--- a/lib/include/openamp/remoteproc.h
+++ b/lib/include/openamp/remoteproc.h
@@ -20,7 +20,7 @@
 extern "C" {
 #endif
 
-#define RSC_NOTIFY_ID_ANY 0xFFFFFFFFUL
+#define RSC_NOTIFY_ID_ANY 0xFFFFFFFFU
 
 #define RPROC_MAX_NAME_LEN 32
 

--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -857,7 +857,7 @@ unsigned int remoteproc_allocate_id(struct remoteproc *rproc,
 
 	if (start == RSC_NOTIFY_ID_ANY)
 		start = 0;
-	if (end == 0)
+	if (end == RSC_NOTIFY_ID_ANY)
 		end = METAL_BITS_PER_ULONG;
 
 	notifyid = metal_bitmap_next_clear_bit(&rproc->bitmap,

--- a/lib/remoteproc/rsc_table_parser.c
+++ b/lib/remoteproc/rsc_table_parser.c
@@ -131,7 +131,9 @@ int handle_vdev_rsc(struct remoteproc *rproc, void *rsc)
 	/* only assign notification IDs but do not initialize vdev */
 	notifyid = vdev_rsc->notifyid;
 	notifyid = remoteproc_allocate_id(rproc,
-					  notifyid, notifyid + 1);
+					  notifyid,
+					  notifyid == RSC_NOTIFY_ID_ANY ?
+					  RSC_NOTIFY_ID_ANY : notifyid + 1);
 	if (notifyid != RSC_NOTIFY_ID_ANY)
 		vdev_rsc->notifyid = notifyid;
 
@@ -143,7 +145,8 @@ int handle_vdev_rsc(struct remoteproc *rproc, void *rsc)
 		notifyid = vring_rsc->notifyid;
 		notifyid = remoteproc_allocate_id(rproc,
 						  notifyid,
-						  notifyid + 1);
+						  notifyid == RSC_NOTIFY_ID_ANY ?
+						  RSC_NOTIFY_ID_ANY : notifyid + 1);
 		if (notifyid != RSC_NOTIFY_ID_ANY)
 			vring_rsc->notifyid = notifyid;
 	}


### PR DESCRIPTION
notifyid is 32 bits in the resource table and must be uint32_t in code
Signed-off-by: Tammy Leino <tammy_leino@mentor.com>