### PR TITLE
virtio: Fix delete_virtqueues function

### DIFF
--- a/lib/include/openamp/virtio.h
+++ b/lib/include/openamp/virtio.h
@@ -298,18 +298,13 @@ int virtio_create_virtqueues(struct virtio_device *vdev, unsigned int flags,
  *
  * @param vdev	Pointer to virtio device structure.
  *
- * @return 0 on success, otherwise error code.
  */
-static inline int virtio_delete_virtqueues(struct virtio_device *vdev)
+static inline void virtio_delete_virtqueues(struct virtio_device *vdev)
 {
-	if (!vdev)
-		return -EINVAL;
-
-	if (!vdev->func || !vdev->func->delete_virtqueues)
-		return -ENXIO;
+	if (!vdev || !vdev->func || !vdev->func->delete_virtqueues)
+		return;
 
 	vdev->func->delete_virtqueues(vdev);
-	return 0;
 }
 
 /**


### PR DESCRIPTION
The function should return void. the reason is that vdev->func->delete_virtqueues() is optional and return void.

To be generic we should call virtio_delete_virtqueues in all cases. Then depending on the dispatcher we do nothing or call delete_virtqueues()

Fixes: 7f90610 ("virtio: add create_virtqueues and delete_virtqueues in virtio_dispatch")