### PR TITLE
rpmsg: set ept address to incease num when alloc from the bitmap

### DIFF
--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -125,6 +125,7 @@ struct rpmsg_device {
 
 	/** Table endpoint address allocation */
 	unsigned long bitmap[metal_bitmap_longs(RPMSG_ADDR_BMP_SIZE)];
+	unsigned int bitnext;
 
 	/** Mutex lock for RPMsg management */
 	metal_mutex_t lock;


### PR DESCRIPTION
rpmsg: set ept address to incease num when alloc from the bitmap


    
    CPU0                                CPU1
    create_ept1:addr1                   create_ept1
    OK                       <======    msg1
    OK                       <======    msg2
    OK                       <======    msg3
                               msg4
                             <======    msg4 on the virtioqueue
    close_ept1                          close_ept1
    
    create_ept2:addr1                   create_ept1
    (same addr with ept1)
                               msg4
    ept2 recv ept1 msg ERROR <======


The msg4 which belong to ep1, error received by ept2.

For the issue, I give a resolve method,
for the rpmsg_get_address(), always return a new increased num.

This should compile with https://github.com/OpenAMP/libmetal/pull/263