### PR TITLE
virtqueue_add_consumed_buffer input parameter fix

### DIFF
--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -302,7 +302,7 @@ int virtqueue_add_consumed_buffer(struct virtqueue *vq, uint16_t head_idx,
 	struct vring_used_elem *used_desc = NULL;
 	uint16_t used_idx;
 
-	if (head_idx > vq->vq_nentries) {
+	if (head_idx >= vq->vq_nentries) {
 		return ERROR_VRING_NO_BUFF;
 	}
 


### PR DESCRIPTION
head_idx must be restricted to 0 ... vq_nentries - 1
Signed-off-by: Tammy Leino <tammy_leino@mentor.com>