### PR TITLE
Avoid unsafe strncpy() edge cases by always 0-terminating destination

### DIFF
--- a/apps/system/linux/machine/generic/platform_info.c
+++ b/apps/system/linux/machine/generic/platform_info.c
@@ -145,6 +145,7 @@ static int sk_unix_client(const char *descr)
 	addr.sun_family = AF_UNIX;
 	strncpy(addr.sun_path, descr + strlen(UNIX_PREFIX),
 		sizeof addr.sun_path);
+	addr.sun_path[sizeof(addr.sun_path) - 1] = '\0';
 	if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) >= 0) {
 		printf("connected to %s\r\n", descr + strlen(UNIX_PREFIX));
 		return fd;
@@ -164,6 +165,7 @@ static int sk_unix_server(const char *descr)
 	addr.sun_family = AF_UNIX;
 	strncpy(addr.sun_path, descr + strlen(UNIXS_PREFIX),
 		sizeof addr.sun_path);
+	addr.sun_path[sizeof(addr.sun_path) - 1] = '\0';
 	unlink(addr.sun_path);
 	if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 		goto fail;

--- a/lib/include/openamp/remoteproc.h
+++ b/lib/include/openamp/remoteproc.h
@@ -580,10 +580,12 @@ remoteproc_init_mem(struct remoteproc_mem *mem, const char *name,
 {
 	if (!mem || !io || size == 0)
 		return;
-	if (name)
+	if (name) {
 		strncpy(mem->name, name, sizeof(mem->name));
-	else
+		mem->name[sizeof(mem->name) - 1] = '\0';
+	} else {
 		mem->name[0] = 0;
+	}
 	mem->pa = pa;
 	mem->da = da;
 	mem->io = io;

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -142,6 +142,7 @@ int rpmsg_send_ns_message(struct rpmsg_endpoint *ept, unsigned long flags)
 	ns_msg.flags = flags;
 	ns_msg.addr = ept->addr;
 	strncpy(ns_msg.name, ept->name, sizeof(ns_msg.name));
+	ns_msg.name[sizeof(ns_msg.name) - 1] = '\0';
 	ret = rpmsg_send_offchannel_raw(ept, ept->addr,
 					RPMSG_NS_EPT_ADDR,
 					&ns_msg, sizeof(ns_msg), true);
@@ -276,6 +277,7 @@ void rpmsg_register_endpoint(struct rpmsg_device *rdev,
 			     rpmsg_ns_unbind_cb ns_unbind_cb)
 {
 	strncpy(ept->name, name ? name : "", sizeof(ept->name));
+	ept->name[sizeof(ept->name) - 1] = '\0';
 	ept->refcnt = 1;
 	ept->addr = src;
 	ept->dest_addr = dest;


### PR DESCRIPTION
@arnopo: as requested.

This PR adds 0-termination of the destination buffer after each call of strncpy() in the open-amp project. In one place optional {...} braces were added to an else branch because its if branch now needs braces.