### PR TITLE
lib: rpmsg_rpc: fix compilation warning and bad API

### DIFF
--- a/lib/include/openamp/rpmsg_rpc_client_server.h
+++ b/lib/include/openamp/rpmsg_rpc_client_server.h
@@ -25,13 +25,13 @@ extern "C" {
  * Aligning to 64 bits -> 488UL
  */
 #define MAX_BUF_LEN	488UL
-#define MAX_FUNC_ID_LEN sizeof(unsigned long int)
+#define MAX_FUNC_ID_LEN sizeof(uint32_t)
 
 struct rpmsg_rpc_clt;
 struct rpmsg_rpc_svr;
 
 typedef void (*rpmsg_rpc_shutdown_cb)(struct rpmsg_rpc_clt *rpc);
-typedef void (*app_cb)(struct rpmsg_rpc_clt *rpc, int statust, void *data,
+typedef void (*app_cb)(struct rpmsg_rpc_clt *rpc, int status, void *data,
 		       size_t len);
 typedef int (*rpmsg_rpc_syscall_cb)(void *data, struct rpmsg_rpc_svr *rpcs);
 
@@ -181,7 +181,7 @@ int rpmsg_rpc_server_init(struct rpmsg_rpc_svr *rpcs, struct rpmsg_device *rdev,
  * @return Length of the received response, negative value for failure.
  */
 int rpmsg_rpc_client_send(struct rpmsg_rpc_clt *rpc,
-			  unsigned int rpc_id, void *request_param,
+			  uint32_t rpc_id, void *request_param,
 			  size_t req_param_size);
 
 /**

--- a/lib/service/rpmsg/rpc/rpmsg_rpc_client.c
+++ b/lib/service/rpmsg/rpc/rpmsg_rpc_client.c
@@ -48,7 +48,7 @@ int rpmsg_rpc_client_init(struct rpmsg_rpc_clt *rpc,
 }
 
 int rpmsg_rpc_client_send(struct rpmsg_rpc_clt *rpc,
-			  unsigned int rpc_id, void *request_param,
+			  uint32_t rpc_id, void *request_param,
 			  size_t req_param_size)
 {
 	unsigned char tmpbuf[MAX_BUF_LEN];


### PR DESCRIPTION
Fix following warning by updating bad rpc_id parameter type in the rpmsg_rpc_client_send() API.
Align the rpc_id type to the one used in rpmsg_rpc_server_send().

/github/workspace/lib/service/rpmsg/rpc/rpmsg_rpc_client.c:60:9: error: ‘memcpy’ reading 8 bytes from a region of size 4 [-Werror=stringop-overread]
1286
   60 |  memcpy(tmpbuf, &rpc_id, MAX_FUNC_ID_LEN);
1287
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1288
/github/workspace/lib/service/rpmsg/rpc/rpmsg_rpc_client.c:51:40: note: source object ‘rpc_id’ of size 4
1289
   51 |  unsigned int rpc_id, void *request_param,
1290
      |  ~~~~~~~~~~~~~^~~~~~