### PR TITLE
Fix warn: declaration of 'vring_rsc' shadows a previous local

### DIFF
--- a/lib/remoteproc/rsc_table_parser.c
+++ b/lib/remoteproc/rsc_table_parser.c
@@ -144,8 +144,6 @@ int handle_vdev_rsc(struct remoteproc *rproc, void *rsc)
 
 	num_vrings = vdev_rsc->num_of_vrings;
 	for (i = 0; i < num_vrings; i++) {
-		struct fw_rsc_vdev_vring *vring_rsc;
-
 		vring_rsc = &vdev_rsc->vring[i];
 		notifyid = vring_rsc->notifyid;
 		notifyid = remoteproc_allocate_id(rproc,


### PR DESCRIPTION
```
 regressed by commit 03c80a13417f67f94852cf7d5cb160f1bdf8271e
    Author: Tammy Leino <tammy_leino@mentor.com>
    Date:   Mon Sep 26 08:14:35 2022 -0700
    
        handle_vdev_rsc must return error if notifyid cannot be assigned
    
        Updated handle_vdev_rsc to return error if a unique id cannot be assigned
        Signed-off-by: Tammy Leino <tammy_leino@mentor.com>
```