### PR TITLE
apps: linux: generic: Use accessor functions for struct remoteproc_mem

### DIFF
--- a/apps/examples/load_fw/zynqmp_apu_lcm_rproc_example.c
+++ b/apps/examples/load_fw/zynqmp_apu_lcm_rproc_example.c
@@ -81,7 +81,6 @@ static void *apu_rproc_mmap(struct remoteproc *rproc,
 	if (!mem)
 		return NULL;
 	mem->pa = lpa;
-	mem->da = lda;
 
 	*io = metal_allocate_memory(sizeof(struct metal_io_region));
 	if (!*io) {
@@ -95,11 +94,10 @@ static void *apu_rproc_mmap(struct remoteproc *rproc,
 	 */
 	metal_io_init(*io, (void *)mem->pa, &mem->pa, size,
 		      sizeof(metal_phys_addr_t)<<3, attribute, NULL);
-	mem->io = *io;
-	metal_list_add_tail(&rproc->mems, &mem->node);
+	remoteproc_init_mem(mem, NULL, lpa, lda, size, *io);
+	remoteproc_add_mem(rproc, mem);
 	*pa = lpa;
 	*da = lda;
-	mem->size = size;
 	return metal_io_phys_to_virt(*io, mem->pa);
 }
 

--- a/apps/examples/load_fw/zynqmp_apu_lcm_rproc_example.c
+++ b/apps/examples/load_fw/zynqmp_apu_lcm_rproc_example.c
@@ -27,7 +27,6 @@ static struct remoteproc *apu_rproc_init(struct remoteproc *rproc,
 	priv->rproc = rproc;
 	priv->cpu_id = cpu_id;
 	priv->rproc->ops = ops;
-	metal_list_init(&priv->rproc->mems);
 	priv->rproc->priv = priv;
 	rproc->state = RPROC_READY;
 	return priv->rproc;

--- a/apps/examples/load_fw/zynqmp_r5_lcm_rproc_example.c
+++ b/apps/examples/load_fw/zynqmp_r5_lcm_rproc_example.c
@@ -202,7 +202,6 @@ void *r5_rproc_mmap(struct remoteproc *rproc,
 	if (!mem)
 		return NULL;
 	mem->pa = lpa;
-	mem->da = lda;
 
 	*io = metal_allocate_memory(sizeof(struct metal_io_region));
 	if (!*io) {
@@ -211,11 +210,10 @@ void *r5_rproc_mmap(struct remoteproc *rproc,
 	}
 	metal_io_init(*io, (void *)mem->pa, &mem->pa, size,
 		      sizeof(metal_phys_addr_t)<<3, attribute, NULL);
-	mem->io = *io;
-	metal_list_add_tail(&rproc->mems, &mem->node);
+	remoteproc_init_mem(mem, NULL, lpa, lda, size, *io);
+	remoteproc_add_mem(rproc, mem);
 	*pa = lpa;
 	*da = lda;
-	mem->size = size;
 	return metal_io_phys_to_virt(*io, mem->pa);
 }
 

--- a/apps/examples/load_fw/zynqmp_r5_lcm_rproc_example.c
+++ b/apps/examples/load_fw/zynqmp_r5_lcm_rproc_example.c
@@ -115,7 +115,6 @@ struct remoteproc *r5_rproc_init(struct remoteproc *rproc,
 	priv->rproc = rproc;
 	priv->cpu_id = cpu_id;
 	priv->rproc->ops = ops;
-	metal_list_init(&priv->rproc->mems);
 	priv->rproc->priv = priv;
 	priv->rpu_base = RPU_BASE_ADDR;
 	metal_io_init(&priv->rpu_io, (void *)RPU_BASE_ADDR, &priv->rpu_base,

--- a/apps/examples/load_fw/zynqmp_rpu_lcm_rproc_example.c
+++ b/apps/examples/load_fw/zynqmp_rpu_lcm_rproc_example.c
@@ -25,7 +25,6 @@ static struct remoteproc *rpu_rproc_init(struct remoteproc *rproc,
 	priv->rproc = rproc;
 	priv->cpu_id = cpu_id;
 	priv->rproc->ops = ops;
-	metal_list_init(&priv->rproc->mems);
 	priv->rproc->priv = priv;
 	rproc->state = RPROC_READY;
 	return priv->rproc;

--- a/apps/examples/load_fw/zynqmp_rpu_lcm_rproc_example.c
+++ b/apps/examples/load_fw/zynqmp_rpu_lcm_rproc_example.c
@@ -94,7 +94,6 @@ static void *rpu_rproc_mmap(struct remoteproc *rproc,
 	if (!mem)
 		return NULL;
 	mem->pa = lpa;
-	mem->da = lda;
 
 	*io = metal_allocate_memory(sizeof(struct metal_io_region));
 	if (!*io) {
@@ -108,11 +107,10 @@ static void *rpu_rproc_mmap(struct remoteproc *rproc,
          */
 	metal_io_init(*io, (void *)mem->pa, &mem->pa, size,
 		      sizeof(metal_phys_addr_t)<<3, attribute, NULL);
-	mem->io = *io;
-	metal_list_add_tail(&rproc->mems, &mem->node);
+	remoteproc_init_mem(mem, NULL, lpa, lda, size, *io);
+	remoteproc_add_mem(rproc, mem);
 	*pa = lpa;
 	*da = lda;
-	mem->size = size;
 	return metal_io_phys_to_virt(*io, mem->pa);
 }
 

--- a/apps/system/linux/machine/generic/platform_info.c
+++ b/apps/system/linux/machine/generic/platform_info.c
@@ -125,6 +125,20 @@ static void linux_proc_block_set(struct metal_io_region *io,
 	return;
 }
 
+static metal_phys_addr_t linux_proc_offset_to_phys(struct metal_io_region *io,
+						   unsigned long offset)
+{
+	/* offset and phys are the same here */
+	return (offset < metal_io_region_size(io) ? offset : METAL_BAD_OFFSET);
+}
+
+static unsigned long linux_proc_phys_to_offset(struct metal_io_region *io,
+					       metal_phys_addr_t phys)
+{
+	/* offset and phys are the same here */
+	return (phys < metal_io_region_size(io) ? phys : METAL_BAD_PHYS);
+}
+
 static struct metal_io_ops linux_proc_io_ops = {
 	.write = NULL,
 	.read = NULL,
@@ -132,6 +146,8 @@ static struct metal_io_ops linux_proc_io_ops = {
 	.block_write = linux_proc_block_write,
 	.block_set = linux_proc_block_set,
 	.close = NULL,
+	.offset_to_phys = linux_proc_offset_to_phys,
+	.phys_to_offset = linux_proc_phys_to_offset,
 };
 
 static int sk_unix_client(const char *descr)
@@ -228,7 +244,6 @@ linux_proc_init(struct remoteproc *rproc,
 {
 	struct remoteproc_priv *prproc = arg;
 	struct metal_io_region *io;
-	struct remoteproc_mem *shm;
 	struct vring_ipi_info *ipi;
 	int ret;
 
@@ -243,13 +258,12 @@ linux_proc_init(struct remoteproc *rproc,
 		return NULL;
 	}
 	prproc->shm_old_io = io;
-	shm = &prproc->shm;
-	shm->pa = 0;
-	shm->da = 0;
-	shm->size = prproc->shm_size;
-	metal_io_init(&prproc->shm_new_io, io->virt, &shm->pa,
-		      shm->size, -1, 0, &linux_proc_io_ops);
-	shm->io = &prproc->shm_new_io;
+
+	metal_io_init(&prproc->shm_new_io, io->virt, NULL,
+		      prproc->shm_size, -1, 0, &linux_proc_io_ops);
+
+	remoteproc_init_mem(&prproc->shm, NULL, 0, 0,
+			    prproc->shm_size, &prproc->shm_new_io);
 
 	/* Open IPI */
 	ipi = &prproc->ipi;
@@ -331,7 +345,7 @@ linux_proc_mmap(struct remoteproc *rproc, metal_phys_addr_t *pa,
 	if (va) {
 		if (io)
 			*io = mem->io;
-		metal_list_add_tail(&rproc->mems, &mem->node);
+		remoteproc_add_mem(rproc, mem);
 	}
 	return va;
 }


### PR DESCRIPTION
The remoteproc_mem struct contents are internal to remoteproc. The struct should be accessed using the provided accessors, not directly. This is done in preperation of making this struct opaque to code outside of the remoteproc drivers.