### PR TITLE
zynqmp_r5 resource table: Change notifyid for the virtio device.

### DIFF
--- a/apps/machine/zynqmp_r5/rsc_table.c
+++ b/apps/machine/zynqmp_r5/rsc_table.c
@@ -51,7 +51,7 @@ struct remote_resource_table __resource resources = {
 
 	/* Virtio device entry */
 	{
-	 RSC_VDEV, VIRTIO_ID_RPMSG_, 0, RPMSG_VDEV_DFEATURES, 0, 0, 0,
+	 RSC_VDEV, VIRTIO_ID_RPMSG_, 31, RPMSG_VDEV_DFEATURES, 0, 0, 0,
 	 NUM_VRINGS, {0, 0},
 	 },
 


### PR DESCRIPTION
The notifyid for the virtio device in the resource table was set to 0, and the notifyids for the vrings were set to 1 and 2. However, the Linux remoteproc implementation changes those values to 0 and 1 when the firmware image is loaded. With the enhanced error checking introduced in commit 2016ff1e, the duplicate assignment of notifyid 0 to the rvdev and vring0 resulted in a failure.

Set the value of notifyid for the virtio device (rvdev) to 31 to avoid possible conflicts with the Linux imposed values.