### PR TITLE
CI: update checkout action to V3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout open-amp
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Checkout libmetal
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: OpenAMP/libmetal
         path: libmetal


### PR DESCRIPTION
Node.js 12 actions are deprecated. Use the checkout V3 action to use Node.js 16