### PR TITLE
BUGFIX: rpmsg: do cache_invalidate() when real data returned

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -244,7 +244,8 @@ static void *rpmsg_virtio_get_rx_buffer(struct rpmsg_virtio_device *rvdev,
 
 #ifdef VIRTIO_CACHED_BUFFERS
 	/* Invalidate the buffer before returning it */
-	metal_cache_invalidate(data, *len);
+	if (data)
+		metal_cache_invalidate(data, *len);
 #endif /* VIRTIO_CACHED_BUFFERS */
 
 	return data;


### PR DESCRIPTION

rpmsg: do cache_invalidate() when real data returned