### PR TITLE
apps: Add use of rpmsg_virtio_get_tx/rx_buffer_size API

### DIFF
--- a/apps/examples/echo/rpmsg-echo.c
+++ b/apps/examples/echo/rpmsg-echo.c
@@ -75,6 +75,10 @@ int app(struct rpmsg_device *rdev, void *priv)
 	}
 
 	LPRINTF("Successfully created rpmsg endpoint.\r\n");
+
+	LPRINTF("RPMsg device TX buffer size: %#x\r\n", rpmsg_virtio_get_tx_buffer_size(rdev));
+	LPRINTF("RPMsg device RX buffer size: %#x\r\n", rpmsg_virtio_get_rx_buffer_size(rdev));
+
 	while(1) {
 		platform_poll(priv);
 		/* we got a shutdown request, exit */

--- a/apps/examples/echo/rpmsg-ping.c
+++ b/apps/examples/echo/rpmsg-ping.c
@@ -88,7 +88,6 @@ static void rpmsg_name_service_bind_cb(struct rpmsg_device *rdev,
 				       RPMSG_ADDR_ANY, dest,
 				       rpmsg_endpoint_cb,
 				       rpmsg_service_unbind);
-
 }
 
 /*-----------------------------------------------------------------------------*
@@ -130,6 +129,9 @@ int app (struct rpmsg_device *rdev, void *priv)
 		metal_free_memory(i_payload);
 		return ret;
 	}
+
+	LPRINTF("RPMsg driver TX buffer size: %#x\r\n", rpmsg_virtio_get_tx_buffer_size(rdev));
+	LPRINTF("RPMsg driver RX buffer size: %#x\r\n", rpmsg_virtio_get_rx_buffer_size(rdev));
 
 	while (!is_rpmsg_ept_ready(&lept))
 		platform_poll(priv);

--- a/apps/tests/msg/rpmsg-ping.c
+++ b/apps/tests/msg/rpmsg-ping.c
@@ -128,12 +128,14 @@ int app (struct rpmsg_device *rdev, void *priv)
 	ret = rpmsg_create_ept(&lept, rdev, RPMSG_SERVICE_NAME,
 			       RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
 			       rpmsg_endpoint_cb, rpmsg_service_unbind);
-
 	if (ret) {
 		LPERROR("Failed to create RPMsg endpoint.\r\n");
 		metal_free_memory(i_payload);
 		return ret;
 	}
+
+	LPRINTF("RPMsg driver TX buffer size: %#x\r\n", rpmsg_virtio_get_tx_buffer_size(rdev));
+	LPRINTF("RPMsg driver RX buffer size: %#x\r\n", rpmsg_virtio_get_rx_buffer_size(rdev));
 
 	while (!is_rpmsg_ept_ready(&lept))
 		platform_poll(priv);


### PR DESCRIPTION
Print the max size of the RX and TX buffer payloads. This allows to test the new API implemented in #521 in the CI.
