### PR TITLE
rpmsg_virtio: fix rpmsg_virtio_get_tx_payload_buffer() error

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -394,7 +394,7 @@ static void *rpmsg_virtio_get_tx_payload_buffer(struct rpmsg_device *rdev,
 		if (status == RPMSG_EOPNOTSUPP) {
 			metal_sleep_usec(RPMSG_TICKS_PER_INTERVAL);
 			tick_count--;
-		} else if (status == RPMSG_SUCCESS) {
+		} else if (status != RPMSG_SUCCESS) {
 			break;
 		}
 	}


### PR DESCRIPTION
If rpmsg_virtio_notify_wait() returns RPMSG_SUCCESS, we should not directly return NULL, but call rpmsg_virtio_get_tx_buffer to get the tx buffer again.

This is the new PR of https://github.com/OpenAMP/open-amp/pull/614, and you can find the detail discussions in https://github.com/OpenAMP/open-amp/pull/614