### PR TITLE
virtio: make unused function virtio_describe() deprecated

### DIFF
--- a/lib/include/openamp/virtio.h
+++ b/lib/include/openamp/virtio.h
@@ -218,9 +218,10 @@ struct virtio_device {
  * Helper functions.
  */
 const char *virtio_dev_name(uint16_t devid);
-void virtio_describe(struct virtio_device *dev, const char *msg,
-		     uint32_t features,
-		     struct virtio_feature_desc *feature_desc);
+
+__deprecated void virtio_describe(struct virtio_device *dev, const char *msg,
+				  uint32_t features,
+				  struct virtio_feature_desc *feature_desc);
 
 /*
  * Functions for virtio device configuration as defined in Rusty Russell's

--- a/lib/virtio/virtio.c
+++ b/lib/virtio/virtio.c
@@ -83,8 +83,8 @@ static const char *virtio_feature_name(unsigned long val,
 	return NULL;
 }
 
-void virtio_describe(struct virtio_device *dev, const char *msg,
-		     uint32_t features, struct virtio_feature_desc *desc)
+__deprecated void virtio_describe(struct virtio_device *dev, const char *msg,
+				  uint32_t features, struct virtio_feature_desc *desc)
 {
 	(void)dev;
 	(void)msg;


### PR DESCRIPTION
The virtio_describe() function does not seem usable. Therefore, it should be marked as deprecated to initiate the removal process.