### PR TITLE
virtio: follow virtio 1.2 spec, add more virtio status and device id

### DIFF
--- a/lib/include/openamp/virtio.h
+++ b/lib/include/openamp/virtio.h
@@ -15,23 +15,55 @@ extern "C" {
 #endif
 
 /* VirtIO device IDs. */
-#define VIRTIO_ID_NETWORK    0x01UL
-#define VIRTIO_ID_BLOCK      0x02UL
-#define VIRTIO_ID_CONSOLE    0x03UL
-#define VIRTIO_ID_ENTROPY    0x04UL
-#define VIRTIO_ID_BALLOON    0x05UL
-#define VIRTIO_ID_IOMEMORY   0x06UL
-#define VIRTIO_ID_RPMSG      0x07UL /* remote processor messaging */
-#define VIRTIO_ID_SCSI       0x08UL
-#define VIRTIO_ID_9P         0x09UL
-#define VIRTIO_DEV_ANY_ID    (-1)UL
+#define VIRTIO_ID_NETWORK        1UL
+#define VIRTIO_ID_BLOCK          2UL
+#define VIRTIO_ID_CONSOLE        3UL
+#define VIRTIO_ID_ENTROPY        4UL
+#define VIRTIO_ID_BALLOON        5UL
+#define VIRTIO_ID_IOMEMORY       6UL
+#define VIRTIO_ID_RPMSG          7UL /* remote processor messaging */
+#define VIRTIO_ID_SCSI           8UL
+#define VIRTIO_ID_9P             9UL
+#define VIRTIO_ID_MAC80211_WLAN  10UL
+#define VIRTIO_ID_RPROC_SERIAL   11UL
+#define VIRTIO_ID_CAIF           12UL
+#define VIRTIO_ID_MEMORY_BALLOON 13UL
+#define VIRTIO_ID_GPU            16UL
+#define VIRTIO_ID_CLOCK          17UL
+#define VIRTIO_ID_INPUT          18UL
+#define VIRTIO_ID_VSOCK          19UL
+#define VIRTIO_ID_CRYPTO         20UL
+#define VIRTIO_ID_SIGNAL_DIST    21UL
+#define VIRTIO_ID_PSTORE         22UL
+#define VIRTIO_ID_IOMMU          23UL
+#define VIRTIO_ID_MEM            24UL
+#define VIRTIO_ID_SOUND          25UL
+#define VIRTIO_ID_FS             26UL
+#define VIRTIO_ID_PMEM           27UL
+#define VIRTIO_ID_RPMB           28UL
+#define VIRTIO_ID_MAC80211_HWSIM 29UL
+#define VIRTIO_ID_VIDEO_ENCODER  30UL
+#define VIRTIO_ID_VIDEO_DECODER  31UL
+#define VIRTIO_ID_SCMI           32UL
+#define VIRTIO_ID_NITRO_SEC_MOD  33UL
+#define VIRTIO_ID_I2C_ADAPTER    34UL
+#define VIRTIO_ID_WATCHDOG       35UL
+#define VIRTIO_ID_CAN            36UL
+#define VIRTIO_ID_PARAM_SERV     38UL
+#define VIRTIO_ID_AUDIO_POLICY   39UL
+#define VIRTIO_ID_BT             40UL
+#define VIRTIO_ID_GPIO           41UL
+#define VIRTIO_ID_RDMA           42UL
+#define VIRTIO_DEV_ANY_ID        -1UL
 
 /* Status byte for guest to report progress. */
-#define VIRTIO_CONFIG_STATUS_ACK       0x01
-#define VIRTIO_CONFIG_STATUS_DRIVER    0x02
-#define VIRTIO_CONFIG_STATUS_DRIVER_OK 0x04
+#define VIRTIO_CONFIG_STATUS_RESET       0x00
+#define VIRTIO_CONFIG_STATUS_ACK         0x01
+#define VIRTIO_CONFIG_STATUS_DRIVER      0x02
+#define VIRTIO_CONFIG_STATUS_DRIVER_OK   0x04
+#define VIRTIO_CONFIG_FEATURES_OK        0x08
 #define VIRTIO_CONFIG_STATUS_NEEDS_RESET 0x40
-#define VIRTIO_CONFIG_STATUS_FAILED    0x80
+#define VIRTIO_CONFIG_STATUS_FAILED      0x80
 
 /* Virtio device role */
 #define VIRTIO_DEV_DRIVER	0UL

--- a/lib/virtio/virtio.c
+++ b/lib/virtio/virtio.c
@@ -26,6 +26,17 @@ static const struct virtio_ident {
 	VIRTIO_ID_IOMEMORY, "IOMemory"}, {
 	VIRTIO_ID_SCSI, "SCSI"}, {
 	VIRTIO_ID_9P, "9P Transport"}, {
+	VIRTIO_ID_MAC80211_WLAN, "MAC80211 WLAN"}, {
+	VIRTIO_ID_RPROC_SERIAL, "Remoteproc Serial"}, {
+	VIRTIO_ID_GPU, "GPU"}, {
+	VIRTIO_ID_INPUT, "Input"}, {
+	VIRTIO_ID_VSOCK, "Vsock Transport"}, {
+	VIRTIO_ID_SOUND, "Sound"}, {
+	VIRTIO_ID_FS, "File System"}, {
+	VIRTIO_ID_MAC80211_HWSIM, "MAC80211 HWSIM"}, {
+	VIRTIO_ID_I2C_ADAPTER, "I2C Adapter"}, {
+	VIRTIO_ID_BT, "Bluetooth"}, {
+	VIRTIO_ID_GPIO, "GPIO" }, {
 	0, NULL}
 };
 


### PR DESCRIPTION
# Summay
Follow virtio v1.2 spec, add more virtio status and device id. I change the device id from hexadecimal to decimal, because the virtio v1.2 spec use decimal.

Make commit 1 in https://github.com/OpenAMP/open-amp/pull/489 be an independent PR.

# Impact
Should be none.