### PR TITLE
openamp: should kick remote when use release_rx_buffer

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -315,6 +315,8 @@ static void rpmsg_virtio_release_rx_buffer(struct rpmsg_device *rdev,
 	/* Return buffer on virtqueue. */
 	len = virtqueue_get_buffer_length(rvdev->rvq, idx);
 	rpmsg_virtio_return_buffer(rvdev, rp_hdr, len, idx);
+	/* tell peer we return some rx buffer */
+	virtqueue_kick(rvdev->rvq);
 	metal_mutex_release(&rdev->lock);
 }
 


### PR DESCRIPTION
openamp: should kick remote when use release_rx_buffer

There is missing virtqueue_kick when use hold_rx/release_rx

Signed-off-by: Guiding Li <liguiding1@xiaomi.com>