### PR TITLE
cmake: update cmake minimum support to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
-if (POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW)
-endif()
-
-if (POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
+cmake_minimum_required (VERSION 3.16)
 
 set (OPENAMP_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set (OPENAMP_BIN_ROOT "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
We currently support an old version of CMake (3.0.2) that was released in 2018.

This requires adding specific policies to support the evolution to the latest versions of Zephyr.

Update the minimum version to 3.16, aligned with the libmetal.

By updating to CMake 3.16 as the minimum version, we can also clean up the following policy add-ons:
- CMP0048 added in CMake v3.0
- CMP0077 added in CMake v3.13


Associated PR in libmetal library: https://github.com/OpenAMP/libmetal/pull/327