### PR TITLE
Add QNX cross-compilation support

### DIFF
--- a/lib/include/openamp/remoteproc_virtio.h
+++ b/lib/include/openamp/remoteproc_virtio.h
@@ -29,8 +29,8 @@ extern "C" {
 #warning "VIRTIO_CACHED_RSC_TABLE is deprecated, please use VIRTIO_USE_DCACHE"
 #endif
 #if defined(VIRTIO_CACHED_RSC_TABLE) || defined(VIRTIO_USE_DCACHE)
-#define RSC_TABLE_FLUSH(x, s)		CACHE_FLUSH(x, s)
-#define RSC_TABLE_INVALIDATE(x, s)	CACHE_INVALIDATE(x, s)
+#define RSC_TABLE_FLUSH(x, s)		metal_cache_flush(x, s)
+#define RSC_TABLE_INVALIDATE(x, s)	metal_cache_invalidate(x, s)
 #else
 #define RSC_TABLE_FLUSH(x, s)		do { } while (0)
 #define RSC_TABLE_INVALIDATE(x, s)	do { } while (0)

--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -34,8 +34,8 @@ extern "C" {
 #warning "VIRTIO_CACHED_BUFFERS is deprecated, please use VIRTIO_USE_DCACHE"
 #endif
 #if defined(VIRTIO_CACHED_BUFFERS) || defined(VIRTIO_USE_DCACHE)
-#define BUFFER_FLUSH(x, s)		CACHE_FLUSH(x, s)
-#define BUFFER_INVALIDATE(x, s)		CACHE_INVALIDATE(x, s)
+#define BUFFER_FLUSH(x, s)		metal_cache_flush(x, s)
+#define BUFFER_INVALIDATE(x, s)		metal_cache_invalidate(x, s)
 #else
 #define BUFFER_FLUSH(x, s)		do { } while (0)
 #define BUFFER_INVALIDATE(x, s)		do { } while (0)

--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -48,16 +48,12 @@ extern "C" {
 /* Support to suppress interrupt until specific index is reached. */
 #define VIRTIO_RING_F_EVENT_IDX        (1 << 29)
 
-/* cache invalidation helpers */
-#define CACHE_FLUSH(x, s)		metal_cache_flush(x, s)
-#define CACHE_INVALIDATE(x, s)		metal_cache_invalidate(x, s)
-
 #ifdef VIRTIO_CACHED_VRINGS
 #warning "VIRTIO_CACHED_VRINGS is deprecated, please use VIRTIO_USE_DCACHE"
 #endif
 #if defined(VIRTIO_CACHED_VRINGS) || defined(VIRTIO_USE_DCACHE)
-#define VRING_FLUSH(x, s)		CACHE_FLUSH(x, s)
-#define VRING_INVALIDATE(x, s)		CACHE_INVALIDATE(x, s)
+#define VRING_FLUSH(x, s)		metal_cache_flush(x, s)
+#define VRING_INVALIDATE(x, s)		metal_cache_invalidate(x, s)
 #else
 #define VRING_FLUSH(x, s)		do { } while (0)
 #define VRING_INVALIDATE(x, s)		do { } while (0)


### PR DESCRIPTION
Hi,
This contribution adds cross-compilation support for QNX operating system to libmetal.

### _Motivation_
QNX is an industry standard real-time operating system for embedded systems, particularly for vehicles, featuring safety focused features. It has also recently been made free for non-commercial use through the QNX Everywhere program, aiming for students, researchers and hobbyists to experiment with the OS.

Given than open-amp is a useful library for supporting AMP in various master slave configurations, it would be great to enable it to run natively on free version of QNX OS.

### _Description of changes_
- Change clashing CACHE_FLUSH definition for QNX compilations

### _How to build for QNX_
The build files and instructions for cross-compiling open-amp for QNX are present at [qnx-ports](https://github.com/qnx-ports/build-files/tree/main/ports/open-amp). A free QNX8 license can be obtained [here](https://blackberry.qnx.com/en/products/qnx-everywhere).

By submitting this pull request, I confirm that my contribution is made under the terms of [BSD License](https://opensource.org/license/bsd-3-clause)