### PR TITLE
Fix shadow warnings in application code and renforce CI build

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -28,12 +28,15 @@ build_linux(){
 	pwd || exit 1
 	ls -l || exit 1
 	cd libmetal || exit 1
-	cmake . -Bbuild || exit 1
+	cmake . -Bbuild \
+	-DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" || exit 1
 	cd build || exit 1
 	make || exit 1
 	export || exit 1
 	cd ../.. || exit 1
-	cmake . -Bbuild -DWITH_APPS=on -DWITH_PROXY=on -DCMAKE_INCLUDE_PATH="./libmetal/build/lib/include" -DCMAKE_LIBRARY_PATH="./libmetal/build/lib" || exit 1
+	cmake . -Bbuild -DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" \
+	-DWITH_APPS=on -DWITH_PROXY=on -DCMAKE_INCLUDE_PATH="./libmetal/build/lib/include"  \
+	-DCMAKE_LIBRARY_PATH="./libmetal/build/lib" || exit 1
 	cd build || exit 1
 	make VERBOSE=1 all || exit 1
 	exit 0
@@ -43,11 +46,16 @@ build_generic(){
 	echo  " Build for generic platform "
 	apt-get install -y gcc-arm-none-eabi || exit 1
 	cd libmetal || exit 1
-	cmake . -Bbuild-generic -DCMAKE_TOOLCHAIN_FILE=template-generic || exit 1
+	cmake . -Bbuild-generic -DCMAKE_TOOLCHAIN_FILE=template-generic \
+	-DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" || exit 1
 	cd build-generic || exit 1
 	make VERBOSE=1 || exit 1
 	cd ../../ || exit 1
-	cmake . -Bbuild-generic -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" -DCMAKE_C_FLAGS="" -DCMAKE_SYSTEM_PROCESSOR="arm" -DCMAKE_C_COMPILER=arm-none-eabi-gcc -DCMAKE_INCLUDE_PATH="./libmetal/build-generic/lib/include" -DCMAKE_LIBRARY_PATH="./libmetal/build-generic/lib" || exit 1
+	cmake . -Bbuild-generic -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" \
+	-DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" \
+	-DCMAKE_SYSTEM_PROCESSOR="arm" -DCMAKE_C_COMPILER=arm-none-eabi-gcc \
+	-DCMAKE_INCLUDE_PATH="./libmetal/build-generic/lib/include" \
+	-DCMAKE_LIBRARY_PATH="./libmetal/build-generic/lib" || exit 1
 	cd build-generic || exit 1
 	make VERBOSE=1 || exit 1
 	exit 0

--- a/apps/examples/linux_rpc_demo/linux_rpc_demo.c
+++ b/apps/examples/linux_rpc_demo/linux_rpc_demo.c
@@ -34,7 +34,7 @@
 #define LPERROR(format, ...) LPRINTF("ERROR: " format, ##__VA_ARGS__)
 
 static struct rpmsg_rpc_clt *rpmsg_default_rpc;
-static int fd, bytes_written, bytes_read;
+static int file_d, bytes_written, bytes_read;
 static struct polling poll;
 static atomic_int wait_resp;
 
@@ -72,9 +72,9 @@ void rpmsg_open_cb(struct rpmsg_rpc_clt *rpc, int status, void *data,
 
 	/* Assign value from return args */
 	if (status)
-		fd = 0;
+		file_d = 0;
 	else
-		fd = resp->fd;
+		file_d = resp->fd;
 
 	/* to clear the flag set in the caller function */
 	atomic_flag_clear(&wait_resp);
@@ -487,25 +487,25 @@ int app(struct rpmsg_device *rdev, void *priv)
 	printf("\nRemote>Creating a file on host and writing to it..\r\n");
 	rpmsg_open(fname, REDEF_O_CREAT | REDEF_O_WRONLY | REDEF_O_APPEND,
 		   S_IRUSR | S_IWUSR);
-	printf("\nRemote>Opened file '%s' with fd = %d\r\n", fname, fd);
+	printf("\nRemote>Opened file '%s' with fd = %d\r\n", fname, file_d);
 	sprintf(wbuff, "This is a test string being written to file..");
-	rpmsg_write(fd, wbuff, strlen(wbuff));
-	printf("\nRemote>Wrote to fd = %d, size = %d, content = %s\r\n", fd,
+	rpmsg_write(file_d, wbuff, strlen(wbuff));
+	printf("\nRemote>Wrote to fd = %d, size = %d, content = %s\r\n", file_d,
 	       bytes_written, wbuff);
-	rpmsg_close(fd);
-	printf("\nRemote>Closed fd = %d\r\n", fd);
+	rpmsg_close(file_d);
+	printf("\nRemote>Closed fd = %d\r\n", file_d);
 
 	/* Remote performing file IO on Host */
 	printf("\nRemote>Reading a file on host and displaying its "
 	"contents..\r\n");
 	rpmsg_open(fname, REDEF_O_RDONLY, S_IRUSR | S_IWUSR);
-	printf("\nRemote>Opened file '%s' with fd = %d\r\n", fname, fd);
-	rpmsg_read(fd, rbuff, sizeof(rbuff));
+	printf("\nRemote>Opened file '%s' with fd = %d\r\n", fname, file_d);
+	rpmsg_read(file_d, rbuff, sizeof(rbuff));
 	*(char *)(&rbuff[0] + bytes_read) = 0;
 	printf("\nRemote>Read from fd = %d, size = %d, "
-	"printing contents below .. %s\r\n", fd, bytes_read, rbuff);
-	rpmsg_close(fd);
-	printf("\nRemote>Closed fd = %d\r\n", fd);
+	"printing contents below .. %s\r\n", file_d, bytes_read, rbuff);
+	rpmsg_close(file_d);
+	printf("\nRemote>Closed fd = %d\r\n", file_d);
 
 	while (1) {
 		/* Remote performing STDIO on Host */

--- a/apps/examples/linux_rpc_demo/linux_rpc_demod.c
+++ b/apps/examples/linux_rpc_demo/linux_rpc_demod.c
@@ -37,14 +37,14 @@
 
 static void *platform;
 static struct rpmsg_device *rpdev;
-static struct rpmsg_rpc_svr rpcs;
+static struct rpmsg_rpc_svr rpc_svr;
 int request_termination;
 int ept_deleted;
 
 void rpmsg_service_server_unbind(struct rpmsg_endpoint *ept)
 {
 	(void)ept;
-	rpmsg_destroy_ept(&rpcs.ept);
+	rpmsg_destroy_ept(&rpc_svr.ept);
 	LPRINTF("Endpoint is destroyed\r\n");
 	ept_deleted = 1;
 }
@@ -53,7 +53,7 @@ void terminate_rpc_app(void)
 {
 	LPRINTF("Destroying endpoint.\r\n");
 	if (!ept_deleted)
-		rpmsg_destroy_ept(&rpcs.ept);
+		rpmsg_destroy_ept(&rpc_svr.ept);
 }
 
 void exit_action_handler(int signum)
@@ -260,7 +260,7 @@ int app(struct rpmsg_device *rdev, void *priv)
 	/* Initialize RPMSG framework */
 	LPRINTF("Try to create rpmsg endpoint.\r\n");
 
-	ret = rpmsg_rpc_server_init(&rpcs, rdev, rpc_table,
+	ret = rpmsg_rpc_server_init(&rpc_svr, rdev, rpc_table,
 				    (int)sizeof(rpc_table) / sizeof(
 				    struct rpmsg_rpc_services),
 				    rpmsg_service_server_unbind);

--- a/apps/examples/nocopy_echo/rpmsg-nocopy-ping.c
+++ b/apps/examples/nocopy_echo/rpmsg-nocopy-ping.c
@@ -40,10 +40,10 @@ static int rnum;
 static int err_cnt;
 static int ept_deleted;
 
-static int rpmsg_check_rcv_msg(struct rpmsg_rcv_msg *rcv_msg, uint32_t exp_num)
+static int rpmsg_check_rcv_msg(struct rpmsg_rcv_msg *msg, uint32_t exp_num)
 {
 	int i, ret = RPMSG_SUCCESS;
-	struct _payload *r_payload = rcv_msg->payload;
+	struct _payload *r_payload = msg->payload;
 
 	if (r_payload->num != exp_num) {
 		LPERROR("Invalid message number received %ld, expected %d\r\n",
@@ -67,7 +67,7 @@ static int rpmsg_check_rcv_msg(struct rpmsg_rcv_msg *rcv_msg, uint32_t exp_num)
 		}
 	}
 out:
-	rpmsg_release_rx_buffer(rcv_msg->ept, r_payload);
+	rpmsg_release_rx_buffer(msg->ept, r_payload);
 
 	return ret;
 }

--- a/apps/tests/msg/rpmsg-nocopy-ping.c
+++ b/apps/tests/msg/rpmsg-nocopy-ping.c
@@ -48,10 +48,10 @@ static int ept_deleted;
 extern int init_system(void);
 extern void cleanup_system(void);
 
-static int rpmsg_check_rcv_msg(struct rpmsg_rcv_msg *rcv_msg, uint32_t exp_num)
+static int rpmsg_check_rcv_msg(struct rpmsg_rcv_msg *msg, uint32_t exp_num)
 {
 	int i, ret = RPMSG_SUCCESS;
-	struct _payload *r_payload = rcv_msg->payload;
+	struct _payload *r_payload = msg->payload;
 
 	if (r_payload->num != exp_num) {
 		LPERROR("Invalid message number received %ld, expected %d\r\n",
@@ -75,7 +75,7 @@ static int rpmsg_check_rcv_msg(struct rpmsg_rcv_msg *rcv_msg, uint32_t exp_num)
 		}
 	}
 out:
-	rpmsg_release_rx_buffer(rcv_msg->ept, r_payload);
+	rpmsg_release_rx_buffer(msg->ept, r_payload);
 
 	return ret;
 }


### PR DESCRIPTION
Based on https://github.com/OpenAMP/open-amp/pull/439

- Fix shadows warning in applications.
- Add new build flags to highlight warnings and treat warnings as an errors