### PR TITLE
[FIX FOR V2024.05] lib: fix build error using legacy VIRTIO_DEVICE/DRIVER_ONLY

### DIFF
--- a/lib/include/openamp/virtio.h
+++ b/lib/include/openamp/virtio.h
@@ -70,13 +70,21 @@ extern "C" {
 #define VIRTIO_DEV_DRIVER	0UL
 #define VIRTIO_DEV_DEVICE	1UL
 
+#if !defined(VIRTIO_DRIVER_SUPPORT) && !defined(VIRTIO_DEVICE_SUPPORT)
 #ifdef VIRTIO_DRIVER_ONLY
 #warning "VIRTIO_DRIVER_ONLY is deprecated, please use VIRTIO_DEVICE_SUPPORT=0"
-#endif
-
-#ifdef VIRTIO_DEVICE_ONLY
+#define VIRTIO_DRIVER_SUPPORT 1
+#define VIRTIO_DEVICE_SUPPORT 0
+#elif VIRTIO_DEVICE_ONLY
 #warning "VIRTIO_DEVICE_ONLY is deprecated, please use VIRTIO_DRIVER_SUPPORT=0"
-#endif
+#define VIRTIO_DRIVER_SUPPORT 0
+#define VIRTIO_DEVICE_SUPPORT 1
+#else
+#warning "VIRTIO_DRIVER_SUPPORT and/or VIRTIO_DEVICE_SUPPORT should be defined"
+#define VIRTIO_DRIVER_SUPPORT 1
+#define VIRTIO_DEVICE_SUPPORT 1
+#endif /* VIRTIO_DRIVER_ONLY */
+#endif /*!defined(VIRTIO_DRIVER_SUPPORT) && !defined(VIRTIO_DEVICE_SUPPORT)*/
 
 #define VIRTIO_ENABLED(option) (option == 1)
 


### PR DESCRIPTION
As part of the deprecation process for VIRTIO_DEVICE_ONLY and VIRTIO_DRIVER_ONLY, we should still support builds without errors when possible.
For legacy support, define VIRTIO_DRIVER_SUPPORT and VIRTIO_DEVICE_SUPPORT default values based on VIRTIO_DEVICE_ONLY and VIRTIO_DRIVER_ONLY.