### PR TITLE
openamp: add new API rpmsg_virtio_get_rx_buffer_size()

### DIFF
--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -166,13 +166,37 @@ rpmsg_virtio_create_virtqueues(struct rpmsg_virtio_device *rvdev,
 }
 
 /**
- * @brief Get rpmsg virtio buffer size
+ * @brief Get rpmsg virtio Tx buffer size
  *
  * @param rdev	Pointer to the rpmsg device
  *
  * @return Next available buffer size for text, negative value for failure
  */
-int rpmsg_virtio_get_buffer_size(struct rpmsg_device *rdev);
+int rpmsg_virtio_get_tx_buffer_size(struct rpmsg_device *rdev);
+
+/**
+ * @brief  Get rpmsg virtio Rx buffer size
+ *
+ * @param rdev	Pointer to the rpmsg device
+ *
+ * @return Next available buffer size for text, negative value for failure
+ */
+int rpmsg_virtio_get_rx_buffer_size(struct rpmsg_device *rdev);
+
+/**
+ * @brief Get rpmsg virtio Tx buffer size
+ *
+ * This function is same as rpmsg_virtio_get_tx_buffer_size(), keep it here
+ * to maintain the forward compatibility.
+ *
+ * @param rdev	Pointer to the rpmsg device.
+ *
+ * @return Next available buffer size for text, negative value for failure.
+ */
+static inline int rpmsg_virtio_get_buffer_size(struct rpmsg_device *rdev)
+{
+	return rpmsg_virtio_get_tx_buffer_size(rdev);
+}
 
 /**
  * @brief Initialize rpmsg virtio device


### PR DESCRIPTION
With this API, user can get the rx buffer size, and use this buffer safer in endpoint callback function.
Follow shows an example:
```c
static int rpmsgfs_ept_cb(FAR struct rpmsg_endpoint *ept,
                          FAR void *data, size_t len, uint32_t src,
                          FAR void *priv)
{
    /* No need extra stack variable or malloced buffer, user can fill the response data in the data directly,
     * And to avoid the data overflow, user can call rpmsg_virtio_get_rx_buffer_size() to get the limitation
     * of input data.
     */

    /* Call rpmsg_send(ept, data, data_len) to send the response data */
    rpmsg_send(ept, data, len);
}
```