### PR TITLE
openamp/rpmsg: fix rpmsg_service memory leak when stop remote

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -862,6 +862,8 @@ void rpmsg_deinit_vdev(struct rpmsg_virtio_device *rvdev)
 			node = rdev->endpoints.next;
 			ept = metal_container_of(node, struct rpmsg_endpoint, node);
 			rpmsg_destroy_ept(ept);
+			if (ept->ns_unbind_cb)
+				ept->ns_unbind_cb(ept);
 		}
 
 		rvdev->rvq = 0;


### PR DESCRIPTION
When remote cannot send destroy messages, master cannot call ns_unbind_cb, this will cause the master to be unable to release resources