### PR TITLE
Vring descriptor count must be limited to 65k per device

### DIFF
--- a/lib/include/openamp/remoteproc_virtio.h
+++ b/lib/include/openamp/remoteproc_virtio.h
@@ -20,6 +20,9 @@
 extern "C" {
 #endif
 
+/* maximum number of vring descriptors for a vdev limited by 16-bit data type */
+#define	RPROC_MAX_VRING_DESC	USHRT_MAX
+
 /* define vdev notification function user should implement */
 typedef int (*rpvdev_notify_func)(void *priv, uint32_t id);
 

--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -296,7 +296,7 @@ int rproc_virtio_init_vring(struct virtio_device *vdev, unsigned int index,
 	unsigned int num_vrings;
 
 	num_vrings = vdev->vrings_num;
-	if (index >= num_vrings)
+	if ((index >= num_vrings) || (num_descs > RPROC_MAX_VRING_DESC))
 		return -RPROC_EINVAL;
 	vring_info = &vdev->vrings_info[index];
 	vring_info->io = io;


### PR DESCRIPTION
Code must ensure we don't overflow the 16-bit count in vring_alloc_info
Signed-off-by: Tammy Leino <tammy_leino@mentor.com>