### PR TITLE
Fix safe_strcpy calls

### DIFF
--- a/lib/include/openamp/remoteproc.h
+++ b/lib/include/openamp/remoteproc.h
@@ -576,7 +576,7 @@ int remoteproc_remove(struct remoteproc *rproc);
  * @brief Initialize remoteproc memory
  *
  * @param mem	Pointer to remoteproc memory
- * @param name	Memory name
+ * @param name	Memory name (max string size \ref RPROC_MAX_NAME_LEN)
  * @param pa	Physical address
  * @param da	Device address
  * @param size	Memory size

--- a/lib/include/openamp/rpmsg.h
+++ b/lib/include/openamp/rpmsg.h
@@ -564,7 +564,7 @@ static inline int rpmsg_send_nocopy(struct rpmsg_endpoint *ept,
  *
  * @param ept		Pointer to rpmsg endpoint
  * @param rdev		RPMsg device associated with the endpoint
- * @param name		Service name associated to the endpoint
+ * @param name		Service name associated to the endpoint (maximum size \ref RPMSG_NAME_SIZE)
  * @param src		Local address of the endpoint
  * @param dest		Target address of the endpoint
  * @param cb		Endpoint callback

--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -307,7 +307,7 @@ void remoteproc_init_mem(struct remoteproc_mem *mem, const char *name,
 	if (!mem || !io || size == 0)
 		return;
 	if (name)
-		(void)safe_strcpy(mem->name, sizeof(mem->name), name, sizeof(name));
+		(void)safe_strcpy(mem->name, sizeof(mem->name), name, RPROC_MAX_NAME_LEN);
 	else
 		mem->name[0] = 0;
 	mem->pa = pa;

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -142,7 +142,7 @@ int rpmsg_send_ns_message(struct rpmsg_endpoint *ept, unsigned long flags)
 
 	ns_msg.flags = flags;
 	ns_msg.addr = ept->addr;
-	(void)safe_strcpy(ns_msg.name, sizeof(ns_msg.name), ept->name, strlen(ept->name));
+	(void)safe_strcpy(ns_msg.name, sizeof(ns_msg.name), ept->name, sizeof(ept->name));
 	ret = rpmsg_send_offchannel_raw(ept, ept->addr,
 					RPMSG_NS_EPT_ADDR,
 					&ns_msg, sizeof(ns_msg), true);
@@ -307,7 +307,7 @@ void rpmsg_register_endpoint(struct rpmsg_device *rdev,
 			     rpmsg_ns_unbind_cb ns_unbind_cb, void *priv)
 {
 	if (name)
-		(void)safe_strcpy(ept->name, sizeof(ept->name), name, sizeof(name));
+		(void)safe_strcpy(ept->name, sizeof(ept->name), name, RPMSG_NAME_SIZE);
 	else
 		ept->name[0] = 0;
 


### PR DESCRIPTION
Fix issue #625 reported by @jonny-svaerd-arm 

Fix `safe_strcpy()`  argument that provides the size of the source string. Indeed, if the source string is of type char*, it is not valid to use `sizeof` to determine its length. Use `strnlen` to get the size of the string while ensuring that we have a maximum size.

On the contrary, it is preferable to use sizeof on `ept->name`, that is an array of char



