### PR TITLE
remoteproc: clear bitmap when stop/shutdown

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -256,6 +256,7 @@ int remoteproc_stop(struct remoteproc *rproc)
 			if (rproc->ops->stop)
 				ret = rproc->ops->stop(rproc);
 			rproc->state = RPROC_STOPPED;
+			rproc->bitmap = 0;
 		} else {
 			ret = 0;
 		}


### PR DESCRIPTION
remoteproc: clear bitmap in remoteproc_stop()
    
Fix parse res_table failed when repeat start the remoteproc.
If we don't clear the bitmap it will failed in
      handle_vdev_rsc() -> remoteproc_allocate_id()