### PR TITLE
CI: fix Zephyr build issue resulting from the introduction of sysbuild

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -96,13 +96,13 @@ build_zephyr(){
 	cd ./zephyr || exit 1
 	source zephyr-env.sh || exit 1
 	echo  "build openamp sample"
-	west build -b lpcxpresso54114_m4 samples/subsys/ipc/openamp/ || exit 1
+	west build --sysbuild -b lpcxpresso54114_m4 samples/subsys/ipc/openamp/ || exit 1
 	rm -r build
 	echo  "build openamp/remote sample"
-	west build -b lpcxpresso54114_m0 samples/subsys/ipc/openamp/remote/ || exit 1
+	west build  --sysbuild -b lpcxpresso54114_m0 samples/subsys/ipc/openamp/remote/ || exit 1
 	rm -r build
 	echo  "build openamp_rsc_table sample"
-	west build -b stm32mp157c_dk2 samples/subsys/ipc/openamp_rsc_table || exit 1
+	west build  --sysbuild -b stm32mp157c_dk2 samples/subsys/ipc/openamp_rsc_table || exit 1
 	exit 0
 }
 


### PR DESCRIPTION
"Sysbuild is a higher-level build system that can be used to combine multiple other build systems together"

Add the option by default for all platform as it is compatible with a single image.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>