### PR TITLE
load_fw: The firmware loading loop terminates prematurely

### DIFF
--- a/apps/examples/load_fw/load_fw.c
+++ b/apps/examples/load_fw/load_fw.c
@@ -96,7 +96,7 @@ int load_exectuable_noblock(struct remoteproc *rproc,
 				offset, len);
 			return ret;
 		}
-		if (nlen == 0)
+		if (nlen == 0 && nmlen == 0)
 			break;
 		offset = noffset;
 		len = nlen;


### PR DESCRIPTION
The remoteproc_load_noblock() is a non-blocking API designed to load the remote firmware in streaming mode. The application has to continue supplying the firmware data blocks until the complete firmware is loaded. The load_fw example does this and checks the `nlen` variable (returned by the remoteproc_load_noblock() API) for zero to determine if the firmware loading is complete. However, `nlen` (contains the filesize of the next program header) alone can't be taken as the sufficient condition to mark the completion of firmware loading as 0 is a valid value for filesize for sections that don't require loading to the target memory such as the .bss section. This patch proposes checking filesize as well as memsize as a better metric to mark completion of the firmware loading loop.