### PR TITLE
openamp: add ns_unbind_notify support

### DIFF
--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -118,6 +118,7 @@ struct rpmsg_device {
 	unsigned long bitmap[metal_bitmap_longs(RPMSG_ADDR_BMP_SIZE)];
 	metal_mutex_t lock;
 	rpmsg_ns_bind_cb ns_bind_cb;
+	rpmsg_ns_bind_cb ns_unbind_cb;
 	struct rpmsg_device_ops ops;
 	bool support_ns;
 };

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -571,6 +571,8 @@ static int rpmsg_virtio_ns_callback(struct rpmsg_endpoint *ept, void *data,
 		metal_mutex_release(&rdev->lock);
 		if (_ept && _ept->ns_unbind_cb)
 			_ept->ns_unbind_cb(_ept);
+		if (rdev->ns_unbind_cb)
+			rdev->ns_unbind_cb(rdev, name, dest);
 	} else {
 		if (!_ept) {
 			/*


### PR DESCRIPTION
openamp: add ns_unbind_notify support

This is for notify rdev unbind event

Signed-off-by: Guiding Li <liguiding1@xiaomi.com>