### PR TITLE
rpmsg_virtio: fix rpmsg_service memory leak when stop remote

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -862,6 +862,8 @@ void rpmsg_deinit_vdev(struct rpmsg_virtio_device *rvdev)
 			node = rdev->endpoints.next;
 			ept = metal_container_of(node, struct rpmsg_endpoint, node);
 			rpmsg_destroy_ept(ept);
+			if (ept->ns_unbind_cb)
+				ept->ns_unbind_cb(ept);
 		}
 
 		rvdev->rvq = 0;


### PR DESCRIPTION
Rpmsg service may malloc memory in the rpmsg bind callback(): rdev->ns_bind_cb() When stop remote, the remote may not send RPMSG_NS_DESTROY message back (baceause the remote may has crashed), so call the unbind callback in rpmsg_deinit_vdev() to aviod potential memroy leak in rpmsg services.