### PR TITLE
Fix #549

### DIFF
--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -128,6 +128,20 @@ __deprecated static inline int deprecated_rpmsg_slave(void)
 }
 
 /**
+ * @brief Set the virtio callback to manage the wait for TX buffer availability.
+ *
+ * @param rvdev			Pointer to rpmsg virtio device.
+ * @param notify_wait_cb	Callback handler to wait buffer notification.
+ *
+ * @return RPMSG_REMOTE or RPMSG_HOST
+ */
+static inline void rpmsg_virtio_set_wait_cb(struct rpmsg_virtio_device *rvdev,
+					    rpmsg_virtio_notify_wait_cb notify_wait_cb)
+{
+	rvdev->notify_wait_cb = notify_wait_cb;
+}
+
+/**
  * @brief Get rpmsg virtio device role.
  *
  * @param rvdev	Pointer to rpmsg virtio device.

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -821,6 +821,7 @@ int rpmsg_init_vdev_with_config(struct rpmsg_virtio_device *rvdev,
 		return RPMSG_ERR_PARAM;
 
 	rdev = &rvdev->rdev;
+	rvdev->notify_wait_cb = NULL;
 	memset(rdev, 0, sizeof(*rdev));
 	metal_mutex_init(&rdev->lock);
 	rvdev->vdev = vdev;


### PR DESCRIPTION
This Pull request is a fix of the PR #549
The rvdev->notify_wait_cb is never initialized to NULL if not set by the user.
the proposal to fix is to initialize it to NULL and provide an API for the user to set it.

The issue is reproduced using flood-ping test in linux environment.

```
echo "################### run flood test #####################"
LD_LIBRARY_PATH=./bin/usr/local/lib:../../libmetal/build/lib/  ./bin/usr/local/bin/rpmsg-echo-shared &
sleep 1
LD_LIBRARY_PATH=./bin/usr/local/lib:../../libmetal/build/lib/  ./bin/usr/local/bin/msg-test-rpmsg-flood-ping-shared 1 || exit

```
@wyr8899 , pleas could you review it and give a feedback