### PR TITLE
Fix https://github.com/OpenAMP/open-amp/issues/455

### DIFF
--- a/lib/service/rpmsg/rpc/rpmsg_rpc_client.c
+++ b/lib/service/rpmsg/rpc/rpmsg_rpc_client.c
@@ -81,8 +81,7 @@ void rpmsg_rpc_client_release(struct rpmsg_rpc_clt *rpc)
 {
 	if (!rpc)
 		return;
-	if (&rpc->ept)
-		rpmsg_destroy_ept(&rpc->ept);
+	rpmsg_destroy_ept(&rpc->ept);
 
 }
 


### PR DESCRIPTION
The if (&rpc->ept) comparison will always evaluate as 'true', since rpc == &rpc->ept and rpc is previously checked to be valid.

This produces an error when building open-amp with gcc >= 13.