### PR TITLE
rpmsg: add release cb and refcnt in endpoint to fix ept used-after-free

### DIFF
--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -50,6 +50,7 @@ struct rpmsg_device;
 /* Returns positive value on success or negative error value on failure */
 typedef int (*rpmsg_ept_cb)(struct rpmsg_endpoint *ept, void *data,
 			    size_t len, uint32_t src, void *priv);
+typedef void (*rpmsg_ept_release_cb)(struct rpmsg_endpoint *ept);
 typedef void (*rpmsg_ns_unbind_cb)(struct rpmsg_endpoint *ept);
 typedef void (*rpmsg_ns_bind_cb)(struct rpmsg_device *rdev,
 				 const char *name, uint32_t dest);
@@ -72,6 +73,12 @@ struct rpmsg_endpoint {
 
 	/** Address of the default remote endpoint binded */
 	uint32_t dest_addr;
+
+	/** Reference count for determining whether the endpoint can be deallocated */
+	uint32_t refcnt;
+
+	/** Callback to inform the user that the endpoint allocation can be safely removed */
+	rpmsg_ept_release_cb release_cb;
 
 	/**
 	 * User rx callback, return value of this callback is reserved for future

--- a/lib/rpmsg/rpmsg_internal.h
+++ b/lib/rpmsg/rpmsg_internal.h
@@ -109,6 +109,31 @@ rpmsg_get_ept_from_addr(struct rpmsg_device *rdev, uint32_t addr)
 	return rpmsg_get_endpoint(rdev, NULL, addr, RPMSG_ADDR_ANY);
 }
 
+/**
+ * @internal
+ *
+ * @brief Increase the endpoint reference count
+ *
+ * This function is used to avoid calling ept_cb after release lock causes race condition
+ * it should be called under lock protection.
+ *
+ * @param ept	pointer to rpmsg endpoint
+ *
+ */
+void rpmsg_ept_incref(struct rpmsg_endpoint *ept);
+
+/**
+ * @internal
+ *
+ * @brief Decrease the end point reference count
+ *
+ * This function is used to avoid calling ept_cb after release lock causes race condition
+ * it should be called under lock protection.
+ *
+ * @param ept	pointer to rpmsg endpoint
+ */
+void rpmsg_ept_decref(struct rpmsg_endpoint *ept);
+
 #if defined __cplusplus
 }
 #endif


### PR DESCRIPTION
issue description:​

![4nOaD0QVZj](https://github.com/OpenAMP/open-amp/assets/75052707/cf4e8350-89e8-41ef-8c44-898232956140)

In our case, the` rpmsg_virtio_rx_callback()` is called in a rpmsg thread. Let's assume a situation, when `my_cb `has already got the ept in rpmsg thread,  user service thread just right called `my_deinit` to excute rpmsg_destroy_ept and released ept, at this time, the execution of ept ->cb has not been completed in rpmsg thread. so , there is a used after free about the ept.

Assuming we choose to fix this situation at the user level, we can continue to refer to the following examples:
```
void my_cb(...)
{
   atomic_fetch_add(&g_priv->refcnt, 1); // 2*
   ....
  if (atomic_fetch_sub(&g_priv->refcnt, 1) == 1) {
    rpmsg_destroy_ept(&g_priv->ept);
    free(g_priv);
  }
}

void my_init(void)
{
  g_priv = malloc(sizeof(*g_priv));
  atomic_init(&g_priv->refcnt, 1);
  g_priv->ept.cb = my_cb;
  rpmsg_create_ept(&g_priv->ept);
}

void my_deinit(void)
{
  if (atomic_fetch_sub(&g_priv->refcnt, 1) == 1) { // 1*
    rpmsg_destroy_ept(&g_priv->ept);
    free(g_priv);
  }
}
```
1. rpmsg_virtio_rx_callback release lock here: https://github.com/OpenAMP/open-amp/blob/cd8823876fb6920571abbeecc570a9da0cb546ba/lib/rpmsg/rpmsg_virtio.c#L561C1-L561C36
2. os decide to suspend rpmsg_virtio_rx_callback and switch to my_deinit
3. my_deinit finish execution and release g_priv(1*)
4. rpmsg_virtio_rx_callback resume and then happen use-after-free

The root cause is that OpenAMP call cb after release lock
Therefore, reference counting in the application layer cannot solve this race condition. Therefore, to avoid race condition, we added refnt to the endpoint and call the release callback when ept callback finished