### PR TITLE
virtio-mmio: hypervisorless mode

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -84,10 +84,16 @@ if (NOT WITH_VIRTIO_DEVICE AND NOT WITH_VIRTIO_SLAVE)
 endif (NOT WITH_VIRTIO_DEVICE AND NOT WITH_VIRTIO_SLAVE)
 
 option (WITH_VIRTIO_MMIO "Build with virtio mmio (front end) enabled" ON)
+option (WITH_HVL_VIRTIO "Build with hypervisor-less virtio (front end) enabled" OFF)
 
 if (WITH_VIRTIO_MMIO)
   add_definitions(-DWITH_VIRTIO_MMIO)
 endif (WITH_VIRTIO_MMIO)
+
+if (WITH_HVL_VIRTIO)
+  set (WITH_VIRTIO_MMIO ON)
+  add_definitions(-DHVL_VIRTIO)
+endif (WITH_HVL_VIRTIO)
 
 option (WITH_DCACHE_VRINGS "Build with vrings cache operations enabled" OFF)
 

--- a/lib/include/openamp/virtio_mmio_hvl.h
+++ b/lib/include/openamp/virtio_mmio_hvl.h
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2022 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef OPENAMP_VIRTIO_MMIO_HVL_H
+#define OPENAMP_VIRTIO_MMIO_HVL_H
+
+#include <openamp/virtqueue.h>
+#include <openamp/virtio.h>
+#include <metal/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(HVL_VIRTIO)
+
+/*
+ * To minimize the number of hardware notification channels used, in hypervirsorless virtio
+ * deployments, a single multiplexed source of notifications is used for all the devices.
+ * The callback framework allows individual device drivers, if needed, to register their
+ * own callbacks (i.e. the equivalent of per-device ISRs)
+ */
+
+/* Max number of hypervisorless virtio callbacks */
+#define VIRTIO_MMIO_HVL_CB_MAX 10
+
+/*
+ * For multi-virtqueue devices in hypervisorless mode, a custom configuration acknowledgment
+ * mechanism is used to process same-register configuration entries like QUEUE_PFN. This is
+ * the ACK value from the physical machine monitor for these configurations.
+ */
+#define VIRTIO_MMIO_HVL_CFG_ACK 0xAABBAABB
+
+/* Hypervisorless virtio callback type */
+typedef void (*virtio_mmio_hvl_cb_t)(void *);
+
+/* Hypervisorless virtio inter-processor notification routine type */
+typedef void (*virtio_mmio_hvl_ipi_t)(void *);
+
+struct vq_bounce_buf {
+	struct metal_list node;
+	void *cookie;
+	uint64_t addr;
+	uint32_t len;
+};
+
+/**
+ * @brief VIRTIO MMIO hypervisorless operation mode initialization
+ *
+ * @param[in] vdev Pointer to struct virtio_device.
+ *
+ * @return N/A.
+ */
+
+void virtio_mmio_hvl_init(struct virtio_device *vdev);
+
+/**
+ * @brief VIRTIO MMIO shared memory pool initialization routine.
+ *
+ * @param[in] mem Pointer to memory.
+ * @param[in] size Size of memory region in bytes.
+ *
+ * @return N/A.
+ */
+
+void virtio_mmio_shm_pool_init(void *mem, size_t size);
+
+/**
+ * @brief VIRTIO MMIO shared memory pool buffer allocation routine.
+ *
+ * @param[in] size Number of bytes requested.
+ *
+ * @return pointer to allocated memory space in shared memory region.
+ */
+
+void *virtio_mmio_shm_pool_alloc(size_t size);
+
+/**
+ * @brief VIRTIO MMIO shared memory pool buffer deallocation routine.
+ *
+ * @param[in] ptr Pointer to memory space to free.
+ *
+ * @return N/A.
+ */
+
+void virtio_mmio_shm_pool_free(void *ptr);
+
+/**
+ * @brief VIRTIO MMIO (hypervisorless mode) inter-processor notification routine
+ *
+ * @return N/A.
+ */
+
+void virtio_mmio_hvl_ipi(void);
+
+/**
+ * @brief VIRTIO MMIO (hypervisorless mode) wait routine.
+ *
+ * @param[in] usec Number of microseconds to wait.
+ *
+ * @return N/A.
+ */
+
+void virtio_mmio_hvl_wait(uint32_t usec);
+
+/**
+ * @brief Add VIRTIO MMIO (hypervisorless mode) callback.
+ *
+ * @param[in] func Callback function pointer.
+ * @param[in] arg  Callback parameter.
+ *
+ * @return int 0 for success.
+ */
+
+int virtio_mmio_hvl_cb_set(virtio_mmio_hvl_cb_t func, void *arg);
+
+/**
+ * @brief VIRTIO MMIO (hypervisorless mode) callback execution routine.
+ *
+ * @return N/A
+ */
+
+void virtio_mmio_hvl_cb_run(void);
+
+/**
+ * @brief Add VIRTIO MMIO (hypervisorless mode) shared-memory bounce buffer.
+ *
+ * In hypervisorless mode this routine transparently allocates a bounce buffer
+ * to be enqueued in vring for consumption, copies the data in the original
+ * buffer and  saves the original buffer information for dequeueing.
+ * If the buffer is already in the pre-shared memory region, the bouncing
+ * mechanism is not used.
+ *
+ * @param[in] vq     Pointer to VirtIO queue control block.
+ * @param[in] cookie Pointer to hold call back data
+ * @param[in] buffer Data buffer
+ * @param[in] len    Data buffer length
+ *
+ * @return bounce buffer physical address or METAL_BAD_PHYS
+ */
+
+uint64_t virtio_mmio_hvl_add_bounce_buf(struct virtqueue *vq, void *cookie, char *buffer,
+					unsigned int len);
+
+/**
+ * @brief Get used VIRTIO MMIO (hypervisorless mode) shared-memory bounce buffer.
+ *
+ * In hypervisorless mode this routine transparently copies data from a dequeued
+ * bounce buffer in pre-shared memory to the original buffer location.
+ *
+ * @param[in] vq     Pointer to VirtIO queue control block.
+ * @param[in] dp     Pointer to vring descriptor.
+ * @param[in] cookie Pointer for callback data
+ *
+ * @return N/A
+ */
+
+void virtio_mmio_hvl_get_bounce_buf(struct virtqueue *vq, struct vring_desc *dp,
+				    void *cookie);
+
+/**
+ * @brief Wait for configuration ack, i.e. value at offset to match data
+ *
+ * @return int 0 for success
+ */
+
+int virtio_mmio_hvl_wait_cfg(struct virtio_device *vdev, int offset, uint32_t data);
+
+/**
+ * @brief Set inter-processor notification routine
+ *
+ * @param[in] vdev     Pointer to virtio_device structure
+ * @param[in] ipi_func Inter-processor notification routine
+ * @param[in] param    Inter-processor notification routine parameter
+ *
+ * @return N/A
+ */
+void virtio_mmio_hvl_set_ipi(struct virtio_device *vdev, virtio_mmio_hvl_ipi_t ipi_func,
+			     void *param);
+
+#endif /* defined(HVL_VIRTIO) */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OPENAMP_VIRTIO_MMIO_HVL_H */

