### PR TITLE
CI: Zephyr, test against known working version and also the very latest on main

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -90,7 +90,7 @@ build_freertos(){
 
 build_zephyr(){
 	echo  " Build for Zephyr OS "
-	sudo apt-get install -y git cmake ninja-build gperf || exit 1
+	sudo apt-get install -y git cmake ninja-build gperf pv || exit 1
   	sudo apt-get install -y ccache dfu-util device-tree-compiler wget || exit 1
 	sudo apt-get install -y python3-dev python3-setuptools python3-tk python3-wheel xz-utils file || exit 1
   	sudo apt-get install -y make gcc gcc-multilib g++-multilib libsdl2-dev || exit 1
@@ -98,8 +98,9 @@ build_zephyr(){
 	pip3 install west || exit 1
 
 	export PROJECT_ROOT=$PWD
-	wget $ZEPHYR_SDK_DOWNLOAD_URL || exit 1
-	tar xvf $ZEPHYR_SDK_SETUP_TAR || exit 1
+	wget $ZEPHYR_SDK_DOWNLOAD_URL --progress=dot:giga || exit 1
+	echo "Extracting $ZEPHYR_SDK_TAR"
+	pv $ZEPHYR_SDK_TAR -i 3 -ptebr -f | tar xJ || exit 1
 	rm -rf $ZEPHYR_SDK_INSTALL_DIR || exit 1
 	yes | ./$ZEPHYR_SDK_SETUP_DIR/setup.sh || exit 1
 	west init ./zephyrproject || exit 1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,13 +41,35 @@ jobs:
       uses: ./open-amp/.github/actions/build_ci
       with:
         target: linux
-    - name: build for Zephyr
-      id: build_Zephyr
-      uses: ./open-amp/.github/actions/build_ci
-      with:
-        target: zephyr
     - name: build for generic arm
       id: build_generic
       uses: ./open-amp/.github/actions/build_ci
       with:
         target: generic
+
+  # Break the zephyr builds into their own job as the common runner was
+  # running out of space when runs were together
+  # Also, as the longest running jobs, this allows them to run in ||
+  zephyr_build_known_good_version:
+    name: Zephyr build with a version that is known to work
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout open-amp
+      uses: actions/checkout@v4
+      with:
+        path: open-amp
+    - name: Checkout libmetal
+      uses: actions/checkout@v4
+      with:
+        repository: OpenAMP/libmetal
+        path: libmetal
+    - name: Checkout openamp-system-reference
+      uses: actions/checkout@v4
+      with:
+        repository: OpenAMP/openamp-system-reference
+        path: openamp-system-reference
+    - name: build for Zephyr (Known Good)
+      id: build_Zephyr
+      uses: ./open-amp/.github/actions/build_ci
+      with:
+        target: zephyr

--- a/.github/workflows/heathcheck.yml
+++ b/.github/workflows/heathcheck.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Linaro Limited.
+
+# The focus of this flow is to check for external changes that will effect
+# the project.  Even if no code changes are happening, changes in external
+# distros or projects can invalidate our work and this flow lets us know
+
+name: open-amp Heath Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - docs/**
+
+  # Allows you to run this workflow manually from the Actions tab or gh API
+  workflow_dispatch:
+
+  # run weekly on Sunday at 5:10 AM UTC (9:10 PM US western)
+  schedule:
+    - cron:  '10 5 * * 0'
+
+jobs:
+  zephyr_build_main:
+    name: 'Zephyr build from latest on main'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout open-amp
+      uses: actions/checkout@v4
+      with:
+        path: open-amp
+    - name: Checkout libmetal
+      uses: actions/checkout@v4
+      with:
+        repository: OpenAMP/libmetal
+        path: libmetal
+    - name: Checkout openamp-system-reference
+      uses: actions/checkout@v4
+      with:
+        repository: OpenAMP/openamp-system-reference
+        path: openamp-system-reference
+    - name: Zephyr Latest
+      id: build_Zephyr_latest
+      uses: ./open-amp/.github/actions/build_ci
+      with:
+        target: zephyr-latest


### PR DESCRIPTION
This PR brings open-amp up to parity with libmetal with regard to Zephyr CI testing

open-amp did not have the latest SDK discovery code nor the sdk install reduction of verbosity that were already in libmetal so this PR is a bit bigger than the one for libmetal but the end result is the same.