### PR TITLE
Removed unnecessary check from remoteproc_mmap

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -372,7 +372,7 @@ void *remoteproc_mmap(struct remoteproc *rproc,
 	if (mem) {
 		if (lpa != METAL_BAD_PHYS)
 			lda = remoteproc_patoda(mem, lpa);
-		else if (lda != METAL_BAD_PHYS)
+		else
 			lpa = remoteproc_datopa(mem, lda);
 		if (io)
 			*io = mem->io;


### PR DESCRIPTION
This conditional will never fail since lpa and lda can't both be null
Signed-off-by: Tammy Leino <tammy_leino@mentor.com>