### PR TITLE
lib: Use strcmp to match endpoint name instead of strncmp

### DIFF
--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -219,8 +219,7 @@ struct rpmsg_endpoint *rpmsg_get_endpoint(struct rpmsg_device *rdev,
 			return ept;
 		/* else use name service and destination address */
 		if (name)
-			name_match = !strncmp(ept->name, name,
-					      sizeof(ept->name));
+			name_match = !strcmp(ept->name, name);
 		if (!name || !name_match)
 			continue;
 		/* destination address is known, equal to ept remote address */


### PR DESCRIPTION
It's not accurate to use strncmp to match endpoint name, because it dosen't match the whole word.
Instead, it's recommended to use strcmp.

Related issue: https://github.com/OpenAMP/open-amp/issues/430