### PR TITLE
lib: fix usage of strncpy

### DIFF
--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -305,10 +305,12 @@ void remoteproc_init_mem(struct remoteproc_mem *mem, const char *name,
 {
 	if (!mem || !io || size == 0)
 		return;
-	if (name)
-		strncpy(mem->name, name, sizeof(mem->name));
-	else
+	if (name) {
+		strncpy(mem->name, name, sizeof(mem->name) - 1);
+		mem->name[sizeof(mem->name) - 1] = 0;
+	} else {
 		mem->name[0] = 0;
+	}
 	mem->pa = pa;
 	mem->da = da;
 	mem->io = io;

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -141,7 +141,8 @@ int rpmsg_send_ns_message(struct rpmsg_endpoint *ept, unsigned long flags)
 
 	ns_msg.flags = flags;
 	ns_msg.addr = ept->addr;
-	strncpy(ns_msg.name, ept->name, sizeof(ns_msg.name));
+	strncpy(ns_msg.name, ept->name, sizeof(ns_msg.name) - 1);
+	ns_msg.name[sizeof(ns_msg.name) - 1] = '\0';
 	ret = rpmsg_send_offchannel_raw(ept, ept->addr,
 					RPMSG_NS_EPT_ADDR,
 					&ns_msg, sizeof(ns_msg), true);
@@ -305,7 +306,8 @@ void rpmsg_register_endpoint(struct rpmsg_device *rdev,
 			     rpmsg_ept_cb cb,
 			     rpmsg_ns_unbind_cb ns_unbind_cb, void *priv)
 {
-	strncpy(ept->name, name ? name : "", sizeof(ept->name));
+	strncpy(ept->name, name ? name : "", sizeof(ept->name) - 1);
+	ept->name[sizeof(ept->name) - 1] = '\0';
 	ept->refcnt = 1;
 	ept->addr = src;
 	ept->dest_addr = dest;


### PR DESCRIPTION
Make sure that the copied-to buffer is null-terminated. This fixes the `stringop-truncation` compilation error.