### PR TITLE
Fix broken CI 

### DIFF
--- a/.github/actions/build_ci/Dockerfile
+++ b/.github/actions/build_ci/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # Install prerequisites
-RUN apt-get --quiet=2 update && apt-get install --quiet=2 --assume-yes sudo git python3 python3-pip wget
+RUN apt-get --quiet=2 update && apt-get install --quiet=2 --assume-yes sudo git python3 python3-pip python3-venv wget
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/actions/build_ci/README.md
+++ b/.github/actions/build_ci/README.md
@@ -15,6 +15,27 @@ The supported targets are:
 
 ## Example usage
 
+Inside a github action use:
+```
 uses: ./.github/actions/build_ci
 with:
   target: linux
+```
+
+## Desktop testing
+
+Right now the directory expectations of the CI script are very messy.
+This should be cleaned up in a future PR.
+
+Desktop testing is possible but is likewise messy right now.
+
+One time setup, starting in open-amp directory:
+```
+$ git clone https://github.com/OpenAMP/libmetal.git
+```
+
+A sequence like below will work, change the "zephyr" at the end of the docker command line to "linux" or "generic" for the other working tests
+```
+$ docker build -t openamp-ci .github/actions/build_ci/ && docker run -it --rm -v$PWD:/prj -w /prj openamp-ci zephyr
+$ sudo rm -rf build* zephyr*
+```


### PR DESCRIPTION
The "open-amp lib Continuous Integration / check builds on different platforms" check has failed due to a Docker environment update.

Issues were found related to timezone settings and pip3. Upon fixing these, a build error was reported by GCC (likely a new version) in rpmsg_rpc_client.c.

This PR addresses both issues to restore a working CI environment.