### PR TITLE
github action: Fix stales action to not close PR/issue after 7 days

### DIFF
--- a/.github/workflows/stales.yml
+++ b/.github/workflows/stales.yml
@@ -24,3 +24,4 @@ jobs:
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true
         remove-pr-stale-when-updated: true
+        days-before-close: -1


### PR DESCRIPTION
By default the action closes the PR or issue 7 days after adding the stale label.

The expected behavior is that the pull requests and issues will never be closed automatically by the bot.