### PR TITLE
openamp: move notify_wait() in rpmsg virtio to rpmsg.

### DIFF
--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -55,6 +55,7 @@ typedef void (*rpmsg_ept_release_cb)(struct rpmsg_endpoint *ept);
 typedef void (*rpmsg_ns_unbind_cb)(struct rpmsg_endpoint *ept);
 typedef void (*rpmsg_ns_bind_cb)(struct rpmsg_device *rdev,
 				 const char *name, uint32_t dest);
+typedef int (*rpmsg_notify_wait_cb)(struct rpmsg_device *rdev, uint32_t id);
 
 /**
  * @brief Structure that binds a local RPMsg address to its user
@@ -150,7 +151,11 @@ struct rpmsg_device {
 	/** Callback handler for name service announcement, called when remote ept is destroyed */
 	rpmsg_ns_bind_cb ns_unbind_cb;
 
+	/** callback handler for rpmsg service, called when service can't get tx buffer */
+	rpmsg_notify_wait_cb notify_wait_cb;
+
 	/** RPMsg device operations */
+
 	struct rpmsg_device_ops ops;
 
 	/** Create/destroy namespace message */

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -385,3 +385,11 @@ void rpmsg_destroy_ept(struct rpmsg_endpoint *ept)
 		(void)rpmsg_send_ns_message(ept, RPMSG_NS_DESTROY);
 	rpmsg_unregister_endpoint(ept);
 }
+
+int rpmsg_notify_wait(struct rpmsg_device *rdev, uint32_t id)
+{
+	if (rdev->notify_wait_cb)
+		return rdev->notify_wait_cb(rdev, id);
+
+	return RPMSG_ERR_NXIO;
+}

--- a/lib/rpmsg/rpmsg_internal.h
+++ b/lib/rpmsg/rpmsg_internal.h
@@ -108,6 +108,8 @@ rpmsg_get_ept_from_addr(struct rpmsg_device *rdev, uint32_t addr)
 	return rpmsg_get_endpoint(rdev, NULL, addr, RPMSG_ADDR_ANY);
 }
 
+int rpmsg_notify_wait(struct rpmsg_device *rdev, uint32_t id);
+
 /**
  * @internal
  *

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -342,16 +342,14 @@ static void rpmsg_virtio_release_rx_buffer(struct rpmsg_device *rdev,
 	metal_mutex_release(&rdev->lock);
 }
 
-static int rpmsg_virtio_notify_wait(struct rpmsg_virtio_device *rvdev, struct virtqueue *vq)
+static int rpmsg_virtio_notify_wait(struct rpmsg_virtio_device *rvdev,
+				    struct virtqueue *vq)
 {
 	struct virtio_vring_info *vring_info;
 
 	vring_info = &rvdev->vdev->vrings_info[vq->vq_queue_index];
 
-	if (!rvdev->notify_wait_cb)
-		return RPMSG_EOPNOTSUPP;
-
-	return rvdev->notify_wait_cb(&rvdev->rdev, vring_info->notifyid);
+	return rpmsg_notify_wait(&rvdev->rdev, vring_info->notifyid);
 }
 
 static void *rpmsg_virtio_get_tx_payload_buffer(struct rpmsg_device *rdev,


### PR DESCRIPTION
This ops can do in rpmsg without coupling to virtio.