### PR TITLE
lib: Add include directory to open_amp-static target

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,6 +61,7 @@ else (WITH_ZEPHYR)
   if (WITH_STATIC_LIB)
     set (_lib ${OPENAMP_LIB}-static)
     add_library (${_lib} STATIC ${_sources})
+    target_include_directories(${_lib} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
     install (TARGETS ${_lib} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     set_target_properties (${_lib} PROPERTIES
       OUTPUT_NAME       "${OPENAMP_LIB}"


### PR DESCRIPTION
Hi,

The following PR adds include directory in the open_amp-static target, enabling building and linking static library using CMake subdirectory. This allows to have open_amp library as git submodule and build it with the parent project as cmake dependency.

For example:

```
add_subdirectory(open-amp)


target_link_libraries(main_app
    PUBLIC
    open_amp-static
)
```

Let me know if you have any suggestions on the target name or better ideas on implementation.