--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -12,6 +12,9 @@
 #include <metal/log.h>
 #include <metal/alloc.h>
 #include <metal/cache.h>
+#if defined(HVL_VIRTIO)
+#include <openamp/virtio_mmio_hvl.h>
+#endif
 
 /* Prototype for internal functions. */
 static void vq_ring_init(struct virtqueue *, void *, int);
@@ -211,6 +214,11 @@ void *virtqueue_get_buffer(struct virtqueue *vq, uint32_t *len, uint16_t *idx)
 	vq_ring_free_chain(vq, desc_idx);
 
 	cookie = vq->vq_descx[desc_idx].cookie;
+
+#if defined(HVL_VIRTIO)
+	virtio_mmio_hvl_get_bounce_buf(vq, &vq->vq_ring.desc[desc_idx], cookie);
+#endif
+
 	vq->vq_descx[desc_idx].cookie = NULL;
 
 	if (idx)
@@ -523,6 +531,14 @@ static uint16_t vq_ring_add_buffer(struct virtqueue *vq,
 	struct vring_desc *dp;
 	int i, needed;
 	uint16_t idx;
+#if defined(HVL_VIRTIO)
+	uint64_t addr = 0;
+	struct vq_desc_extra *dxp = NULL;
+	void *cookie = NULL;
+
+	dxp = &vq->vq_descx[head_idx];
+	cookie = dxp->cookie;
+#endif
 
 	(void)vq;
 
@@ -548,6 +564,12 @@ static uint16_t vq_ring_add_buffer(struct virtqueue *vq,
 		if (i >= readable)
 			dp->flags |= VRING_DESC_F_WRITE;
 
+#if defined(HVL_VIRTIO)
+		addr = virtio_mmio_hvl_add_bounce_buf(vq, cookie, buf_list[i].buf, buf_list[i].len);
+		if (addr != 0) {
+			dp->addr = addr;
+		}
+#endif
 		/*
 		 * Instead of flushing the whole desc region, we flush only the
 		 * single entry hopefully saving some cycles

--- a/lib/virtio_mmio/CMakeLists.txt
+++ b/lib/virtio_mmio/CMakeLists.txt
@@ -1,4 +1,5 @@
 collect (PROJECT_LIB_SOURCES virtio_mmio.c)
+collect (PROJECT_LIB_SOURCES virtio_mmio_hvl.c)
 collect (PROJECT_LIB_SOURCES virtio_rng.c)
 collect (PROJECT_LIB_SOURCES virtio_net.c)
 collect (PROJECT_LIB_SOURCES virtio_serial.c)

--- a/lib/virtio_mmio/virtio_mmio_hvl.c
+++ b/lib/virtio_mmio/virtio_mmio_hvl.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2022 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * $FreeBSD$
+ */
+
+#if defined(HVL_VIRTIO)
+
+#include <openamp/open_amp.h>
+#include <openamp/virtqueue.h>
+#include <openamp/virtio.h>
+#include <openamp/virtio_mmio.h>
+#include <openamp/virtio_mmio_hvl.h>
+#include <metal/device.h>
+#include <metal/sleep.h>
+
+/*
+ * The implementation depends on OS-specific services for memory pool management
+ * routines, blocking wait and IPI.
+ * TODO: Replace them in a future iteration of the hypervisorless virtio feature
+ * set with APIs (to be introduced) in libmetal.
+ */
+
+/* weak symbols */
+void virtio_mmio_shm_pool_init(void *mem, size_t size) __attribute__((weak));
+void *virtio_mmio_shm_pool_alloc(size_t size) __attribute__((weak));
+void virtio_mmio_shm_pool_free(void *ptr) __attribute__((weak));
+void virtio_mmio_hvl_ipi(void) __attribute__((weak));
+void virtio_mmio_hvl_wait(uint32_t usec) __attribute__((weak));
+
+/* hypervisorless virtio callback framework */
+static virtio_mmio_hvl_cb_t _cb_funcs[VIRTIO_MMIO_HVL_CB_MAX];
+static void *_cb_args[VIRTIO_MMIO_HVL_CB_MAX];
+static int _num_cb_funcs;
+
+/* pre-shared memory */
+uint32_t __shmem0_pool_start __attribute__((weak));
+uint32_t __shmem0_end __attribute__((weak));
+
+static void virtio_mmio_hvl_ipi_wrap(void *param)
+{
+	(void)param;
+	virtio_mmio_hvl_ipi();
+}
+
+void virtio_mmio_hvl_init(struct virtio_device *vdev)
+{
+	static int init;
+	uint32_t *shmem_pool_mem = NULL;
+	uint32_t shmem_pool_size = 0;
+
+	if (!init) {
+		shmem_pool_mem = &__shmem0_pool_start;
+		if (shmem_pool_mem != 0) {
+			shmem_pool_size = ((uintptr_t)&__shmem0_end -
+					   (uintptr_t)&__shmem0_pool_start);
+			virtio_mmio_shm_pool_init(shmem_pool_mem, shmem_pool_size);
+			init = 1;
+		}
+	}
+	if (vdev) {
+		virtio_mmio_hvl_set_ipi(vdev, virtio_mmio_hvl_ipi_wrap, NULL);
+	}
+}
+
+int virtio_mmio_hvl_cb_set(virtio_mmio_hvl_cb_t func, void *arg)
+{
+	if (_num_cb_funcs < VIRTIO_MMIO_HVL_CB_MAX - 1) {
+		_cb_funcs[_num_cb_funcs] = func;
+		_cb_args[_num_cb_funcs] = arg;
+		_num_cb_funcs++;
+		return 0;
+	}
+	return -1;
+}
+
+void virtio_mmio_hvl_cb_run(void)
+{
+	int i = 0;
+
+	for (i = 0; i < _num_cb_funcs; i++) {
+		if (_cb_funcs[i] != NULL) {
+			_cb_funcs[i](_cb_args[i]);
+		}
+	}
+}
+
+/* weak symbols */
+void virtio_mmio_shm_pool_init(void *mem, size_t size)
+{
+	(void)mem;
+	(void)size;
+}
+
+void *virtio_mmio_shm_pool_alloc(size_t size)
+{
+	(void)size;
+	return NULL;
+}
+
+void virtio_mmio_shm_pool_free(void *ptr)
+{
+	(void)ptr;
+}
+
+void virtio_mmio_hvl_ipi(void) {}
+
+void virtio_mmio_hvl_wait(uint32_t usec)
+{
+	(void)usec;
+}
+
+int virtio_mmio_hvl_wait_cfg(struct virtio_device *vdev, int offset, uint32_t data)
+{
+	uint32_t val;
+	struct virtio_mmio_device *vmdev = metal_container_of(vdev,
+							      struct virtio_mmio_device, vdev);
+
+	val = metal_io_read32(vmdev->cfg_io, offset);
+
+	if (val == data) {
+		return 0;
+	}
+
+	virtio_mmio_hvl_wait(4000000);
+
+	val = metal_io_read32(vmdev->cfg_io, offset);
+	if (val == data) {
+		return 0;
+}
+
+	return -1;
+}
+
+
+int virtio_mmio_hvl_wait_cfg_ptr(uint32_t *ptr, uint32_t data)
+{
+	if (*ptr == data) {
+		return 0;
+	}
+
+	virtio_mmio_hvl_wait(4000000);
+
+	if (*ptr == data) {
+		return 0;
+	}
+
+	return -1;
+}
+
+uint64_t virtio_mmio_hvl_add_bounce_buf(struct virtqueue *vq, void *cookie, char *buffer,
+					unsigned int len)
+{
+	struct vq_bounce_buf *bb = NULL;
+	uint64_t addr = 0;
+	char *buf = NULL;
+	struct virtio_mmio_device *vmdev = NULL;
+
+	if (!vq || !cookie || !buffer || (len == 0))
+		return 0;
+
+	vmdev = metal_container_of(vq->vq_dev, struct virtio_mmio_device, vdev);
+
+	if (vmdev && (vmdev->hvl_mode == 1)) {
+		/* check if buffer is already in pre-shared shared memory */
+		addr = metal_io_virt_to_phys(vq->shm_io, buffer);
+		if (addr != METAL_BAD_PHYS) {
+			return addr;
+		}
+
+		buf = virtio_mmio_shm_pool_alloc(len);
+		if (buf != NULL) {
+			memcpy(buf, buffer, len);
+			addr = metal_io_virt_to_phys(vq->shm_io, buf);
+			bb = virtio_mmio_shm_pool_alloc(sizeof(struct vq_bounce_buf));
+			if (bb != NULL) {
+				bb->addr = (uintptr_t)buffer;
+				bb->len = len;
+				bb->cookie = cookie;
+				metal_list_add_tail(&vmdev->bounce_buf_list, &bb->node);
+				return addr;
+			}
+			virtio_mmio_shm_pool_free(buf);
+		}
+	}
+
+	return 0;
+}
+
+void virtio_mmio_hvl_get_bounce_buf(struct virtqueue *vq, struct vring_desc *dp, void *cookie)
+{
+	struct vq_bounce_buf *bb = NULL;
+	struct metal_list *node = NULL;
+	struct virtio_mmio_device *vmdev = NULL;
+
+	VIRTIO_ASSERT(vq != NULL, "Invalid virtqueue");
+	VIRTIO_ASSERT(dp != NULL, "Invalid vring descriptor");
+	VIRTIO_ASSERT(cookie != NULL, "Invalid cookie");
+
+	vmdev = metal_container_of(vq->vq_dev, struct virtio_mmio_device, vdev);
+
+	if (vmdev && (vmdev->hvl_mode == 1)) {
+		metal_list_for_each(&vmdev->bounce_buf_list, node) {
+			bb = metal_container_of(node, struct vq_bounce_buf, node);
+			if (bb->cookie == cookie) {
+				memcpy((void *)(uintptr_t)bb->addr,
+				       (void *)(metal_io_phys_to_virt(vq->shm_io, dp->addr)),
+				       dp->len);
+				metal_list_del(node);
+				virtio_mmio_shm_pool_free(bb);
+				virtio_mmio_shm_pool_free(
+					(void *)(metal_io_phys_to_virt(vq->shm_io, dp->addr)));
+				break;
+			}
+		}
+	}
+}
+
+void virtio_mmio_hvl_set_ipi(struct virtio_device *vdev, virtio_mmio_hvl_ipi_t ipi_func,
+			     void *param)
+{
+	struct virtio_mmio_device *vmdev = metal_container_of(vdev,
+							      struct virtio_mmio_device, vdev);
+
+	vmdev->ipi = ipi_func;
+	vmdev->ipi_param = param;
+}
+
+#endif /* defined(HVL_VIRTIO) */
+


### PR DESCRIPTION
OpenAMP library support for VIRTIO MMIO network, entropy and console in hypervisorless VIRTIO operation mode.

Validated using Zephyr environment based on https://github.com/OpenAMP/openamp-zephyr-staging/tree/virtio-exp.
Build tools for complete hypervisorless virtio system (Xilinx ZCU 102) are available here: https://github.com/danmilea/hypervisorless_virtio_zcu102/

Additional hypervisorless virtio information:
https://github.com/danmilea/hypervisorless_virtio_zcu102/blob/main/README_hypervisorless_virtio.md