### PR TITLE
remoteproc: Fix the NULL vs RPROC_IS_ERR() bug for remoteproc_get_rsc_table()

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -112,28 +112,27 @@ static void *remoteproc_get_rsc_table(struct remoteproc *rproc,
 	 * the caller should be responsible to release the memory
 	 */
 	rsc_table = metal_allocate_memory(len);
-	if (!rsc_table) {
-		return RPROC_ERR_PTR(-RPROC_ENOMEM);
-	}
+	if (!rsc_table)
+		return NULL;
+
 	ret = store_ops->load(store, offset, len, &img_data, RPROC_LOAD_ANYADDR,
 			      NULL, 1);
 	if (ret < 0 || ret < (int)len || !img_data) {
 		metal_log(METAL_LOG_ERROR,
 			  "get rsc failed: 0x%llx, 0x%llx\r\n", offset, len);
-		ret = -RPROC_EINVAL;
 		goto error;
 	}
 	memcpy(rsc_table, img_data, len);
 
 	ret = handle_rsc_table(rproc, rsc_table, len, NULL);
-	if (ret < 0) {
+	if (ret < 0)
 		goto error;
-	}
+
 	return rsc_table;
 
 error:
 	metal_free_memory(rsc_table);
-	return RPROC_ERR_PTR(ret);
+	return NULL;
 }
 
 static int remoteproc_parse_rsc_table(struct remoteproc *rproc,


### PR DESCRIPTION

* Since remoteproc_get_rsc_table() returns RPROC_ERR_PTR and never NULL, use RPROC_IS_ERR() to check the return value.