### PR TITLE
remoteproc virtio: Fix documentation

### DIFF
--- a/lib/include/openamp/remoteproc_virtio.h
+++ b/lib/include/openamp/remoteproc_virtio.h
@@ -121,8 +121,6 @@ int rproc_virtio_notified(struct virtio_device *vdev, uint32_t notifyid);
  * communications.
  *
  * @param vdev	Pointer to the virtio device
- *
- * @return true when remote processor is ready.
  */
 void rproc_virtio_wait_remote_ready(struct virtio_device *vdev);
 


### PR DESCRIPTION
The function rproc_virtio_wait_remote_ready does not return a value. Remove the related @return field from the documentation.