### PR TITLE
remoteproc_virtio: initialize the virtio device id when create vdev

### DIFF
--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -254,6 +254,7 @@ rproc_virtio_create_vdev(unsigned int role, unsigned int notifyid,
 	rpvdev->vdev_rsc_io = rsc_io;
 
 	vdev->notifyid = notifyid;
+	vdev->id.device = vdev_rsc->id;
 	vdev->role = role;
 	vdev->reset_cb = rst_cb;
 	vdev->vrings_num = num_vrings;


### PR DESCRIPTION
Should init the device ID when create the virtio device.