### PR TITLE
Add RPMsg API to get buffer size

### DIFF
--- a/apps/examples/echo/rpmsg-echo.c
+++ b/apps/examples/echo/rpmsg-echo.c
@@ -76,8 +76,8 @@ int app(struct rpmsg_device *rdev, void *priv)
 
 	LPRINTF("Successfully created rpmsg endpoint.\r\n");
 
-	LPRINTF("RPMsg device TX buffer size: %#x\r\n", rpmsg_virtio_get_tx_buffer_size(rdev));
-	LPRINTF("RPMsg device RX buffer size: %#x\r\n", rpmsg_virtio_get_rx_buffer_size(rdev));
+	LPRINTF("RPMsg device TX buffer size: %#x\r\n", rpmsg_get_tx_buffer_size(&lept));
+	LPRINTF("RPMsg device RX buffer size: %#x\r\n", rpmsg_get_rx_buffer_size(&lept));
 
 	while(1) {
 		platform_poll(priv);

--- a/apps/examples/nocopy_echo/rpmsg-nocopy-ping.c
+++ b/apps/examples/nocopy_echo/rpmsg-nocopy-ping.c
@@ -122,14 +122,6 @@ static int app(struct rpmsg_device *rdev, void *priv)
 	LPRINTF(" 1 - Send data to remote core, retrieve the echo");
 	LPRINTF(" and validate its integrity ..\r\n");
 
-	max_size = rpmsg_virtio_get_buffer_size(rdev);
-	if ((int32_t)max_size < 0) {
-		LPERROR("No available buffer size.\r\n");
-		return -1;
-	}
-	max_size -= sizeof(struct _payload);
-	num_payloads = max_size - PAYLOAD_MIN_SIZE + 1;
-
 	/* Create RPMsg endpoint */
 	ret = rpmsg_create_ept(&lept, rdev, RPMSG_SERVICE_NAME,
 			       RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
@@ -142,8 +134,17 @@ static int app(struct rpmsg_device *rdev, void *priv)
 
 	while (!is_rpmsg_ept_ready(&lept))
 		platform_poll(priv);
-
 	LPRINTF("RPMSG endpoint is binded with remote.\r\n");
+
+	max_size = rpmsg_get_tx_buffer_size(&lept);
+	if ((int32_t)max_size <= 0) {
+		LPERROR("No available buffer size.\r\n");
+		rpmsg_destroy_ept(&lept);
+		return -1;
+	}
+	max_size -= sizeof(struct _payload);
+	num_payloads = max_size - PAYLOAD_MIN_SIZE + 1;
+
 	for (i = 0, size = PAYLOAD_MIN_SIZE; i < num_payloads; i++, size++) {
 		struct _payload *i_payload;
 

--- a/apps/tests/msg/rpmsg-nocopy-ping.c
+++ b/apps/tests/msg/rpmsg-nocopy-ping.c
@@ -132,14 +132,6 @@ int app(struct rpmsg_device *rdev, void *priv)
 	int expect_rnum = 0;
 	void *buff_list[MAX_NB_TX_BUFF];
 
-	max_size = rpmsg_virtio_get_buffer_size(rdev);
-	if (((int)max_size) < 0) {
-		LPERROR("No available buffer size.\r\n");
-		return -1;
-	}
-	max_size -= sizeof(struct _payload);
-	num_payloads = max_size - PAYLOAD_MIN_SIZE + 1;
-
 	/* Create RPMsg endpoint */
 	ret = rpmsg_create_ept(&lept, rdev, RPMSG_SERVICE_NAME,
 			       RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
@@ -154,6 +146,15 @@ int app(struct rpmsg_device *rdev, void *priv)
 		platform_poll(priv);
 
 	LPRINTF("RPMSG endpoint is binded with remote.\r\n");
+
+	max_size = rpmsg_get_tx_buffer_size(&lept);
+	if (((int)max_size) <= 0) {
+		LPERROR("No available buffer size.\r\n");
+		rpmsg_destroy_ept(&lept);
+		return -1;
+	}
+	max_size -= sizeof(struct _payload);
+	num_payloads = max_size - PAYLOAD_MIN_SIZE + 1;
 
 	LPRINTF(" 1 - Get some TX buffers\r\n");
 	for (i = 0; i < MAX_NB_TX_BUFF; i++)

--- a/apps/tests/msg/rpmsg-ping.c
+++ b/apps/tests/msg/rpmsg-ping.c
@@ -108,9 +108,19 @@ int app (struct rpmsg_device *rdev, void *priv)
 	LPRINTF(" 1 - Send data to remote core, retrieve the echo");
 	LPRINTF(" and validate its integrity ..\r\n");
 
-	max_size = rpmsg_virtio_get_buffer_size(rdev);
-	if (max_size < 0) {
+	/* Create RPMsg endpoint */
+	ret = rpmsg_create_ept(&lept, rdev, RPMSG_SERVICE_NAME,
+			       RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
+			       rpmsg_endpoint_cb, rpmsg_service_unbind);
+	if (ret) {
+		LPERROR("Failed to create RPMsg endpoint.\r\n");
+		return ret;
+	}
+
+	max_size = rpmsg_get_tx_buffer_size(&lept);
+	if (max_size <= 0) {
 		LPERROR("No available buffer size.\r\n");
+		rpmsg_destroy_ept(&lept);
 		return -1;
 	}
 	max_size -= sizeof(struct _payload);
@@ -121,21 +131,12 @@ int app (struct rpmsg_device *rdev, void *priv)
 
 	if (!i_payload) {
 		LPERROR("memory allocation failed.\r\n");
+		rpmsg_destroy_ept(&lept);
 		return -1;
 	}
 
-	/* Create RPMsg endpoint */
-	ret = rpmsg_create_ept(&lept, rdev, RPMSG_SERVICE_NAME,
-			       RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
-			       rpmsg_endpoint_cb, rpmsg_service_unbind);
-	if (ret) {
-		LPERROR("Failed to create RPMsg endpoint.\r\n");
-		metal_free_memory(i_payload);
-		return ret;
-	}
-
-	LPRINTF("RPMsg driver TX buffer size: %#x\r\n", rpmsg_virtio_get_tx_buffer_size(rdev));
-	LPRINTF("RPMsg driver RX buffer size: %#x\r\n", rpmsg_virtio_get_rx_buffer_size(rdev));
+	LPRINTF("RPMsg device TX buffer size: %#x\r\n", rpmsg_get_tx_buffer_size(&lept));
+	LPRINTF("RPMsg device RX buffer size: %#x\r\n", rpmsg_get_rx_buffer_size(&lept));
 
 	while (!is_rpmsg_ept_ready(&lept))
 		platform_poll(priv);

--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -121,6 +121,12 @@ struct rpmsg_device_ops {
 
 	/** Release RPMsg TX buffer */
 	int (*release_tx_buffer)(struct rpmsg_device *rdev, void *txbuf);
+
+	/** Get RPMsg RX buffer size */
+	int (*get_rx_buffer_size)(struct rpmsg_device *rdev);
+
+	/** Get RPMsg TX buffer size */
+	int (*get_tx_buffer_size)(struct rpmsg_device *rdev);
 };
 
 /** @brief Representation of a RPMsg device */
@@ -403,6 +409,30 @@ void *rpmsg_get_tx_payload_buffer(struct rpmsg_endpoint *ept,
  * @see rpmsg_get_tx_payload_buffer
  */
 int rpmsg_release_tx_buffer(struct rpmsg_endpoint *ept, void *txbuf);
+
+/**
+ * @brief Get RPMsg Tx buffer size
+ *
+ * @param ept	The rpmsg endpoint
+ *
+ * @return
+ *   - Next available Tx buffer size on success
+ *   - RPMSG_ERR_PARAM on invalid parameter
+ *   - RPMSG_ERR_PERM if service not implemented
+ */
+int rpmsg_get_tx_buffer_size(struct rpmsg_endpoint *ept);
+
+/**
+ * @brief Get RPMsg Rx buffer size
+ *
+ * @param ept	The rpmsg endpoint
+ *
+ * @return
+ *   - Next available Rx buffer size on success
+ *   - RPMSG_ERR_PARAM on invalid parameter
+ *   - RPMSG_ERR_PERM if service not implemented
+ */
+int rpmsg_get_rx_buffer_size(struct rpmsg_endpoint *ept);
 
 /**
  * @brief Send a message in tx buffer reserved by

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -208,6 +208,36 @@ void *rpmsg_get_tx_payload_buffer(struct rpmsg_endpoint *ept,
 	return NULL;
 }
 
+int rpmsg_get_tx_buffer_size(struct rpmsg_endpoint *ept)
+{
+	struct rpmsg_device *rdev;
+
+	if (!ept || !ept->rdev)
+		return RPMSG_ERR_PARAM;
+
+	rdev = ept->rdev;
+
+	if (rdev->ops.get_tx_buffer_size)
+		return rdev->ops.get_tx_buffer_size(rdev);
+
+	return RPMSG_EOPNOTSUPP;
+}
+
+int rpmsg_get_rx_buffer_size(struct rpmsg_endpoint *ept)
+{
+	struct rpmsg_device *rdev;
+
+	if (!ept || !ept->rdev)
+		return RPMSG_ERR_PARAM;
+
+	rdev = ept->rdev;
+
+	if (rdev->ops.get_rx_buffer_size)
+		return rdev->ops.get_rx_buffer_size(rdev);
+
+	return RPMSG_EOPNOTSUPP;
+}
+
 int rpmsg_send_offchannel_nocopy(struct rpmsg_endpoint *ept, uint32_t src,
 				 uint32_t dst, const void *data, int len)
 {

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -826,6 +826,8 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 	rdev->ops.get_tx_payload_buffer = rpmsg_virtio_get_tx_payload_buffer;
 	rdev->ops.send_offchannel_nocopy = rpmsg_virtio_send_offchannel_nocopy;
 	rdev->ops.release_tx_buffer = rpmsg_virtio_release_tx_buffer;
+	rdev->ops.get_rx_buffer_size = rpmsg_virtio_get_rx_buffer_size;
+	rdev->ops.get_tx_buffer_size = rpmsg_virtio_get_tx_buffer_size;
 	role = rpmsg_virtio_get_role(rvdev);
 
 #ifndef VIRTIO_DEVICE_ONLY


### PR DESCRIPTION
In patch 3 of this series you can see core of the issue, applications have no way of finding if the transport layer under RPMsg has a maximum supported message size. The examples end up having to look directly into the transport layer to find this info. With this API they can ask the RPMsg layer without having to know about the backing transport layer. This is better API layering and allows the core of the examples to work across any transport layer.
