### PR TITLE
virtio: Remove never used virtio_feature_name()

### DIFF
--- a/lib/virtio/virtio.c
+++ b/lib/virtio/virtio.c
@@ -38,16 +38,6 @@ static const struct virtio_ident {
 	0, NULL}
 };
 
-/* Device independent features. */
-static const struct virtio_feature_desc virtio_common_feature_desc[] = {
-	{VIRTIO_F_NOTIFY_ON_EMPTY, "NotifyOnEmpty"},
-	{VIRTIO_RING_F_INDIRECT_DESC, "RingIndirect"},
-	{VIRTIO_RING_F_EVENT_IDX, "EventIdx"},
-	{VIRTIO_F_BAD_FEATURE, "BadFeature"},
-
-	{0, NULL}
-};
-
 const char *virtio_dev_name(unsigned short devid)
 {
 	const struct virtio_ident *ident;
@@ -60,36 +50,13 @@ const char *virtio_dev_name(unsigned short devid)
 	return NULL;
 }
 
-static const char *virtio_feature_name(unsigned long val,
-				       const struct virtio_feature_desc *desc)
-{
-	int i, j;
-	const struct virtio_feature_desc *descs[2] = { desc,
-		virtio_common_feature_desc
-	};
-
-	for (i = 0; i < 2; i++) {
-		if (!descs[i])
-			continue;
-
-		for (j = 0; descs[i][j].vfd_val != 0; j++) {
-			if (val == descs[i][j].vfd_val)
-				return descs[i][j].vfd_str;
-		}
-	}
-
-	return NULL;
-}
-
 __deprecated void virtio_describe(struct virtio_device *dev, const char *msg,
 				  uint32_t features, struct virtio_feature_desc *desc)
 {
 	(void)dev;
 	(void)msg;
 	(void)features;
-
-	/* TODO: Not used currently - keeping it for future use*/
-	virtio_feature_name(0, desc);
+	(void)desc;
 }
 
 int virtio_create_virtqueues(struct virtio_device *vdev, unsigned int flags,


### PR DESCRIPTION
The comments states this was kept for "future use", that was a decade ago.. Remove this never used function and associated data.