### PR TITLE
rpmsg: Allow to send virtqueue_kick only when RX queue is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ library for it project:
   This option can be set to OFF if the only the remote mode is implemented.
 * **WITH_VIRTIO_DEVICE** (default ON): Build with virtio device enabled.
   This option can be set to OFF if the only the driver mode is implemented.
+* **WITH_VQ_RX_EMPTY_NOTIFY** (default OFF): Choose notify mode. When set to
+  ON, only notify when there are no more Message in the RX queue. When set to
+  OFF, notify for each RX buffer released.
 * **WITH_STATIC_LIB** (default ON): Build with a static library.
 * **WITH_SHARED_LIB** (default ON): Build with a shared library.
 * **WITH_ZEPHYR** (default OFF): Build open-amp as a zephyr library. This option

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -80,6 +80,14 @@ if (WITH_VIRTIO_MMIO_DRV)
   add_definitions(-DWITH_VIRTIO_MMIO_DRV)
 endif (WITH_VIRTIO_MMIO_DRV)
 
+option (WITH_VQ_RX_EMPTY_NOTIFY "Build with virtqueue rx empty notify enabled" OFF)
+
+if (NOT WITH_VQ_RX_EMPTY_NOTIFY)
+  add_definitions(-DVQ_RX_EMPTY_NOTIFY=0)
+else (NOT WITH_VQ_RX_EMPTY_NOTIFY)
+  add_definitions(-DVQ_RX_EMPTY_NOTIFY=1)
+endif (NOT WITH_VQ_RX_EMPTY_NOTIFY)
+
 option (WITH_DCACHE "Build with all cache operations enabled" OFF)
 
 if (WITH_DCACHE)


### PR DESCRIPTION
Add VQ_RX_EMPTY_NOTIFY config to define the behavior. If VQ_RX_EMPTY_NOTIFY is disabled, notify the other side each time a buffer is released. If VQ_RX_EMPTY_NOTIFY is enabled, only send one notification when the RX queue is empty to improve performance.