### PR TITLE
Update CI

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -31,19 +31,20 @@ pre_build(){
 build_linux(){
 	echo  " Build for linux"
 	apt-get install -y libsysfs-dev libhugetlbfs-dev gcc || exit 1
+	export PROJECT_ROOT=$PWD
 	export || exit 1
 	pwd || exit 1
 	ls -l || exit 1
-	cd libmetal || exit 1
+	cd $PROJECT_ROOT/libmetal || exit 1
 	cmake . -Bbuild \
 	-DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" || exit 1
 	cd build || exit 1
 	make || exit 1
 	export || exit 1
-	cd ../.. || exit 1
+	cd $PROJECT_ROOT/open-amp || exit 1
 	cmake . -Bbuild -DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" \
-	-DWITH_APPS=on -DWITH_PROXY=on -DCMAKE_INCLUDE_PATH="./libmetal/build/lib/include"  \
-	-DCMAKE_LIBRARY_PATH="./libmetal/build/lib" || exit 1
+	-DWITH_APPS=on -DWITH_PROXY=on -DCMAKE_INCLUDE_PATH="$PROJECT_ROOT/libmetal/build/lib/include"  \
+	-DCMAKE_LIBRARY_PATH="$PROJECT_ROOT/libmetal/build/lib" || exit 1
 	cd build || exit 1
 	make VERBOSE=1 all || exit 1
 	exit 0
@@ -52,17 +53,18 @@ build_linux(){
 build_generic(){
 	echo  " Build for generic platform "
 	apt-get install -y gcc-arm-none-eabi || exit 1
-	cd libmetal || exit 1
+	export PROJECT_ROOT=$PWD
+	cd $PROJECT_ROOT/libmetal || exit 1
 	cmake . -Bbuild-generic -DCMAKE_TOOLCHAIN_FILE=template-generic \
 	-DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" || exit 1
 	cd build-generic || exit 1
 	make VERBOSE=1 || exit 1
-	cd ../../ || exit 1
+	cd $PROJECT_ROOT/open-amp || exit 1
 	cmake . -Bbuild-generic -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" \
 	-DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" \
 	-DCMAKE_SYSTEM_PROCESSOR="arm" -DCMAKE_C_COMPILER=arm-none-eabi-gcc \
-	-DCMAKE_INCLUDE_PATH="./libmetal/build-generic/lib/include" \
-	-DCMAKE_LIBRARY_PATH="./libmetal/build-generic/lib" || exit 1
+	-DCMAKE_INCLUDE_PATH="$PROJECT_ROOT/libmetal/build-generic/lib/include" \
+	-DCMAKE_LIBRARY_PATH="$PROJECT_ROOT/libmetal/build-generic/lib" || exit 1
 	cd build-generic || exit 1
 	make VERBOSE=1 || exit 1
 	exit 0
@@ -89,6 +91,7 @@ build_zephyr(){
 	sudo apt-get install -y libc6-dev-i386 gperf g++ python3-ply python3-yaml device-tree-compiler ncurses-dev uglifyjs -qq || exit 1
 	pip3 install west || exit 1
 
+	export PROJECT_ROOT=$PWD
 	wget $ZEPHYR_SDK_DOWNLOAD_URL || exit 1
 	tar xvf $ZEPHYR_SDK_SETUP_TAR || exit 1
 	rm -rf $ZEPHYR_SDK_INSTALL_DIR || exit 1
@@ -100,11 +103,11 @@ build_zephyr(){
 	pip3 install  -r ./zephyr/scripts/requirements.txt || exit 1
 	echo  "Update zephyr OpenAMP repos"
 	#Update zephyr OpenAMP repos
-	cp -r ../lib modules/lib/open-amp/open-amp/ || exit 1
-	cp ../CMakeLists.txt modules/lib/open-amp/open-amp/ || exit 1
-	cp ../VERSION modules/lib/open-amp/open-amp/ || exit 1
-	cp -r ../cmake modules/lib/open-amp/open-amp/ || exit 1
-	cp -r ../libmetal modules/hal/libmetal/ || exit 1
+	cp -r $PROJECT_ROOT/open-amp/lib modules/lib/open-amp/open-amp/ || exit 1
+	cp $PROJECT_ROOT/open-amp/CMakeLists.txt modules/lib/open-amp/open-amp/ || exit 1
+	cp $PROJECT_ROOT/open-amp/VERSION modules/lib/open-amp/open-amp/ || exit 1
+	cp -r $PROJECT_ROOT/open-amp/cmake modules/lib/open-amp/open-amp/ || exit 1
+	cp -r $PROJECT_ROOT/libmetal modules/hal/libmetal/ || exit 1
 	cd ./zephyr || exit 1
 	source zephyr-env.sh || exit 1
 	echo  "build openamp sample"

--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -32,21 +32,27 @@ build_linux(){
 	echo  " Build for linux"
 	apt-get install -y libsysfs-dev libhugetlbfs-dev gcc || exit 1
 	export PROJECT_ROOT=$PWD
-	export || exit 1
-	pwd || exit 1
-	ls -l || exit 1
-	cd $PROJECT_ROOT/libmetal || exit 1
-	cmake . -Bbuild \
-	-DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" || exit 1
-	cd build || exit 1
-	make || exit 1
-	export || exit 1
-	cd $PROJECT_ROOT/open-amp || exit 1
-	cmake . -Bbuild -DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" \
-	-DWITH_APPS=on -DWITH_PROXY=on -DCMAKE_INCLUDE_PATH="$PROJECT_ROOT/libmetal/build/lib/include"  \
-	-DCMAKE_LIBRARY_PATH="$PROJECT_ROOT/libmetal/build/lib" || exit 1
-	cd build || exit 1
-	make VERBOSE=1 all || exit 1
+	echo " -- Build libmetal --"
+	cd $PROJECT_ROOT/libmetal &&
+	cmake . -Bbuild -DCMAKE_INSTALL_PREFIX=$PROJECT_ROOT/target \
+		-DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" || exit 1
+	make -C build install || exit 1
+	echo " -- Build open_amp --"
+	cd $PROJECT_ROOT/open-amp
+	cmake . -Bbuild -DCMAKE_INCLUDE_PATH=$PROJECT_ROOT/libmetal/build/lib/include/ \
+		-DCMAKE_LIBRARY_PATH=$PROJECT_ROOT/libmetal/build/lib/ \
+		-DCMAKE_INSTALL_PREFIX=$PROJECT_ROOT/target   -DWITH_PROXY=on \
+		-DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" || exit 1
+	make -C build install || exit 1
+	pwd
+	echo " -- Build legacy Apps --"
+	cd $PROJECT_ROOT/openamp-system-reference/examples/legacy_apps
+	cmake -Bbuild \
+		-DCMAKE_INCLUDE_PATH="$PROJECT_ROOT/libmetal/build/lib/include/;$PROJECT_ROOT/open-amp/build/lib/include/" \
+		-DCMAKE_LIBRARY_PATH="$PROJECT_ROOT/libmetal/build/lib/;$PROJECT_ROOT/open-amp/build/lib/" \
+		-DCMAKE_INSTALL_PREFIX=$PROJECT_ROOT/target  \
+		-DCMAKE_C_FLAGS="-Werror -Wall -Wextra -Wshadow -Wunused-but-set-variable" || exit 1
+	make -C build install || exit 1
 	exit 0
 }
 

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -10,6 +10,7 @@ on:
       - docs/**
       - cmake/**
       - scripts/**
+      - .github/**
 
 jobs:
   checkpatch_review:

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,6 +31,11 @@ jobs:
       with:
         repository: OpenAMP/libmetal
         path: libmetal
+    - name: Checkout openamp-system-reference
+      uses: actions/checkout@v4
+      with:
+        repository: OpenAMP/openamp-system-reference
+        path: openamp-system-reference
     - name: build for Linux
       id: build_linux
       uses: ./open-amp/.github/actions/build_ci

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout open-amp
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Checkout libmetal
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: OpenAMP/libmetal
         path: libmetal

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout open-amp
       uses: actions/checkout@v4
+      with:
+        path: open-amp
     - name: Checkout libmetal
       uses: actions/checkout@v4
       with:
@@ -31,16 +33,16 @@ jobs:
         path: libmetal
     - name: build for Linux
       id: build_linux
-      uses: ./.github/actions/build_ci
+      uses: ./open-amp/.github/actions/build_ci
       with:
         target: linux
     - name: build for Zephyr
       id: build_Zephyr
-      uses: ./.github/actions/build_ci
+      uses: ./open-amp/.github/actions/build_ci
       with:
         target: zephyr
     - name: build for generic arm
       id: build_generic
-      uses: ./.github/actions/build_ci
+      uses: ./open-amp/.github/actions/build_ci
       with:
         target: generic


### PR DESCRIPTION
Update CI to build the https://github.com/OpenAMP/openamp-system-reference/tree/main/examples/legacy_apps applications instead of the https://github.com/OpenAMP/open-amp/tree/main/apps applications, which will be deprecated in the next release.