### PR TITLE
zynq7, microblaze resource table: virtio notifyid

### DIFF
--- a/apps/machine/microblaze_generic/rsc_table.c
+++ b/apps/machine/microblaze_generic/rsc_table.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2020-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -42,7 +43,7 @@ struct remote_resource_table __resource resources = {
 
 	/* Virtio device entry */
 	{
-	 RSC_VDEV, VIRTIO_ID_RPMSG, 0, RPMSG_VDEV_DFEATURES, 0, 0, 0,
+	 RSC_VDEV, VIRTIO_ID_RPMSG_, 31, RPMSG_VDEV_DFEATURES, 0, 0, 0,
 	 NUM_VRINGS, {0, 0},
 	 },
 

--- a/apps/machine/zynq7/rsc_table.c
+++ b/apps/machine/zynq7/rsc_table.c
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2014, Mentor Graphics Corporation
  * All rights reserved.
- * Copyright (c) 2015 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2015-2022 Xilinx, Inc. All rights reserved.
+ * Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -51,7 +52,7 @@ struct remote_resource_table __resource resources = {
 
 	/* Virtio device entry */
 	{
-	 RSC_VDEV, VIRTIO_ID_RPMSG_, 0, RPMSG_VDEV_DFEATURES, 0, 0, 0,
+	 RSC_VDEV, VIRTIO_ID_RPMSG_, 31, RPMSG_VDEV_DFEATURES, 0, 0, 0,
 	 NUM_VRINGS, {0, 0},
 	},
 


### PR DESCRIPTION
The open-amp apps are failing on zynq7 with "Failed to initialize remoteproc" after v2022.10.0 update.
Port commit 46d041808804 ("zynqmp_r5 resource table: Change notifyid for the virtio device.") to zynq7 and microblaze.