### PR TITLE
Docs: style doxygen when built as part of OpenAMP docs

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,11 +1,23 @@
 if (DOXYGEN_FOUND)
 
-  configure_file (Doxyfile.in Doxyfile @ONLY)
+  if (EXISTS ${CMAKE_SOURCE_DIR}/../_doxygen/openamp/Doxyfile-openamp.in)
+    set (OAMP_DOX_DIR ${CMAKE_SOURCE_DIR}/../_doxygen/openamp)
+    configure_file (Doxyfile.in Doxyfile1 @ONLY)
+    configure_file (${OAMP_DOX_DIR}/Doxyfile-openamp.in Doxyfile2 @ONLY)
 
-  add_custom_target (doc ALL
-    ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  )
+    add_custom_target (doc ALL
+      COMMAND cat Doxyfile1 Doxyfile2 >Doxyfile
+      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+  else ()
+    configure_file (Doxyfile.in Doxyfile @ONLY)
+
+    add_custom_target (doc ALL
+      ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+  endif ()
 
 install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html
   DESTINATION share/doc/${PROJECT_NAME})


### PR DESCRIPTION
Detect when we are a submodule of OpenAMP-docs.
If so use the top level's Doxyfile overrides on top of our Doxyfile. If not, no change.