### PR TITLE
Fixes #550: OpenAMP elf loader loads ELF sections to their load addresses

### DIFF
--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -368,7 +368,7 @@ static const void *elf_next_load_segment(void *elf_info, int *nseg,
 		if (!phdr)
 			return NULL;
 		elf_parse_segment(elf_info, phdr, &p_type, noffset,
-				  da, NULL, nfsize, nmsize);
+				  NULL, da, nfsize, nmsize);
 		*nseg = *nseg + 1;
 	}
 	return phdr;


### PR DESCRIPTION
Unlike the Linux rproc elf loader, the OpenAMP elf loader loads the remote elf program segments to their load addresses instead of their link addresses. This results in memory corruption when the remote firmware attempts to relocate segments from their link addresses to load addresses at runtime such as the data section.

Signed-off-by: Umair Khan <umair_khan@mentor.com>