### PR TITLE
rpmsg_virtio.c: wait_remote_ready use metal_sleep_usec to avoid starvation

### DIFF
--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -15,6 +15,7 @@
 #include <metal/sys.h>
 #include <metal/utilities.h>
 #include <metal/alloc.h>
+#include <metal/sleep.h>
 
 static void rproc_virtio_delete_virtqueues(struct virtio_device *vdev)
 {
@@ -412,6 +413,6 @@ void rproc_virtio_wait_remote_ready(struct virtio_device *vdev)
 		status = rproc_virtio_get_status(vdev);
 		if (status & VIRTIO_CONFIG_STATUS_DRIVER_OK)
 			return;
-		metal_yield();
+		metal_sleep_usec(1000);
 	}
 }

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -272,7 +272,7 @@ static int rpmsg_virtio_wait_remote_ready(struct rpmsg_virtio_device *rvdev)
 		} else if (status & VIRTIO_CONFIG_STATUS_DRIVER_OK) {
 			return 0;
 		}
-		metal_yield();
+		metal_sleep_usec(1000);
 	}
 }
 


### PR DESCRIPTION
`metal_cpu_yield` can either result in an unimplemented function (thus not being executed) or a yield function of the corresponding os..

The yield function however only yields execution to another thread of the same or higher priority. Thus starving any lower priority threads.

`wait_remote_ready` can be blocked for a long time i.e. seconds waiting on the remote core to start communication.

Instead use metal_sleep_usec, allowing lower priority tasks to be executed. While waiting on the remote core.