### PR TITLE
openamp: move notify_wait() in rpmsg virtio to rpmsg.

### DIFF
--- a/lib/include/openamp/remoteproc.h
+++ b/lib/include/openamp/remoteproc.h
@@ -463,17 +463,6 @@ struct remoteproc_ops {
 	int (*notify)(struct remoteproc *rproc, uint32_t id);
 
 	/**
-	 * @brief Wait for remote notified, when there is no TX buffer anymore.
-	 * Set to NULL means use usleep to wait TX buffer available.
-	 *
-	 * @param rproc		pointer to remoteproc instance
-	 * @param id		the notifyid
-	 *
-	 * return 0 means there is notify available, otherwise negative value.
-	 */
-	int (*wait_notified)(struct remoteproc *rproc, uint32_t id);
-
-	/**
 	 * @brief Get remoteproc memory I/O region by either name, virtual
 	 * address, physical address or device address.
 	 *

--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -55,6 +55,7 @@ typedef void (*rpmsg_ept_release_cb)(struct rpmsg_endpoint *ept);
 typedef void (*rpmsg_ns_unbind_cb)(struct rpmsg_endpoint *ept);
 typedef void (*rpmsg_ns_bind_cb)(struct rpmsg_device *rdev,
 				 const char *name, uint32_t dest);
+typedef int (*rpmsg_notify_wait_cb)(struct rpmsg_device *rdev, uint32_t id);
 
 /**
  * @brief Structure that binds a local RPMsg address to its user
@@ -143,6 +144,9 @@ struct rpmsg_device {
 
 	/** Callback handler for name service announcement, called when remote ept is destroyed */
 	rpmsg_ns_bind_cb ns_unbind_cb;
+
+	/** callback handler for rpmsg service, called when service can't get tx buffer */
+	rpmsg_notify_wait_cb notify_wait_cb;
 
 	/** RPMsg device operations */
 	struct rpmsg_device_ops ops;
@@ -357,7 +361,7 @@ void rpmsg_hold_rx_buffer(struct rpmsg_endpoint *ept, void *rxbuf);
  * @see rpmsg_hold_rx_buffer
  */
 void rpmsg_release_rx_buffer(struct rpmsg_endpoint *ept, void *rxbuf);
-
+ *                  
 /**
  * @brief Gets the tx buffer for message payload.
  *

--- a/lib/include/openamp/virtio.h
+++ b/lib/include/openamp/virtio.h
@@ -275,9 +275,6 @@ struct virtio_dispatch {
 
 	/** Notify the other side that a virtio vring as been updated. */
 	void (*notify)(struct virtqueue *vq);
-
-	/** Customize the wait, when no Tx buffer is available (optional) */
-	int (*wait_notified)(struct virtio_device *dev, struct virtqueue *vq);
 };
 
 /**

--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -901,16 +901,6 @@ static int remoteproc_virtio_notify(void *priv, uint32_t id)
 	return 0;
 }
 
-static int remoteproc_wait_notified(void *priv, uint32_t id)
-{
-	struct remoteproc *rproc = priv;
-
-	if (rproc->ops->wait_notified)
-		return rproc->ops->wait_notified(rproc, id);
-
-	return -RPROC_EOPNOTSUPP;
-}
-
 struct virtio_device *
 remoteproc_create_virtio(struct remoteproc *rproc,
 			 int vdev_id, unsigned int role,
@@ -969,7 +959,6 @@ remoteproc_create_virtio(struct remoteproc *rproc,
 	rproc_virtio_wait_remote_ready(vdev);
 
 	rpvdev = metal_container_of(vdev, struct remoteproc_virtio, vdev);
-	rproc_virtio_set_wait_notified(vdev, remoteproc_wait_notified);
 	metal_list_add_tail(&rproc->vdevs, &rpvdev->node);
 	num_vrings = vdev_rsc->num_of_vrings;
 

--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -30,21 +30,6 @@ static void rproc_virtio_virtqueue_notify(struct virtqueue *vq)
 	rpvdev->notify(rpvdev->priv, vring_info->notifyid);
 }
 
-static int rproc_virtio_wait_notified(struct virtio_device *vdev,
-				      struct virtqueue *vq)
-{
-	struct remoteproc_virtio *rpvdev;
-	struct virtio_vring_info *vring_info;
-	unsigned int vq_id = vq->vq_queue_index;
-
-	rpvdev = metal_container_of(vdev, struct remoteproc_virtio, vdev);
-	vring_info = &vdev->vrings_info[vq_id];
-
-	return rpvdev->wait_notified ?
-	       rpvdev->wait_notified(rpvdev->priv, vring_info->notifyid) :
-	       -RPROC_EOPNOTSUPP;
-}
-
 static unsigned char rproc_virtio_get_status(struct virtio_device *vdev)
 {
 	struct remoteproc_virtio *rpvdev;
@@ -202,7 +187,6 @@ static const struct virtio_dispatch remoteproc_virtio_dispatch_funcs = {
 	.get_features = rproc_virtio_get_features,
 	.read_config = rproc_virtio_read_config,
 	.notify = rproc_virtio_virtqueue_notify,
-	.wait_notified = rproc_virtio_wait_notified,
 #ifndef VIRTIO_DEVICE_ONLY
 	/*
 	 * We suppose here that the vdev is in a shared memory so that can

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -354,3 +354,11 @@ void rpmsg_destroy_ept(struct rpmsg_endpoint *ept)
 		(void)rpmsg_send_ns_message(ept, RPMSG_NS_DESTROY);
 	rpmsg_unregister_endpoint(ept);
 }
+
+int rpmsg_notify_wait(struct rpmsg_device *rdev, uint32_t id)
+{
+	if (rdev->notify_wait_cb)
+		return rdev->notify_wait_cb(rdev, id);
+
+	return RPMSG_ERR_NXIO;
+}

--- a/lib/rpmsg/rpmsg_internal.h
+++ b/lib/rpmsg/rpmsg_internal.h
@@ -111,6 +111,8 @@ rpmsg_get_ept_from_addr(struct rpmsg_device *rdev, uint32_t addr)
 	return rpmsg_get_endpoint(rdev, NULL, addr, RPMSG_ADDR_ANY);
 }
 
+int rpmsg_notify_wait(struct rpmsg_device *rdev, uint32_t id);
+
 /**
  * @internal
  *

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -358,12 +358,14 @@ static void rpmsg_virtio_release_rx_buffer(struct rpmsg_device *rdev,
 	metal_mutex_release(&rdev->lock);
 }
 
-static int rpmsg_virtio_wait_notified(struct rpmsg_virtio_device *rvdev,
-				      struct virtqueue *vq)
+static int rpmsg_virtio_notify_wait(struct rpmsg_virtio_device *rvdev,
+				    struct virtqueue *vq)
 {
-	return rvdev->vdev->func->wait_notified ?
-	       rvdev->vdev->func->wait_notified(rvdev->vdev, vq) :
-	       RPMSG_EOPNOTSUPP;
+	struct virtio_vring_info *vring_info;
+
+	vring_info = &rvdev->vdev->vrings_info[vq->vq_queue_index];
+
+	return rpmsg_notify_wait(&rvdev->rdev, vring_info->notifyid);
 }
 
 static void *rpmsg_virtio_get_tx_payload_buffer(struct rpmsg_device *rdev,
@@ -400,7 +402,7 @@ static void *rpmsg_virtio_get_tx_payload_buffer(struct rpmsg_device *rdev,
 		 * Try to use wait loop implemented in the virtio dispatcher and
 		 * use metal_sleep_usec() method by default.
 		 */
-		status = rpmsg_virtio_wait_notified(rvdev, rvdev->rvq);
+		status = rpmsg_virtio_notify_wait(rvdev, rvdev->rvq);
 		if (status != RPMSG_SUCCESS) {
 			metal_sleep_usec(RPMSG_TICKS_PER_INTERVAL);
 			tick_count--;


### PR DESCRIPTION
This ops can do in rpmsg without coupling to virtio.