### PR TITLE
Documentation: fix license.md and readme.md formating

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,7 +15,7 @@ modification, are permitted provided that the following conditions are met:
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
 
-3. Neither the name of <the copyright holder> nor the names of its contributors
+3. Neither the name of `<the copyright holder>` nor the names of its contributors
    may be used to endorse or promote products derived from this software
    without specific prior written permission.
 
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 BSD 2-Clause License
 -------------------------
 
-Copyright (c) <year> <owner>. All rights reserved.
+Copyright (c) `<year> <owner>`. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -117,21 +117,21 @@ process.
 ### Example to compile OpenAMP for communication between Linux processes:
 * Install libsysfs devel and libhugetlbfs devel packages on your Linux host.
 * build libmetal library on your host as follows:
-
-    ```
-        $ mkdir -p build-libmetal
-        $ cd build-libmetal
-        $ cmake <libmetal_source>
-        $ make VERBOSE=1 DESTDIR=<libmetal_install> install
-    ```
+  ```
+  $ mkdir -p build-libmetal
+  $ cd build-libmetal
+  $ cmake <libmetal_source>
+  $ make VERBOSE=1 DESTDIR=<libmetal_install> install
+  ```
 
 * build OpenAMP library on your host as follows:
-
-        $ mkdir -p build-openamp
-        $ cd build-openamp
-        $ cmake <openamp_source> -DCMAKE_INCLUDE_PATH=<libmetal_built_include_dir> \
+   ```
+  $ mkdir -p build-openamp
+  $ cd build-openamp
+  $ cmake <openamp_source> -DCMAKE_INCLUDE_PATH=<libmetal_built_include_dir> \
               -DCMAKE_LIBRARY_PATH=<libmetal_built_lib_dir> [-DWITH_APPS=ON]
-        $ make VERBOSE=1 DESTDIR=$(pwd) install
+  $ make VERBOSE=1 DESTDIR=$(pwd) install
+  ```
 
 The OpenAMP library will be generated to `build/usr/local/lib` directory,
 headers will be generated to `build/usr/local/include` directory, and the
@@ -143,76 +143,74 @@ directory.
   your Linux host as follows:
 
   * rpmsg echo demo:
-    ```
-    # Start echo test server to wait for message to echo
-    $ sudo LD_LIBRARY_PATH=<openamp_built>/usr/local/lib:<libmetal_built>/usr/local/lib \
-       build/usr/local/bin/rpmsg-echo-shared
-    # Run echo test to send message to echo test server
-    $ sudo LD_LIBRARY_PATH=<openamp_built>/usr/local/lib:<libmetal_built>/usr/local/lib \
-       build/usr/local/bin/rpmsg-echo-ping-shared 1
-    ```
+  ```
+  # Start echo test server to wait for message to echo
+  $ sudo LD_LIBRARY_PATH=<openamp_built>/usr/local/lib:<libmetal_built>/usr/local/lib \
+     build/usr/local/bin/rpmsg-echo-shared
+  # Run echo test to send message to echo test server
+  $ sudo LD_LIBRARY_PATH=<openamp_built>/usr/local/lib:<libmetal_built>/usr/local/lib \
+     build/usr/local/bin/rpmsg-echo-ping-shared 1
+  ```
 
   * rpmsg echo demo with the nocopy API:
-    ```
-    # Start echo test server to wait for message to echo
-    $ sudo LD_LIBRARY_PATH=<openamp_built>/usr/local/lib:<libmetal_built>/usr/local/lib \
-       build/usr/local/bin/rpmsg-nocopy-echo-shared
-    # Run echo test to send message to echo test server
-    $ sudo LD_LIBRARY_PATH=<openamp_built>/usr/local/lib:<libmetal_built>/usr/local/lib \
-       build/usr/local/bin/rpmsg-nocopy-ping-shared 1
-    ```
+  ```
+  # Start echo test server to wait for message to echo
+  $ sudo LD_LIBRARY_PATH=<openamp_built>/usr/local/lib:<libmetal_built>/usr/local/lib \
+     build/usr/local/bin/rpmsg-nocopy-echo-shared
+  # Run echo test to send message to echo test server
+  $ sudo LD_LIBRARY_PATH=<openamp_built>/usr/local/lib:<libmetal_built>/usr/local/lib \
+     build/usr/local/bin/rpmsg-nocopy-ping-shared 1
+  ```
 
 ###  Example to compile Zynq UltraScale+ MPSoC R5 generic(baremetal) remote:
 * build libmetal library on your host as follows:
   * Create your on cmake toolchain file to compile libmetal for your generic
     (baremetal) platform. Here is the example of the toolchain file:
