### PR TITLE
remoteproc_virtio: add shm_io for remoteproc virtio

### DIFF
--- a/lib/include/openamp/remoteproc_virtio.h
+++ b/lib/include/openamp/remoteproc_virtio.h
@@ -50,6 +50,9 @@ struct remoteproc_virtio {
 	/** Metal I/O region of vdev_info, can be NULL */
 	struct metal_io_region *vdev_rsc_io;
 
+	/** Metal I/O region of vdev share memory */
+	struct metal_io_region *shm_io;
+
 	/** Notification function */
 	rpvdev_notify_func notify;
 
@@ -87,6 +90,17 @@ rproc_virtio_create_vdev(unsigned int role, unsigned int notifyid,
  * @param vdev	Pointer to the virtio device
  */
 void rproc_virtio_remove_vdev(struct virtio_device *vdev);
+
+/**
+ * @brief Set the remoteproc virtio device share memory I/O region
+ *
+ * @param vdev		Pointer to the virtio device
+ * @param shm_io	Metal I/O region to set
+ *
+ * @return 0 for success, negative value for failure.
+ */
+int rproc_virtio_set_shm_io(struct virtio_device *vdev,
+			    struct metal_io_region *shm_io);
 
 /**
  * @brief Initialize rproc virtio vring

--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -280,6 +280,20 @@ err0:
 	return NULL;
 }
 
+int rproc_virtio_set_shm_io(struct virtio_device *vdev,
+			    struct metal_io_region *shm_io)
+{
+	struct remoteproc_virtio *rpvdev;
+
+	if (!vdev || !shm_io)
+		return -RPROC_EINVAL;
+
+	rpvdev = metal_container_of(vdev, struct remoteproc_virtio, vdev);
+	rpvdev->shm_io = shm_io;
+
+	return 0;
+}
+
 void rproc_virtio_remove_vdev(struct virtio_device *vdev)
 {
 	struct remoteproc_virtio *rpvdev;


### PR DESCRIPTION
Now the rpmsg device need pass a share memory io region to rpmsg_init_vdev().
I think every virtio device need a share memory io to access the share memory and this region should be provided by the transport layer. Like the MMIO transport layer did in OpenAMP.

So I add shm_io in the remoteproc virtio device and also provide an API to set it.