### PR TITLE
Application-supplied buffer addresses not checked for validity

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -293,11 +293,12 @@ static void rpmsg_virtio_hold_rx_buffer(struct rpmsg_device *rdev, void *rxbuf)
 
 	rvdev = metal_container_of(rdev, struct rpmsg_virtio_device, rdev);
 
-	if ((rxbuf < ((struct metal_io_region *)rvdev->rvq->shm_io)->virt + sizeof(struct rpmsg_hdr)) ||
+	if ((rxbuf < ((struct metal_io_region *)rvdev->rvq->shm_io)->virt +
+	    sizeof(struct rpmsg_hdr)) ||
 	    (rxbuf >= (((struct metal_io_region *)rvdev->rvq->shm_io)->virt +
 	    ((struct metal_io_region *)rvdev->rvq->shm_io)->size)))
 		return;
-		
+
 	rp_hdr = RPMSG_LOCATE_HDR(rxbuf);
 
 	/* Set held status to keep buffer */
@@ -313,12 +314,13 @@ static void rpmsg_virtio_release_rx_buffer(struct rpmsg_device *rdev,
 	uint32_t len;
 
 	rvdev = metal_container_of(rdev, struct rpmsg_virtio_device, rdev);
-	
-	if ((rxbuf < ((struct metal_io_region *)rvdev->rvq->shm_io)->virt + sizeof(struct rpmsg_hdr)) ||
+
+	if ((rxbuf < ((struct metal_io_region *)rvdev->rvq->shm_io)->virt +
+	    sizeof(struct rpmsg_hdr)) ||
 	    (rxbuf >= (((struct metal_io_region *)rvdev->rvq->shm_io)->virt +
 	    ((struct metal_io_region *)rvdev->rvq->shm_io)->size)))
 		return;
-		
+
 	rp_hdr = RPMSG_LOCATE_HDR(rxbuf);
 	/* The reserved field contains buffer index */
 	idx = (uint16_t)(rp_hdr->reserved & ~RPMSG_BUF_HELD);
@@ -392,6 +394,12 @@ static int rpmsg_virtio_send_offchannel_nocopy(struct rpmsg_device *rdev,
 	if ((data < ((struct metal_io_region *)rvdev->rvq->shm_io)->virt + sizeof(struct rpmsg_hdr)) ||
 	    ((data + len) > (((struct metal_io_region *)rvdev->rvq->shm_io)->virt +
 	    ((struct metal_io_region *)rvdev->rvq->shm_io)->size))) 
+		return RPMSG_ERR_PARAM;
+
+	if ((data < ((struct metal_io_region *)rvdev->rvq->shm_io)->virt +
+	    sizeof(struct rpmsg_hdr)) ||
+	    ((data + len) > (((struct metal_io_region *)rvdev->rvq->shm_io)->virt +
+	    ((struct metal_io_region *)rvdev->rvq->shm_io)->size)))
 		return RPMSG_ERR_PARAM;
 
 	hdr = RPMSG_LOCATE_HDR(data);


### PR DESCRIPTION
Code must check for valid buffer address to avoid potential corruption
Signed-off-by: Tammy Leino <tammy_leino@mentor.com>