### PR TITLE
virtio: Inline vring_init() and vring_need_event() functions

### DIFF
--- a/lib/include/openamp/virtio_ring.h
+++ b/lib/include/openamp/virtio_ring.h
@@ -186,31 +186,6 @@ static inline int vring_size(unsigned int num, unsigned long align)
 	return size;
 }
 
-static inline void
-vring_init(struct vring *vr, unsigned int num, uint8_t *p, unsigned long align)
-{
-	vr->num = num;
-	vr->desc = (struct vring_desc *)p;
-	vr->avail = (struct vring_avail *)(p + num * sizeof(struct vring_desc));
-	vr->used = (struct vring_used *)
-	    (((unsigned long)&vr->avail->ring[num] + sizeof(uint16_t) +
-	      align - 1) & ~(align - 1));
-}
-
-/*
- * The following is used with VIRTIO_RING_F_EVENT_IDX.
- *
- * Assuming a given event_idx value from the other size, if we have
- * just incremented index from old to new_idx, should we trigger an
- * event?
- */
-static inline int
-vring_need_event(uint16_t event_idx, uint16_t new_idx, uint16_t old)
-{
-	return (uint16_t)(new_idx - event_idx - 1) <
-	    (uint16_t)(new_idx - old);
-}
-
 #if defined __cplusplus
 }
 #endif

--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -496,7 +496,12 @@ static void vq_ring_init(struct virtqueue *vq, void *ring_mem, int alignment)
 	size = vq->vq_nentries;
 	vr = &vq->vq_ring;
 
-	vring_init(vr, size, ring_mem, alignment);
+	vr->num = size;
+	vr->desc = (struct vring_desc *)ring_mem;
+	vr->avail = (struct vring_avail *)(ring_mem + size * sizeof(struct vring_desc));
+	vr->used = (struct vring_used *)
+	    (((unsigned long)&vr->avail->ring[size] + sizeof(uint16_t) +
+	      alignment - 1) & ~(alignment - 1));
 
 #ifndef VIRTIO_DEVICE_ONLY
 	if (vq->vq_dev->role == VIRTIO_DEV_DRIVER) {
@@ -625,6 +630,19 @@ void virtqueue_notification(struct virtqueue *vq)
 	atomic_thread_fence(memory_order_seq_cst);
 	if (vq->callback)
 		vq->callback(vq);
+}
+
+/*
+ * The following is used with VIRTIO_RING_F_EVENT_IDX.
+ *
+ * Assuming a given event_idx value from the other size, if we have
+ * just incremented index from old to new_idx, should we trigger an
+ * event?
+ */
+static int vring_need_event(uint16_t event_idx, uint16_t new_idx, uint16_t old)
+{
+	return (uint16_t)(new_idx - event_idx - 1) <
+	    (uint16_t)(new_idx - old);
 }
 
 /*


### PR DESCRIPTION
Both of these functions should be internal to virtqueue. They should have had no usefulness outside of this file and so moving them should not cause any API issue. This simplifies the virtio ring setup code for later improvements