### PR TITLE
remoteproc.c: fix compile error

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -306,7 +306,7 @@ void remoteproc_init_mem(struct remoteproc_mem *mem, const char *name,
 	if (!mem || !io || size == 0)
 		return;
 	if (name)
-		strncpy(mem->name, name, sizeof(mem->name));
+		strncpy(mem->name, name, sizeof(mem->name) - 1);
 	else
 		mem->name[0] = 0;
 	mem->pa = pa;


### PR DESCRIPTION
CC:  open-amp/lib/rpmsg/rpmsg_virtio.c open-amp/lib/remoteproc/remoteproc.c: In function 'remoteproc_init_mem': open-amp/lib/remoteproc/remoteproc.c:309:17: error: 'strncpy' specified bound 32 equals destination size [-Werror=stringop-truncation]
  309 |                 strncpy(mem->name, name, sizeof(mem->name));