### PR TITLE
BUG FIX: rpmsg: add cache flush when hold rx buffer

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -93,6 +93,11 @@ static void rpmsg_virtio_return_buffer(struct rpmsg_virtio_device *rvdev,
 				       uint16_t idx)
 {
 	unsigned int role = rpmsg_virtio_get_role(rvdev);
+
+#ifdef VIRTIO_CACHED_BUFFERS
+	metal_cache_invalidate(buffer, len);
+#endif
+
 #ifndef VIRTIO_DEVICE_ONLY
 	if (role == RPMSG_HOST) {
 		struct virtqueue_buf vqbuf;


### PR DESCRIPTION
rpmsg: add cache flush when hold rx buffer

Here is the bug:

Assume we have 2 cpus, and use cached shram buffer

```
CPU0                        CPU1

1. send tx bufferX  
                              2. recv rx bufferX  
                              3. set idx to hdr->reserved 
                              4. handled rx bufferX 
                              5. return bufferX
6. reuse tx bufferX 
                              7. dirty cache auto flushed cause by step 3, hdr changed by CPU1
8. bufferX meet error
```

So, can we use the cache flush to resolve the issue or other ways ?