### PR TITLE
open-amp: fix compile warning

### DIFF
--- a/lib/remoteproc/rsc_table_parser.c
+++ b/lib/remoteproc/rsc_table_parser.c
@@ -126,10 +126,10 @@ int handle_vendor_rsc(struct remoteproc *rproc, void *rsc)
 
 int handle_vdev_rsc(struct remoteproc *rproc, void *rsc)
 {
+	struct fw_rsc_vdev_vring *vring_rsc;
 	struct fw_rsc_vdev *vdev_rsc = rsc;
 	int i, num_vrings;
 	unsigned int notifyid;
-	struct fw_rsc_vdev_vring *vring_rsc;
 
 	/* only assign notification IDs but do not initialize vdev */
 	notifyid = vdev_rsc->notifyid;
@@ -144,8 +144,6 @@ int handle_vdev_rsc(struct remoteproc *rproc, void *rsc)
 
 	num_vrings = vdev_rsc->num_of_vrings;
 	for (i = 0; i < num_vrings; i++) {
-		struct fw_rsc_vdev_vring *vring_rsc;
-
 		vring_rsc = &vdev_rsc->vring[i];
 		notifyid = vring_rsc->notifyid;
 		notifyid = remoteproc_allocate_id(rproc,


### PR DESCRIPTION
open-amp: fix compile warning

```
open-amp/lib/remoteproc/rsc_table_parser.c: In function ‘handle_vdev_rsc’: open-amp/lib/remoteproc/rsc_table_parser.c:147:43: warning: declaration of ‘vring_rsc’ shadows a previous local [-Wshadow]
  147 |                 struct fw_rsc_vdev_vring *vring_rsc;
      |                                           ^~~~~~~~~
open-amp/lib/remoteproc/rsc_table_parser.c:132:35: note: shadowed declaration is here
  132 |         struct fw_rsc_vdev_vring *vring_rsc;
      |
```

Signed-off-by: chao an <anchao@xiaomi.com>