### PR TITLE
Remove layer breaking functions from rpmsg_virtio

### DIFF
--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -212,6 +212,8 @@ rpmsg_virtio_write_config(struct rpmsg_virtio_device *rvdev,
 /**
  * @brief Create the rpmsg virtio device virtqueue.
  *
+ * Deprecated: Use virtio_create_virtqueues() instead
+ *
  * @param rvdev		Pointer to the rpmsg virtio device.
  * @param flags		Create flag.
  * @param nvqs		The virtqueue number.
@@ -220,6 +222,7 @@ rpmsg_virtio_write_config(struct rpmsg_virtio_device *rvdev,
  *
  * @return 0 on success, otherwise error code.
  */
+__deprecated
 static inline int
 rpmsg_virtio_create_virtqueues(struct rpmsg_virtio_device *rvdev,
 			       int flags, unsigned int nvqs,
@@ -233,8 +236,11 @@ rpmsg_virtio_create_virtqueues(struct rpmsg_virtio_device *rvdev,
 /**
  * @brief Delete the virtqueues created in rpmsg_virtio_create_virtqueues()
  *
+ * Deprecated: Use virtio_delete_virtqueues() instead
+ *
  * @param rvdev	Pointer to the rpmsg virtio device
  */
+__deprecated
 static inline void
 rpmsg_virtio_delete_virtqueues(struct rpmsg_virtio_device *rvdev)
 {

--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -143,9 +143,12 @@ rpmsg_virtio_get_role(struct rpmsg_virtio_device *rvdev)
 /**
  * @brief Set rpmsg virtio device status.
  *
+ * Deprecated: Use virtio_set_status() instead
+ *
  * @param rvdev		Pointer to rpmsg virtio device.
  * @param status	Value to be set as rpmsg virtio device status.
  */
+__deprecated
 static inline void rpmsg_virtio_set_status(struct rpmsg_virtio_device *rvdev,
 					   uint8_t status)
 {
@@ -155,10 +158,13 @@ static inline void rpmsg_virtio_set_status(struct rpmsg_virtio_device *rvdev,
 /**
  * @brief Retrieve rpmsg virtio device status.
  *
+ * Deprecated: Use virtio_get_status() instead
+ *
  * @param rvdev	Pointer to rpmsg virtio device.
  *
  * @return The rpmsg virtio device status.
  */
+__deprecated
 static inline uint8_t rpmsg_virtio_get_status(struct rpmsg_virtio_device *rvdev)
 {
 	return rvdev->vdev->func->get_status(rvdev->vdev);
@@ -167,10 +173,13 @@ static inline uint8_t rpmsg_virtio_get_status(struct rpmsg_virtio_device *rvdev)
 /**
  * @brief Get the rpmsg virtio device features.
  *
+ * Deprecated: Use virtio_get_features() instead
+ *
  * @param rvdev	Pointer to the rpmsg virtio device.
  *
  * @return The features supported by both the rpmsg driver and rpmsg device.
  */
+__deprecated
 static inline uint32_t
 rpmsg_virtio_get_features(struct rpmsg_virtio_device *rvdev)
 {
@@ -180,11 +189,14 @@ rpmsg_virtio_get_features(struct rpmsg_virtio_device *rvdev)
 /**
  * @brief Retrieve configuration data from the rpmsg virtio device.
  *
+ * Deprecated: Use virtio_read_config() instead
+ *
  * @param rvdev		Pointer to the rpmsg virtio device.
  * @param offset	Offset of the data within the configuration area.
  * @param dst		Address of the buffer that will hold the data.
  * @param length	Length of the data to be retrieved.
  */
+__deprecated
 static inline void
 rpmsg_virtio_read_config(struct rpmsg_virtio_device *rvdev,
 			 uint32_t offset, void *dst, int length)
@@ -195,6 +207,8 @@ rpmsg_virtio_read_config(struct rpmsg_virtio_device *rvdev,
 /**
  * @brief Write configuration data to the rpmsg virtio device.
  *
+ * Deprecated: Use virtio_write_config() instead
+ *
  * @param rvdev		Pointer to the rpmsg virtio device.
  * @param offset	Offset of the data within the configuration area.
  * @param src		Address of the buffer that holds the data to write.
@@ -202,6 +216,7 @@ rpmsg_virtio_read_config(struct rpmsg_virtio_device *rvdev,
  *
  * @return 0 on success, otherwise error code.
  */
+__deprecated
 static inline void
 rpmsg_virtio_write_config(struct rpmsg_virtio_device *rvdev,
 			 uint32_t offset, void *src, int length)

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -892,8 +892,8 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 	metal_list_init(&rvdev->reclaimer);
 
 	/* Create virtqueues for remote device */
-	status = rpmsg_virtio_create_virtqueues(rvdev, 0, RPMSG_NUM_VRINGS,
-						vq_names, callback);
+	status = virtio_create_virtqueues(rvdev->vdev, 0, RPMSG_NUM_VRINGS,
+					  vq_names, callback, NULL);
 	if (status != RPMSG_SUCCESS)
 		return status;
 
@@ -982,7 +982,7 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 
 #ifndef VIRTIO_DEVICE_ONLY
 err:
-	rpmsg_virtio_delete_virtqueues(rvdev);
+	virtio_delete_virtqueues(rvdev->vdev);
 	return status;
 #endif /*!VIRTIO_DEVICE_ONLY*/
 }
@@ -1004,7 +1004,7 @@ void rpmsg_deinit_vdev(struct rpmsg_virtio_device *rvdev)
 		rvdev->rvq = 0;
 		rvdev->svq = 0;
 
-		rpmsg_virtio_delete_virtqueues(rvdev);
+		virtio_delete_virtqueues(rvdev->vdev);
 		metal_mutex_deinit(&rdev->lock);
 	}
 }


### PR DESCRIPTION
These functions are only used internally by rpmsg_virtio but are exposed in rpmsg_virtio.h which is included by users of the OpenAMP API. These functions reach into virtio structs which is a layering issue. They also have equivalents in the virtio API which should be used instead for this access. Remove these functions from the header before they get used by someone and turn into API.