### PR TITLE
lib: remove deprecated MASTER/SLAVE configuration

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -60,27 +60,19 @@ endif(NOT ${MACHINE} STREQUAL "zynqmp_r5")
 
 option (WITH_VIRTIO_DRIVER "Build with virtio driver (front end)  enabled" ON)
 option (WITH_VIRTIO_DEVICE "Build with virtio device (back end)  enabled" ON)
-option (WITH_VIRTIO_MASTER "Build with virtio driver (front end)  enabled" OFF)
-option (WITH_VIRTIO_SLAVE "Build with virtio device (back end)  enabled" OFF)
 
-if (WITH_VIRTIO_MASTER)
-  message(DEPRECATION "deprecated cmake option replaced by WITH_VIRTIO_DRIVER" ...)
-endif (WITH_VIRTIO_MASTER)
-if (WITH_VIRTIO_SLAVE)
-  message(DEPRECATION "deprecated cmake option replaced by WITH_VIRTIO_DEVICE" ...)
-endif (WITH_VIRTIO_SLAVE)
 
-if (NOT WITH_VIRTIO_DRIVER AND NOT WITH_VIRTIO_MASTER)
+if (NOT WITH_VIRTIO_DRIVER)
 	add_definitions(-DVIRTIO_DRIVER_SUPPORT=0)
-else (NOT WITH_VIRTIO_DRIVER AND NOT WITH_VIRTIO_MASTER)
+else (NOT WITH_VIRTIO_DRIVER)
 	add_definitions(-DVIRTIO_DRIVER_SUPPORT=1)
-endif (NOT WITH_VIRTIO_DRIVER AND NOT WITH_VIRTIO_MASTER)
+endif (NOT WITH_VIRTIO_DRIVER)
 
-if (NOT WITH_VIRTIO_DEVICE AND NOT WITH_VIRTIO_SLAVE)
+if (NOT WITH_VIRTIO_DEVICE)
 	add_definitions(-DVIRTIO_DEVICE_SUPPORT=0)
-else (NOT WITH_VIRTIO_DEVICE AND NOT WITH_VIRTIO_SLAVE)
+else (NOT WITH_VIRTIO_DEVICE)
 	add_definitions(-DVIRTIO_DEVICE_SUPPORT=1)
-endif (NOT WITH_VIRTIO_DEVICE AND NOT WITH_VIRTIO_SLAVE)
+endif (NOT WITH_VIRTIO_DEVICE)
 
 option (WITH_VIRTIO_MMIO_DRV "Build with virtio mmio driver support enabled" OFF)
 

--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -112,21 +112,6 @@ struct rpmsg_virtio_device {
 #define RPMSG_REMOTE	VIRTIO_DEV_DEVICE
 #define RPMSG_HOST	VIRTIO_DEV_DRIVER
 
-#define RPMSG_SLAVE        deprecated_rpmsg_slave()
-#define RPMSG_MASTER       deprecated_rpmsg_master()
-
-__deprecated static inline int deprecated_rpmsg_master(void)
-{
-	/* "RPMSG_MASTER is deprecated, please use RPMSG_HOST" */
-	return RPMSG_HOST;
-}
-
-__deprecated static inline int deprecated_rpmsg_slave(void)
-{
-	/* "RPMSG_SLAVE is deprecated, please use RPMSG_REMOTE" */
-	return RPMSG_REMOTE;
-}
-
 /**
  * @brief Set the virtio callback to manage the wait for TX buffer availability.
  *

--- a/lib/include/openamp/virtio.h
+++ b/lib/include/openamp/virtio.h
@@ -70,29 +70,6 @@ extern "C" {
 #define VIRTIO_DEV_DRIVER	0UL
 #define VIRTIO_DEV_DEVICE	1UL
 
-#define VIRTIO_DEV_MASTER	deprecated_virtio_dev_master()
-#define VIRTIO_DEV_SLAVE	deprecated_virtio_dev_slave()
-
-__deprecated static inline int deprecated_virtio_dev_master(void)
-{
-	/* "VIRTIO_DEV_MASTER is deprecated, please use VIRTIO_DEV_DRIVER" */
-	return VIRTIO_DEV_DRIVER;
-}
-
-__deprecated static inline int deprecated_virtio_dev_slave(void)
-{
-	/* "VIRTIO_DEV_SLAVE is deprecated, please use VIRTIO_DEV_DEVICE" */
-	return VIRTIO_DEV_DEVICE;
-}
-
-#ifdef VIRTIO_MASTER_ONLY
-#warning "VIRTIO_MASTER_ONLY is deprecated, please use VIRTIO_DEVICE_SUPPORT=0"
-#endif
-
-#ifdef VIRTIO_SLAVE_ONLY
-#warning "VIRTIO_SLAVE_ONLY is deprecated, please use VIRTIO_DRIVER_SUPPORT=0"
-#endif
-
 #ifdef VIRTIO_DRIVER_ONLY
 #warning "VIRTIO_DRIVER_ONLY is deprecated, please use VIRTIO_DEVICE_SUPPORT=0"
 #endif


### PR DESCRIPTION
The use of the master and slave wors in configs and API are now deprecated since 2 years, we can remove the associated code.