### PR TITLE
remoteproc: fix management of non loadable segments

### DIFF
--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -571,20 +571,25 @@ int elf_load(struct remoteproc *rproc,
 		nsegment = *load_state & ELF_NEXT_SEGMENT_MASK;
 		phdr = elf_next_load_segment(*img_info, &nsegment, da,
 					     noffset, &nsize, &nsegmsize);
-		if (!phdr) {
-			metal_log(METAL_LOG_DEBUG, "cannot find more segment\r\n");
-			*load_state = (*load_state & (~ELF_NEXT_SEGMENT_MASK)) |
-				      (nsegment & ELF_NEXT_SEGMENT_MASK);
-			return *load_state;
-		}
-		*nlen = nsize;
-		*nmemsize = nsegmsize;
+
 		phnums = elf_phnum(*img_info);
-		metal_log(METAL_LOG_DEBUG, "segment: %d, total segs %d\r\n",
-			  nsegment, phnums);
+		if (phdr) {
+			*nlen = nsize;
+			*nmemsize = nsegmsize;
+			metal_log(METAL_LOG_DEBUG, "segment: %d, total segs %d\r\n",
+				  nsegment, phnums);
+		}
+
 		if (nsegment == phnums) {
-			*load_state = (*load_state & (~RPROC_LOADER_MASK)) |
+			if (phdr) {
+				*load_state = (*load_state & (~RPROC_LOADER_MASK)) |
 				      RPROC_LOADER_POST_DATA_LOAD;
+			} else {
+				metal_log(METAL_LOG_DEBUG, "no more segment to load\r\n");
+				*load_state = (*load_state & (~RPROC_LOADER_MASK)) |
+					RPROC_LOADER_LOAD_COMPLETE;
+					*da = RPROC_LOAD_ANYADDR;
+			}
 		}
 		*load_state = (*load_state & (~ELF_NEXT_SEGMENT_MASK)) |
 			      (nsegment & ELF_NEXT_SEGMENT_MASK);


### PR DESCRIPTION
The elf loader assumes that the last ELF program segment will always be a LOAD type segment. I deduce this from the fact that the elf_load() function, when loading the remote ELF sections during the RPROC_LOADER_READY_TO_LOAD stage, compares the last load segment num to the total ELF sections to determine if the loading is complete and it can move to the next stage RPROC_LOADER_POST_DATA_LOAD. If the last program segment in the ELF is not of type LOAD, the last loaded LOAD segment never equals total ELF sections. This creates an error condition and the firmware loading fails. This patch fixes this issue by comparing the last loaded LOAD segment number with the max LOAD segment number in the ELF.

This PR fixes OpenAMP#552

Signed-off-by: Muhammad Umair Khan <umair_khan@mentor.com>