### PR TITLE
openamp: change rx buffer hold flag to count

### DIFF
--- a/lib/rpmsg/rpmsg_internal.h
+++ b/lib/rpmsg/rpmsg_internal.h
@@ -28,7 +28,9 @@ extern "C" {
 #define RPMSG_ASSERT(_exp, _msg) metal_assert(_exp)
 #endif
 
-#define RPMSG_BUF_HELD (1U << 31) /* Flag to suggest to hold the buffer */
+/* Mask to get the rpmsg buffer held counter from rpmsg_hdr reserved field */
+#define RPMSG_BUF_HELD_SHIFT 16
+#define RPMSG_BUF_HELD_MASK  (0xFFFFU << RPMSG_BUF_HELD_SHIFT)
 
 #define RPMSG_LOCATE_HDR(p) \
 	((struct rpmsg_hdr *)((unsigned char *)(p) - sizeof(struct rpmsg_hdr)))


### PR DESCRIPTION
This commit fix one issue, before this commit, if `rpmsg_hold_rx_buffer()` is called in the endpoint callback to hold current received buffer and call` rpmsg_release_rx_buffer()` to release this buffer immediately.
This buffer will be returned to the virtqueue in `rpmsg_virtio_release_rx_buffer()` and returned to virtqueue again in `rpmsg_virtio_return_buffer()` after the `ept->cb()`.
So same buffer returned to the virtqueue twice, error happened.
Follow shows this process:

```
rpmsg_virtio_rx_callback()
  - get rp_hdr
  - ept->cb(data = RPMSG_LOCATE_DATA(rp_hdr))
    - rpsmg_hold_rx_buffer(data)
    - rpmsg_release_rx_buffer(data) here has returned buffer to virtqueue
  - rpmsg_virtio_return_buffer() return same buffer to virtqueue again
```

The root cause of this issue is that the RPMSG_BUF_HELD has been cleared in `rpmsg_release_rx_buffer()` so `rpmsg_virtio_rx_callback()` will treat this buffer is not HELD and call `rpmsg_virtio_return_buffer()` to return this buffer again.

This commit change the HELD flag in rp_hdr to count to fix this issue and also support hold/release rx buffer recursively.