### PR TITLE
remoteproc: Un-inline remoteproc_init_mem() and remoteproc_add_mem()

### DIFF
--- a/lib/include/openamp/remoteproc.h
+++ b/lib/include/openamp/remoteproc.h
@@ -573,22 +573,9 @@ int remoteproc_remove(struct remoteproc *rproc);
  * @param size	Memory size
  * @param io	Pointer to the I/O region
  */
-static inline void
-remoteproc_init_mem(struct remoteproc_mem *mem, const char *name,
-		    metal_phys_addr_t pa, metal_phys_addr_t da,
-		    size_t size, struct metal_io_region *io)
-{
-	if (!mem || !io || size == 0)
-		return;
-	if (name)
-		strncpy(mem->name, name, sizeof(mem->name));
-	else
-		mem->name[0] = 0;
-	mem->pa = pa;
-	mem->da = da;
-	mem->io = io;
-	mem->size = size;
-}
+void remoteproc_init_mem(struct remoteproc_mem *mem, const char *name,
+			 metal_phys_addr_t pa, metal_phys_addr_t da,
+			 size_t size, struct metal_io_region *io);
 
 /**
  * @brief Add remoteproc memory
@@ -596,13 +583,7 @@ remoteproc_init_mem(struct remoteproc_mem *mem, const char *name,
  * @param rproc	Pointer to remoteproc
  * @param mem	Pointer to remoteproc memory
  */
-static inline void
-remoteproc_add_mem(struct remoteproc *rproc, struct remoteproc_mem *mem)
-{
-	if (!rproc || !mem)
-		return;
-	metal_list_add_tail(&rproc->mems, &mem->node);
-}
+void remoteproc_add_mem(struct remoteproc *rproc, struct remoteproc_mem *mem);
 
 /**
  * @brief Get remoteproc memory I/O region with name

--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -290,6 +290,29 @@ int remoteproc_shutdown(struct remoteproc *rproc)
 	return ret;
 }
 
+void remoteproc_init_mem(struct remoteproc_mem *mem, const char *name,
+			 metal_phys_addr_t pa, metal_phys_addr_t da,
+			 size_t size, struct metal_io_region *io)
+{
+	if (!mem || !io || size == 0)
+		return;
+	if (name)
+		strncpy(mem->name, name, sizeof(mem->name));
+	else
+		mem->name[0] = 0;
+	mem->pa = pa;
+	mem->da = da;
+	mem->io = io;
+	mem->size = size;
+}
+
+void remoteproc_add_mem(struct remoteproc *rproc, struct remoteproc_mem *mem)
+{
+	if (!rproc || !mem)
+		return;
+	metal_list_add_tail(&rproc->mems, &mem->node);
+}
+
 struct metal_io_region *
 remoteproc_get_io_with_name(struct remoteproc *rproc,
 			    const char *name)


### PR DESCRIPTION
Having these functions as inline header functions forces the contents of struct remoteproc_mem to remain externally exposed. It also does not save space in most cases as every call-site gets the full contents of the function instead of just a call instruction. Make these normal functions like all others in remoteproc.h.