### PR TITLE
virtio.h: add some user-friendly apis

### DIFF
--- a/lib/include/openamp/virtio.h
+++ b/lib/include/openamp/virtio.h
@@ -449,6 +449,9 @@ static inline int virtio_get_features(struct virtio_device *vdev,
 		return -ENXIO;
 
 	*features = vdev->func->get_features(vdev);
+	if (VIRTIO_ROLE_IS_DEVICE(vdev))
+		vdev->features = *features;
+
 	return 0;
 }
 
@@ -563,6 +566,28 @@ static inline int virtio_free_buf(struct virtio_device *vdev, void *buf)
 	vdev->mmops->free(vdev, buf);
 
 	return 0;
+}
+
+/**
+ * @brief Check if the virtio device support a specific feature.
+ *
+ * @param vdev		Pointer to device structure.
+ * @param feature_bit	Feature bit to check.
+ *
+ * @return true if the feature is supported, otherwise false.
+ */
+static inline bool virtio_has_feature(struct virtio_device *vdev,
+				      unsigned int feature_bit)
+{
+	uint32_t features;
+
+	if (!vdev && feature_bit >= sizeof(features) * 8)
+		return false;
+
+	if (!vdev->features)
+		virtio_get_features(vdev, &features);
+
+	return (vdev->features & (1UL << feature_bit)) != 0;
 }
 
 #if defined __cplusplus

--- a/lib/include/openamp/virtio.h
+++ b/lib/include/openamp/virtio.h
@@ -119,6 +119,12 @@ struct virtio_device_id {
 #define VIRTIO_F_NOTIFY_ON_EMPTY (1 << 24)
 
 /*
+ * This feature indicates that the device accepts arbitrary
+ * descriptor layouts.
+ */
+#define VIRTIO_F_ANY_LAYOUT (1 << 27)
+
+/*
  * The guest should never negotiate this feature; it
  * is used to detect faulty drivers.
  */


### PR DESCRIPTION
-    virtio.h: add new api virtio_has_feature()
```c
virtio_has_feature() can be easily used to heck if the virtio device
support a specific feature.

And assgin feature to vdev->feature for virtio device role when get
features, so the virtio device side can use virtio_has_featrue() to
check weather the virtio device support a feature.
```

-    virtio.h: add new feature bit VIRTIO_F_ANY_LAYOUT
```c
Follow the virtio spec, this feature bit indicates that the device
accepts arbitrary descriptor layouts.
```
