### PR TITLE
remoteproc: Fix build warning in rproc_virtio_create_vdev function

### DIFF
--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -219,11 +219,13 @@ rproc_virtio_create_vdev(unsigned int role, unsigned int notifyid,
 
 	for (i = 0; i < num_vrings; i++) {
 		struct virtqueue *vq;
+#ifndef VIRTIO_DEVICE_ONLY
 		struct fw_rsc_vdev_vring *vring_rsc;
+#endif
 		unsigned int num_extra_desc = 0;
 
-		vring_rsc = &vdev_rsc->vring[i];
 #ifndef VIRTIO_DEVICE_ONLY
+		vring_rsc = &vdev_rsc->vring[i];
 		if (role == VIRTIO_DEV_DRIVER) {
 			num_extra_desc = vring_rsc->num;
 		}


### PR DESCRIPTION
The arm-none-eabi-gcc complains when VIRTIO_DEVICE_ONLY is enable

remoteproc_virtio.c:222:29: warning: variable 'vring_rsc' set but not used [-Wunused-but-set-variable]
  222 |   struct fw_rsc_vdev_vring *vring_rsc;
      |                             ^~~~~~~~~

The vring_rsc variable should be declared and set only if VIRTIO_DEVICE_ONLY is not enable.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>