### PR TITLE
virtqueue: Fix comment on shm_io and fix type

### DIFF
--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -114,10 +114,10 @@ struct virtqueue {
 	uint16_t vq_queued_cnt;
 
 	/**
-	 * Metal I/O region of the vrings and buffers.
+	 * Metal I/O region of the buffers.
 	 * This structure is used for conversion between virtual and physical addresses.
 	 */
-	void *shm_io;
+	struct metal_io_region *shm_io;
 
 	/**
 	 * Head of the free chain in the descriptor table. If there are no free descriptors,

--- a/lib/virtio_mmio/virtio_mmio_drv.c
+++ b/lib/virtio_mmio/virtio_mmio_drv.c
@@ -325,7 +325,7 @@ struct virtqueue *virtio_mmio_setup_virtqueue(struct virtio_device *vdev,
 	virtio_mmio_write32(vdev, VIRTIO_MMIO_QUEUE_NUM, vq->vq_nentries);
 	virtio_mmio_write32(vdev, VIRTIO_MMIO_QUEUE_ALIGN, 4096);
 	virtio_mmio_write32(vdev, VIRTIO_MMIO_QUEUE_PFN,
-			    ((uintptr_t)metal_io_virt_to_phys(vq->shm_io,
+			    ((uintptr_t)metal_io_virt_to_phys(vmdev->shm_io,
 			    (char *)vq->vq_ring.desc)) / 4096);
 
 	vdev->vrings_info[vdev->vrings_num].vq = vq;


### PR DESCRIPTION
This should hold a pointer to an metal_io_region, make that the type.

Also fix the comment, this region holds the address of the message buffers, not the vring's descriptor table nor available/used rings. It is only used for virt-to-phys/phys-to-vert on the buffers pointed to by these descriptors.

This comment seems to have cause an issue in virtio_mmio_drv where this region was used to translate the address of the vring descriptors. This may have worked if the vring descriptors where part of the same IO space as the buffers they point to, but this is not guaranteed to always be the case. Fix that here.