### PR TITLE
openamp: fix remoteproc_load_noblock hasn't update rsc_io

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -847,6 +847,7 @@ int remoteproc_load_noblock(struct remoteproc *rproc,
 			}
 			rproc->rsc_table = rsc_table;
 			rproc->rsc_len = rsc_size;
+			rproc->rsc_io = *io;
 			metal_free_memory(lrsc_table);
 		}
 


### PR DESCRIPTION
Signed-off-by: Ben Levinsky <ben.levinsky@amd.com>