+  ```
+  set (CMAKE_SYSTEM_PROCESSOR "arm"              CACHE STRING "")
+  set (MACHINE "zynqmp_r5" CACHE STRING "")
 
-    ```
-        set (CMAKE_SYSTEM_PROCESSOR "arm"              CACHE STRING "")
-        set (MACHINE "zynqmp_r5" CACHE STRING "")
+  set (CROSS_PREFIX           "armr5-none-eabi-" CACHE STRING "")
+  set (CMAKE_C_FLAGS          "-mfloat-abi=soft -mcpu=cortex-r5 -Wall -Werror -Wextra \
+         -flto -Os -I/ws/xsdk/r5_0_bsp/psu_cortexr5_0/include" CACHE STRING "")
 
-        set (CROSS_PREFIX           "armr5-none-eabi-" CACHE STRING "")
-        set (CMAKE_C_FLAGS          "-mfloat-abi=soft -mcpu=cortex-r5 -Wall -Werror -Wextra \
-           -flto -Os -I/ws/xsdk/r5_0_bsp/psu_cortexr5_0/include" CACHE STRING "")
+  SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
+  SET(CMAKE_AR  "gcc-ar" CACHE STRING "")
+  SET(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+  SET(CMAKE_C_ARCHIVE_FINISH   true)
 
-        SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
-        SET(CMAKE_AR  "gcc-ar" CACHE STRING "")
-        SET(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
-        SET(CMAKE_C_ARCHIVE_FINISH   true)
-
-        include (cross-generic-gcc)
-    ```
+  include (cross-generic-gcc)
+  ```
 
   * Compile libmetal library:
-
-    ```
-        $ mkdir -p build-libmetal
-        $ cd build-libmetal
-        $ cmake <libmetal_source> -DCMAKE_TOOLCHAIN_FILE=<toolchain_file>
-        $ make VERBOSE=1 DESTDIR=<libmetal_install> install
-    ```
+  ```
+  $ mkdir -p build-libmetal
+  $ cd build-libmetal
+  $ cmake <libmetal_source> -DCMAKE_TOOLCHAIN_FILE=<toolchain_file>
+  $ make VERBOSE=1 DESTDIR=<libmetal_install> install
+  ```
 
 * build OpenAMP library on your host as follows:
   * Create your on cmake toolchain file to compile openamp for your generic
     (baremetal) platform. Here is the example of the toolchain file:
-    ```
-        set (CMAKE_SYSTEM_PROCESSOR "arm" CACHE STRING "")
-        set (MACHINE                "zynqmp_r5" CACHE STRING "")
-        set (CROSS_PREFIX           "armr5-none-eabi-" CACHE STRING "")
-        set (CMAKE_C_FLAGS          "-mfloat-abi=soft -mcpu=cortex-r5 -Os -flto \
+  ```
+  set (CMAKE_SYSTEM_PROCESSOR "arm" CACHE STRING "")
+  set (MACHINE                "zynqmp_r5" CACHE STRING "")
+  set (CROSS_PREFIX           "armr5-none-eabi-" CACHE STRING "")
+  set (CMAKE_C_FLAGS          "-mfloat-abi=soft -mcpu=cortex-r5 -Os -flto \
           -I/ws/libmetal-r5-generic/usr/local/include \
           -I/ws/xsdk/r5_0_bsp/psu_cortexr5_0/include" CACHE STRING "")
-        set (CMAKE_ASM_FLAGS        "-mfloat-abi=soft -mcpu=cortex-r5" CACHE STRING "")
-        set (PLATFORM_LIB_DEPS      "-lxil -lc -lm" CACHE STRING "")
-        SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
-        SET(CMAKE_AR  "gcc-ar" CACHE STRING "")
-        SET(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
-        SET(CMAKE_C_ARCHIVE_FINISH   true)
-        set (CMAKE_FIND_ROOT_PATH /ws/libmetal-r5-generic/usr/local/lib \
+  set (CMAKE_ASM_FLAGS        "-mfloat-abi=soft -mcpu=cortex-r5" CACHE STRING "")
+  set (PLATFORM_LIB_DEPS      "-lxil -lc -lm" CACHE STRING "")
+  SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
+  SET(CMAKE_AR  "gcc-ar" CACHE STRING "")
+  SET(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+  SET(CMAKE_C_ARCHIVE_FINISH   true)
+  set (CMAKE_FIND_ROOT_PATH /ws/libmetal-r5-generic/usr/local/lib \
             /ws/xsdk/r5_bsp/psu_cortexr5_0/lib )
 
-        include (cross_generic_gcc)
-    ```
+  include (cross_generic_gcc)
+  ```
 
   * We use cmake `find_path` and `find_library` to check if libmetal includes
     and libmetal library is in the includes and library search paths. However,
@@ -220,13 +218,12 @@ directory.
     `CMAKE_LIBRARY_PATH` variables, and thus, we need to specify those paths
     in the toolchain file with `CMAKE_C_FLAGS` and `CMAKE_FIND_ROOT_PATH`.
 * Compile the OpenAMP library:
-
-    ```
-    $ mkdir -p build-openamp
-    $ cd build-openamp
-    $ cmake <openamp_source> -DCMAKE_TOOLCHAIN_FILE=<toolchain_file>
-    $ make VERBOSE=1 DESTDIR=$(pwd) install
-    ```
+  ```
+  $ mkdir -p build-openamp
+  $ cd build-openamp
+  $ cmake <openamp_source> -DCMAKE_TOOLCHAIN_FILE=<toolchain_file>
+  $ make VERBOSE=1 DESTDIR=$(pwd) install
+  ```
 
 The OpenAMP library will be generated to `build/usr/local/lib` directory,
 headers will be generated to `build/usr/local/include` directory, and the
@@ -280,26 +277,25 @@ Code is contributed to the Linux kernel under a number of licenses, but all code
 with version the [BSD License](https://github.com/OpenAMP/open-amp/blob/main/LICENSE.md), which is
 the license covering the OpenAMP distribution as a whole. In practice, use the following tag
 instead of the full license text in the individual files:
-
-    ```
-    SPDX-License-Identifier:    BSD-3-Clause
-    SPDX-License-Identifier:    BSD-2-Clause
-    ```
+  ```
+  SPDX-License-Identifier:    BSD-3-Clause
+  SPDX-License-Identifier:    BSD-2-Clause
+  ```
 ### Signed-off-by
 Commit message must contain Signed-off-by: line and your email must match the change authorship
 information. Make sure your .gitconfig is set up correctly:
-
-    ```
-    git config --global user.name "first-name Last-Namer"
-    git config --global user.email "yourmail@company.com"
-    ```
+  ```
+  git config --global user.name "first-name Last-Namer"
+  git config --global user.email "yourmail@company.com"
+  ```
 ### gitlint
 Before you submit a pull request to the project, verify your commit messages meet the requirements.
 The check can be  performed locally using the the gitlint command.
 
 Run gitlint locally in your tree and branch where your patches have been committed:
-
-      ```gitlint```
+  ```
+  gitlint
+  ```
 Note, gitlint only checks HEAD (the most recent commit), so you should run it after each commit, or
 use the --commits option to specify a commit range covering all the development patches to be
 submitted.
@@ -313,10 +309,9 @@ The Linux kernel GPL-licensed tool checkpatch is used to check coding style conf
 available in the scripts directory.
 
 To check your \<n\> commits in your git branch:
-   ```
-   ./scripts/checkpatch.pl --strict  -g HEAD-<n>
-
-   ```
+  ```
+  ./scripts/checkpatch.pl --strict  -g HEAD-<n>
+  ```
 ### Send a pull request
 We use standard github mechanism for pull request. Please refer to github documentation for help.
 


### PR DESCRIPTION
Fix Doxygen warnings on markdown files.
The reported warning is "warning: Unsupported xml/html tag <....>"

This also corrects the display of markdown file in GitHub.