### PR TITLE
rpmsg_virtio: deinit rvdev->vdev when rvdev is deinited

### DIFF
--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -976,5 +976,6 @@ void rpmsg_deinit_vdev(struct rpmsg_virtio_device *rvdev)
 
 		virtio_delete_virtqueues(rvdev->vdev);
 		metal_mutex_deinit(&rdev->lock);
+		rvdev->vdev = NULL;
 	}
 }


### PR DESCRIPTION
If rvdev is deinited, using rvdev->vdev may cause a use-after-free error.