### PR TITLE
Add missing include with EINVAL definition

### DIFF
--- a/lib/service/rpmsg/rpc/rpmsg_rpc_client.c
+++ b/lib/service/rpmsg/rpc/rpmsg_rpc_client.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <errno.h>
 #include <openamp/rpmsg_rpc_client_server.h>
 
 static int rpmsg_endpoint_client_cb(struct rpmsg_endpoint *, void *, size_t,

--- a/lib/service/rpmsg/rpc/rpmsg_rpc_server.c
+++ b/lib/service/rpmsg/rpc/rpmsg_rpc_server.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <errno.h>
 #include <openamp/rpmsg_rpc_client_server.h>
 
 #define LPERROR(format, ...) metal_log(METAL_LOG_ERROR, format, ##__VA_ARGS__)


### PR DESCRIPTION
Hi,

The following PR fixes open-amp compilation with Vitis 2023.2 for cortex-R5F core. The compilation process stops with two errors in `rpmsg_rpc_server.c` and rpmsg_rpc_client.c due to undeclared `EINVAL`.

Let me know if you have any suggestions on this patch or better ideas on how to fix this issue(maybe in libmetal).

Please see the logs attached. 


```
 /YOYO//workspace/ultra96_platform/psu_cortexr5_0/freertos_psu_cortexr5_0/bsp/include/xparameters.h:228: note: this is the location of the previous definition
       | 
 /YOYO//workspace/ultra96_platform/psu_cortexr5_0/freertos_psu_cortexr5_0/bsp/libsrc/openamp/src/lib/service/rpmsg/rpc/rpmsg_rpc_server.c: In function 'rpmsg_endpoint_server_cb':
[ERROR] /YOYO//workspace/ultra96_platform/psu_cortexr5_0/freertos_psu_cortexr5_0/bsp/libsrc/openamp/src/lib/service/rpmsg/rpc/rpmsg_rpc_server.c:61:25: error: 'EINVAL' undeclared (first use in this function)
       |                         ^~~~~~
 /YOYO//workspace/ultra96_platform/psu_cortexr5_0/freertos_psu_cortexr5_0/bsp/libsrc/openamp/src/lib/service/rpmsg/rpc/rpmsg_rpc_server.c:61:25: note: each undeclared identifier is reported only once for each function it appears in
 /YOYO//workspace/ultra96_platform/psu_cortexr5_0/freertos_psu_cortexr5_0/bsp/libsrc/openamp/src/lib/service/rpmsg/rpc/rpmsg_rpc_server.c: In function 'rpmsg_rpc_server_send':
[ERROR] /YOYO//workspace/ultra96_platform/psu_cortexr5_0/freertos_psu_cortexr5_0/bsp/libsrc/openamp/src/lib/service/rpmsg/rpc/rpmsg_rpc_server.c:88:25: error: 'EINVAL' undeclared (first use in this function)
     
```