### PR TITLE
virtio_mmio: Remove unneeded use of libmetal device

### DIFF
--- a/lib/include/openamp/virtio_mmio.h
+++ b/lib/include/openamp/virtio_mmio.h
@@ -143,10 +143,10 @@ struct virtio_mmio_device {
 	struct virtio_device vdev;
 
 	/** Device configuration space metal_io_region */
-	struct metal_io_region *cfg_io;
+	struct metal_io_region cfg_io;
 
 	/** Pre-shared memory space metal_io_region */
-	struct metal_io_region *shm_io;
+	struct metal_io_region shm_io;
 
 	/** VIRTIO device configuration space */
 	struct virtio_mmio_dev_mem cfg_mem;

--- a/lib/include/openamp/virtio_mmio.h
+++ b/lib/include/openamp/virtio_mmio.h
@@ -148,9 +148,6 @@ struct virtio_mmio_device {
 	/** Pre-shared memory space metal_io_region */
 	struct metal_io_region *shm_io;
 
-	/** Shared memory device */
-	struct metal_device shm_device;
-
 	/** VIRTIO device configuration space */
 	struct virtio_mmio_dev_mem cfg_mem;
 


### PR DESCRIPTION
A virtual metal_device is created, then the needed IO regions are created and added to this device. Immediately we extract these same regions back out and make use of them. There is no reason to do this, instead simply use the created IO regions.

This also removes the need to have struct metal_device defined to have more than one IO region (METAL_MAX_DEVICE_REGIONS), which is not the default and can change per-platform. If the libmetal library was built with the default value for METAL_MAX_DEVICE_REGIONS, then this would have led to runtime failures.