### PR TITLE
apps: remove remaining master terminology

### DIFF
--- a/apps/machine/zynq7/platform_info_remoteproc_master.c
+++ b/apps/machine/zynq7/platform_info_remoteproc_master.c
@@ -31,7 +31,7 @@ extern struct hil_platform_ops zynq_a9_proc_ops;
 #define SHM_SIZE                          0x00200000
 #define VRING0_IPI_VECT                   6
 #define VRING1_IPI_VECT                   3
-#define MASTER_CPU_ID                     0
+#define HOST_CPU_ID                       0
 #define REMOTE_CPU_ID                     1
 
 /**

--- a/apps/machine/zynq7/platform_info_remoteproc_master.c
+++ b/apps/machine/zynq7/platform_info_remoteproc_master.c
@@ -35,7 +35,7 @@ extern struct hil_platform_ops zynq_a9_proc_ops;
 #define REMOTE_CPU_ID                     1
 
 /**
- * This array provdes defnition of CPU nodes for host and remote
+ * This array provides definition of CPU nodes for host and remote
  * context. It contains two nodes because the same file is intended
  * to use with both host and remote configurations. On zynq platform
  * only one node definition is required for host/remote as there
@@ -51,7 +51,7 @@ extern struct hil_platform_ops zynq_a9_proc_ops;
  * -Channel info.
  *
  * Although the channel info is not platform specific information
- * but it is conveneient to keep it in HIL so that user can easily
+ * but it is convenient to keep it in HIL so that user can easily
  * provide it without modifying the generic part.
  *
  * It is good idea to define hil_proc structure with platform

--- a/apps/tests/msg/rpmsg-nocopy-echo.c
+++ b/apps/tests/msg/rpmsg-nocopy-echo.c
@@ -140,7 +140,7 @@ int app(struct rpmsg_device *rdev, void *priv)
 			break;
 		}
 		while (rpmsg_list) {
-			/* Send data back to master */
+			/* Send data back to host */
 			ret = rpmsg_send(rpmsg_list->ept, rpmsg_list->data,
 					 rpmsg_list->len);
 			if (ret < 0) {


### PR DESCRIPTION
Some potentially offensive terms are still present in the code, Replace them.