### PR TITLE
cmake: Undeprecate granular cache maintenance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ project (open_amp C)
 
 include (CheckIncludeFiles)
 include (CheckCSourceCompiles)
+include (CMakeDependentOption)
 include (collect)
 include (options)
 include (depends)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -83,9 +83,20 @@ endif (NOT WITH_VQ_RX_EMPTY_NOTIFY)
 
 option (WITH_DCACHE "Build with all cache operations enabled" OFF)
 
-if (WITH_DCACHE)
-  add_definitions(-DVIRTIO_USE_DCACHE)
-endif (WITH_DCACHE)
+cmake_dependent_option(WITH_DCACHE_VRINGS "Build with vrings cache operations enabled" OFF "NOT WITH_DCACHE" ON)
+if (WITH_DCACHE_VRINGS)
+  add_definitions(-DVIRTIO_CACHED_VRINGS)
+endif (WITH_DCACHE_VRINGS)
+
+cmake_dependent_option (WITH_DCACHE_BUFFERS "Build with buffers cache operations enabled" OFF "NOT WITH_DCACHE" ON)
+if (WITH_DCACHE_BUFFERS)
+  add_definitions(-DVIRTIO_CACHED_BUFFERS)
+endif (WITH_DCACHE_BUFFERS)
+
+cmake_dependent_option (WITH_DCACHE_RSC_TABLE "Build with resource table cache operations enabled" OFF "NOT WITH_DCACHE" ON)
+if (WITH_DCACHE_RSC_TABLE)
+  add_definitions(-DVIRTIO_CACHED_RSC_TABLE)
+endif (WITH_DCACHE_RSC_TABLE)
 
 # Set the complication flags
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")

--- a/lib/include/openamp/remoteproc_virtio.h
+++ b/lib/include/openamp/remoteproc_virtio.h
@@ -25,13 +25,13 @@ extern "C" {
 #define	RPROC_MAX_VRING_DESC	USHRT_MAX
 
 /* cache invalidation helpers for resource table */
-#if defined(VIRTIO_USE_DCACHE)
+#if defined(VIRTIO_CACHED_RSC_TABLE)
 #define RSC_TABLE_FLUSH(x, s)		metal_cache_flush(x, s)
 #define RSC_TABLE_INVALIDATE(x, s)	metal_cache_invalidate(x, s)
 #else
 #define RSC_TABLE_FLUSH(x, s)		do { } while (0)
 #define RSC_TABLE_INVALIDATE(x, s)	do { } while (0)
-#endif /* VIRTIO_USE_DCACHE */
+#endif /* VIRTIO_CACHED_RSC_TABLE */
 
 /* define vdev notification function user should implement */
 typedef int (*rpvdev_notify_func)(void *priv, uint32_t id);

--- a/lib/include/openamp/rpmsg_virtio.h
+++ b/lib/include/openamp/rpmsg_virtio.h
@@ -30,13 +30,14 @@ extern "C" {
 /* The feature bitmap for virtio rpmsg */
 #define VIRTIO_RPMSG_F_NS	0 /* RP supports name service notifications */
 
-#if defined(VIRTIO_USE_DCACHE)
+/* cache invalidation helpers for virtio buffers */
+#if defined(VIRTIO_CACHED_BUFFERS)
 #define BUFFER_FLUSH(x, s)		metal_cache_flush(x, s)
 #define BUFFER_INVALIDATE(x, s)		metal_cache_invalidate(x, s)
 #else
 #define BUFFER_FLUSH(x, s)		do { } while (0)
 #define BUFFER_INVALIDATE(x, s)		do { } while (0)
-#endif /* VIRTIO_USE_DCACHE */
+#endif /* VIRTIO_CACHED_BUFFERS */
 
 /* Callback handler for rpmsg virtio service */
 typedef int (*rpmsg_virtio_notify_wait_cb)(struct rpmsg_device *rdev, uint32_t id);

--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -48,13 +48,14 @@ extern "C" {
 /* Support to suppress interrupt until specific index is reached. */
 #define VIRTIO_RING_F_EVENT_IDX        (1 << 29)
 
-#if defined(VIRTIO_USE_DCACHE)
+/* cache invalidation helpers for vrings */
+#if defined(VIRTIO_CACHED_VRINGS)
 #define VRING_FLUSH(x, s)		metal_cache_flush(x, s)
 #define VRING_INVALIDATE(x, s)		metal_cache_invalidate(x, s)
 #else
 #define VRING_FLUSH(x, s)		do { } while (0)
 #define VRING_INVALIDATE(x, s)		do { } while (0)
-#endif /* VIRTIO_USE_DCACHE */
+#endif /* VIRTIO_CACHED_VRINGS */
 
 /** @brief Buffer descriptor. */
 struct virtqueue_buf {


### PR DESCRIPTION
Not all of these memory locations need to be in regions of the same cacheability. Add back options to set the regions individually. WITH_DCACHE set to ON sets all regions to ON also for backwards compatibility with current behavior.