### PR TITLE
rpmsg_virtio: rpmsg_deinit_vdev: Add check for empty endpoint list

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -957,6 +957,15 @@ void rpmsg_deinit_vdev(struct rpmsg_virtio_device *rvdev)
 			node = rdev->endpoints.next;
 			ept = metal_container_of(node, struct rpmsg_endpoint, node);
 			rpmsg_destroy_ept(ept);
+
+			/*
+			 * The first node will still be present because the
+			 * first node is created before endpoints. So
+			 * exit the loop if only this original node remains.
+			 */
+			if (!node->next) {
+				break;
+			}
 		}
 
 		rvdev->rvq = 0;


### PR DESCRIPTION
There can exist scenario where the endpoint list in a rpmsg vdev can be empty of endpoint-created nodes but the original remains, check if that is the case to ensure the while loop can properly terminate.