### PR TITLE
ELF loader should validate before load

### DIFF
--- a/lib/include/internal/utilities.h
+++ b/lib/include/internal/utilities.h
@@ -5,6 +5,8 @@
  *
  */
 
+#include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 
 /**
@@ -33,3 +35,180 @@
  */
 size_t safe_strcpy(char *dst, size_t d_size, const char *src, size_t s_size);
 
+/*
+ * Convert an arithmetic operand to uint64_t, rejecting negative values and
+ * values which cannot be represented. This also makes the builtin and
+ * fallback implementations below apply the same input rules.
+ */
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_add_overflow) && \
+	__has_builtin(__builtin_sub_overflow) && \
+	__has_builtin(__builtin_mul_overflow)
+#define OPENAMP_HAVE_BUILTIN_OVERFLOW 1
+#endif
+#endif
+
+#if !defined(OPENAMP_HAVE_BUILTIN_OVERFLOW) && defined(__GNUC__) && \
+	(__GNUC__ >= 5)
+#define OPENAMP_HAVE_BUILTIN_OVERFLOW 1
+#endif
+
+#if defined(OPENAMP_HAVE_BUILTIN_OVERFLOW)
+#define OPENAMP_TO_U64_SAFE(value, out) (__extension__({ \
+	__typeof__(value) __openamp_value = (value); \
+	__builtin_add_overflow(__openamp_value, 0, (out)); \
+}))
+#else
+#define OPENAMP_TO_U64_SAFE(value, out) (__extension__({ \
+	__typeof__(value) __openamp_value = (value); \
+	int __openamp_overflow = 1; \
+	if (__openamp_value == 0 || __openamp_value > 0) { \
+		*(out) = (uint64_t)__openamp_value; \
+		__openamp_overflow = 0; \
+	} \
+	__openamp_overflow; \
+}))
+#endif
+
+#if defined(OPENAMP_HAVE_BUILTIN_OVERFLOW)
+#define OPENAMP_ADD_U64_SAFE(a, b, out) \
+	__builtin_add_overflow((a), (b), (out))
+#define OPENAMP_SUB_U64_SAFE(a, b, out) \
+	__builtin_sub_overflow((a), (b), (out))
+#define OPENAMP_MUL_U64_SAFE(a, b, out) \
+	__builtin_mul_overflow((a), (b), (out))
+#else
+#define OPENAMP_ADD_U64_SAFE(a, b, out) (__extension__({ \
+	__typeof__(out) __openamp_out = (out); \
+	__typeof__(a) __openamp_a = (a); \
+	__typeof__(b) __openamp_b = (b); \
+	uint64_t __openamp_umax = (uint64_t)(__typeof__(*__openamp_out)) \
+		~(__typeof__(*__openamp_out))0; \
+	int __openamp_overflow = __openamp_a > __openamp_umax || \
+		__openamp_b > __openamp_umax - __openamp_a; \
+	if (!__openamp_overflow) \
+		*__openamp_out = (__typeof__(*__openamp_out)) \
+			(__openamp_a + __openamp_b); \
+	__openamp_overflow; \
+}))
+#define OPENAMP_SUB_U64_SAFE(a, b, out) (__extension__({ \
+	__typeof__(out) __openamp_out = (out); \
+	__typeof__(a) __openamp_a = (a); \
+	__typeof__(b) __openamp_b = (b); \
+	uint64_t __openamp_umax = (uint64_t)(__typeof__(*__openamp_out)) \
+		~(__typeof__(*__openamp_out))0; \
+	int __openamp_overflow = __openamp_a > __openamp_umax || \
+		__openamp_b > __openamp_umax || __openamp_a < __openamp_b; \
+	if (!__openamp_overflow) \
+		*__openamp_out = (__typeof__(*__openamp_out)) \
+			(__openamp_a - __openamp_b); \
+	__openamp_overflow; \
+}))
+#define OPENAMP_MUL_U64_SAFE(a, b, out) (__extension__({ \
+	__typeof__(out) __openamp_out = (out); \
+	__typeof__(a) __openamp_a = (a); \
+	__typeof__(b) __openamp_b = (b); \
+	uint64_t __openamp_umax = (uint64_t)(__typeof__(*__openamp_out)) \
+		~(__typeof__(*__openamp_out))0; \
+	int __openamp_overflow = __openamp_a != 0 && \
+		__openamp_b > __openamp_umax / __openamp_a; \
+	if (!__openamp_overflow) \
+		*__openamp_out = (__typeof__(*__openamp_out)) \
+			(__openamp_a * __openamp_b); \
+	__openamp_overflow; \
+}))
+#endif
+
+/**
+ * @internal
+ *
+ * @brief Safely add two non-negative values with overflow detection.
+ *
+ * @return 0 on success, otherwise non-zero.
+ */
+#define OPENAMP_ADD_SAFE(a, b, out) (__extension__({ \
+	__typeof__(out) __openamp_out = (out); \
+	uint64_t __openamp_a; \
+	uint64_t __openamp_b; \
+	int __openamp_overflow = !__openamp_out || \
+		OPENAMP_TO_U64_SAFE((a), &__openamp_a) || \
+		OPENAMP_TO_U64_SAFE((b), &__openamp_b); \
+	if (!__openamp_overflow) \
+		__openamp_overflow = OPENAMP_ADD_U64_SAFE( \
+			__openamp_a, __openamp_b, __openamp_out); \
+	__openamp_overflow; \
+}))
+
+/**
+ * @internal
+ *
+ * @brief Safely subtract two non-negative values with underflow detection.
+ *
+ * @return 0 on success, otherwise non-zero.
+ */
+#define OPENAMP_SUB_SAFE(a, b, out) (__extension__({ \
+	__typeof__(out) __openamp_out = (out); \
+	uint64_t __openamp_a; \
+	uint64_t __openamp_b; \
+	int __openamp_overflow = !__openamp_out || \
+		OPENAMP_TO_U64_SAFE((a), &__openamp_a) || \
+		OPENAMP_TO_U64_SAFE((b), &__openamp_b); \
+	if (!__openamp_overflow) \
+		__openamp_overflow = OPENAMP_SUB_U64_SAFE( \
+			__openamp_a, __openamp_b, __openamp_out); \
+	__openamp_overflow; \
+}))
+
+/**
+ * @internal
+ *
+ * @brief Safely multiply two non-negative values with overflow detection.
+ *
+ * @return 0 on success, otherwise non-zero.
+ */
+#define OPENAMP_MUL_SAFE(a, b, out) (__extension__({ \
+	__typeof__(out) __openamp_out = (out); \
+	uint64_t __openamp_a; \
+	uint64_t __openamp_b; \
+	int __openamp_overflow = !__openamp_out || \
+		OPENAMP_TO_U64_SAFE((a), &__openamp_a) || \
+		OPENAMP_TO_U64_SAFE((b), &__openamp_b); \
+	if (!__openamp_overflow) \
+		__openamp_overflow = OPENAMP_MUL_U64_SAFE( \
+			__openamp_a, __openamp_b, __openamp_out); \
+	__openamp_overflow; \
+}))
+
+/**
+ * @internal
+ *
+ * @brief Check whether one half-open size range is contained in another.
+ *
+ * @param base      Start of the containing range.
+ * @param base_len  Length of the containing range.
+ * @param offset    Start of the range to check.
+ * @param len       Length of the range to check.
+ * @param contained Non-null pointer to store the containment result.
+ *
+ * @return 0 on success, otherwise non-zero on arithmetic overflow or an
+ *         invalid output pointer.
+ */
+#define OPENAMP_RANGE_CONTAINS(base, base_len, offset, len, contained) \
+	(__extension__({ \
+		__typeof__(contained) __openamp_contained = (contained); \
+		__typeof__(base) __openamp_base = (base); \
+		__typeof__(base_len) __openamp_base_len = (base_len); \
+		__typeof__(offset) __openamp_offset = (offset); \
+		__typeof__(len) __openamp_len = (len); \
+		size_t __openamp_base_end; \
+		size_t __openamp_end; \
+		int __openamp_range_overflow = !__openamp_contained || \
+			OPENAMP_ADD_SAFE(__openamp_base, __openamp_base_len, \
+					 &__openamp_base_end) || \
+			OPENAMP_ADD_SAFE(__openamp_offset, __openamp_len, \
+					 &__openamp_end); \
+		if (!__openamp_range_overflow) \
+			*__openamp_contained = __openamp_base <= __openamp_offset && \
+				__openamp_base_end >= __openamp_end; \
+		__openamp_range_overflow; \
+	}))

--- a/lib/include/openamp/elf_loader.h
+++ b/lib/include/openamp/elf_loader.h
@@ -290,6 +290,7 @@ struct elf32_info {
 	Elf32_Phdr *phdrs;
 	Elf32_Shdr *shdrs;
 	void *shstrtab;
+	size_t shstrtab_size;
 };
 
 struct elf64_info {
@@ -298,6 +299,7 @@ struct elf64_info {
 	Elf64_Phdr *phdrs;
 	Elf64_Shdr *shdrs;
 	void *shstrtab;
+	size_t shstrtab_size;
 };
 
 #define ELF_STATE_INIT              0x0L

--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -124,6 +124,50 @@ static int elf_shstrndx(const void *elf_info)
 	}
 }
 
+/**
+ * @brief Validate that an ELF header matches the supported header layout.
+ *
+ * @param elf_info	ELF information containing a copied ELF header.
+ *
+ * @return 0 on success, otherwise -RPROC_EINVAL.
+ */
+static int elf_validate_header(const void *elf_info)
+{
+	if (elf_is_64(elf_info) != 0) {
+		const Elf64_Ehdr *ehdr = elf_info;
+
+		if (ehdr->e_ident[EI_CLASS] != ELFCLASS64)
+			return -RPROC_EINVAL;
+		if (ehdr->e_ehsize != sizeof(Elf64_Ehdr))
+			return -RPROC_EINVAL;
+		if (ehdr->e_phnum != 0 &&
+		    ehdr->e_phentsize != sizeof(Elf64_Phdr))
+			return -RPROC_EINVAL;
+		if (ehdr->e_shnum != 0 &&
+		    ehdr->e_shentsize != sizeof(Elf64_Shdr))
+			return -RPROC_EINVAL;
+	} else {
+		const Elf32_Ehdr *ehdr = elf_info;
+
+		if (ehdr->e_ident[EI_CLASS] != ELFCLASS32)
+			return -RPROC_EINVAL;
+		if (ehdr->e_ehsize != sizeof(Elf32_Ehdr))
+			return -RPROC_EINVAL;
+		if (ehdr->e_phnum != 0 &&
+		    ehdr->e_phentsize != sizeof(Elf32_Phdr))
+			return -RPROC_EINVAL;
+		if (ehdr->e_shnum != 0 &&
+		    ehdr->e_shentsize != sizeof(Elf32_Shdr))
+			return -RPROC_EINVAL;
+	}
+
+	if (elf_shnum(elf_info) != 0 &&
+	    elf_shstrndx(elf_info) >= elf_shnum(elf_info))
+		return -RPROC_EINVAL;
+
+	return 0;
+}
+
 static void **elf_phtable_ptr(void *elf_info)
 {
 	if (elf_is_64(elf_info) == 0) {
@@ -414,14 +458,25 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 			return ELF_STATE_INIT;
 		} else {
 			size_t infosize = elf_info_size(img_data);
+			bool info_allocated = false;
+			int ret;
 
 			if (!*img_info) {
 				*img_info = metal_allocate_memory(infosize);
 				if (!*img_info)
 					return -RPROC_ENOMEM;
 				memset(*img_info, 0, infosize);
+				info_allocated = true;
 			}
 			memcpy(*img_info, img_data, tmpsize);
+			ret = elf_validate_header(*img_info);
+			if (ret < 0) {
+				if (info_allocated) {
+					metal_free_memory(*img_info);
+					*img_info = NULL;
+				}
+				return ret;
+			}
 			load_state = elf_load_state(*img_info);
 			*load_state = ELF_STATE_WAIT_FOR_PHDRS;
 			last_load_state = ELF_STATE_WAIT_FOR_PHDRS;

--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -207,6 +207,21 @@ static void **elf_shstrtab_ptr(void *elf_info)
 	}
 }
 
+/**
+ * @brief Store the loaded ELF section string table size.
+ *
+ * @param elf_info	ELF information.
+ * @param size		Loaded section string table size.
+ */
+static void elf_set_shstrtab_size(void *elf_info, size_t size)
+{
+	if (elf_is_64(elf_info) == 0) {
+		((struct elf32_info *)elf_info)->shstrtab_size = size;
+	} else {
+		((struct elf64_info *)elf_info)->shstrtab_size = size;
+	}
+}
+
 static int *elf_load_state(void *elf_info)
 {
 	if (elf_is_64(elf_info) == 0) {
@@ -598,6 +613,7 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 		*shstrtab = metal_allocate_memory(shstrtab_size);
 		if (!*shstrtab)
 			return -RPROC_ENOMEM;
+		elf_set_shstrtab_size(*img_info, shstrtab_size);
 		memcpy(*shstrtab,
 		       (const char *)img_data + shstrtab_offset,
 		       shstrtab_size);

--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -5,7 +5,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <stdbool.h>
 #include <string.h>
+#include <internal/utilities.h>
 #include <metal/alloc.h>
 #include <metal/log.h>
 #include <openamp/elf_loader.h>

--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -235,6 +235,35 @@ static int *elf_load_state(void *elf_info)
 	}
 }
 
+/**
+ * @brief Compare a section name with a bounded section string table entry.
+ *
+ * @param name		Section name to match.
+ * @param name_table	Loaded section string table.
+ * @param name_table_size	Size of the loaded section string table.
+ * @param sh_name	Offset of the candidate name in the string table.
+ *
+ * @return true if the name matches, otherwise false.
+ */
+static bool elf_section_name_matches(const char *name, const char *name_table,
+				     size_t name_table_size, size_t sh_name)
+{
+	size_t name_len;
+	size_t remaining;
+	const char *candidate;
+
+	if (sh_name >= name_table_size)
+		return false;
+
+	remaining = name_table_size - sh_name;
+	name_len = strlen(name);
+	if (name_len >= remaining)
+		return false;
+
+	candidate = name_table + sh_name;
+	return memcmp(name, candidate, name_len + 1) == 0;
+}
+
 static void elf_parse_segment(void *elf_info, const void *elf_phdr,
 			      unsigned int *p_type, size_t *p_offset,
 			      metal_phys_addr_t *p_vaddr,
@@ -303,6 +332,7 @@ static void *elf_get_section_from_name(void *elf_info, const char *name)
 {
 	unsigned int i;
 	const char *name_table;
+	size_t name_table_size;
 
 	if (elf_is_64(elf_info) == 0) {
 		struct elf32_info *einfo = elf_info;
@@ -310,10 +340,13 @@ static void *elf_get_section_from_name(void *elf_info, const char *name)
 		Elf32_Shdr *shdr = einfo->shdrs;
 
 		name_table = einfo->shstrtab;
+		name_table_size = einfo->shstrtab_size;
 		if (!shdr || !name_table)
 			return NULL;
 		for (i = 0; i < ehdr->e_shnum; i++, shdr++) {
-			if (strcmp(name, name_table + shdr->sh_name))
+			if (!elf_section_name_matches(name, name_table,
+						      name_table_size,
+						      shdr->sh_name))
 				continue;
 			else
 				return shdr;
@@ -324,10 +357,13 @@ static void *elf_get_section_from_name(void *elf_info, const char *name)
 		Elf64_Shdr *shdr = einfo->shdrs;
 
 		name_table = einfo->shstrtab;
+		name_table_size = einfo->shstrtab_size;
 		if (!shdr || !name_table)
 			return NULL;
 		for (i = 0; i < ehdr->e_shnum; i++, shdr++) {
-			if (strcmp(name, name_table + shdr->sh_name))
+			if (!elf_section_name_matches(name, name_table,
+						      name_table_size,
+						      shdr->sh_name))
 				continue;
 			else
 				return shdr;

--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -571,6 +571,8 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 		int shstrndx;
 		void *shdr;
 		void **shstrtab;
+		bool range_contained;
+		int ret;
 
 		metal_log(METAL_LOG_DEBUG, "Loading ELF shstrtab.\r\n");
 		shstrndx = elf_shstrndx(*img_info);
@@ -581,8 +583,11 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 				  NULL, &shstrtab_offset,
 				  &shstrtab_size, NULL, NULL,
 				  NULL, NULL);
-		if (offset > shstrtab_offset ||
-		    offset + len < shstrtab_offset + shstrtab_size) {
+		ret = OPENAMP_RANGE_CONTAINS(offset, len, shstrtab_offset,
+					     shstrtab_size, &range_contained);
+		if (ret)
+			return -RPROC_EINVAL;
+		if (!range_contained) {
 			*noffset = shstrtab_offset;
 			*nlen = shstrtab_size;
 			return *load_state;

--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -490,14 +490,22 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 	if (*load_state == ELF_STATE_WAIT_FOR_PHDRS) {
 		size_t phdrs_size;
 		size_t phdrs_offset;
+		bool range_contained;
+		int ret;
 		void **phdrs;
 		const void *img_phdrs;
 
 		metal_log(METAL_LOG_DEBUG, "Loading ELF program header.\r\n");
 		phdrs_offset = elf_phoff(*img_info);
-		phdrs_size = elf_phnum(*img_info) * elf_phentsize(*img_info);
-		if (offset > phdrs_offset ||
-		    offset + len < phdrs_offset + phdrs_size) {
+		ret = OPENAMP_MUL_SAFE(elf_phnum(*img_info),
+				       elf_phentsize(*img_info), &phdrs_size);
+		if (ret)
+			return -RPROC_EINVAL;
+		ret = OPENAMP_RANGE_CONTAINS(offset, len, phdrs_offset,
+					     phdrs_size, &range_contained);
+		if (ret)
+			return -RPROC_EINVAL;
+		if (!range_contained) {
 			*noffset = phdrs_offset;
 			*nlen = phdrs_size;
 			return *load_state;
@@ -517,6 +525,8 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 	if ((*load_state & ELF_STATE_WAIT_FOR_SHDRS) != 0) {
 		size_t shdrs_size;
 		size_t shdrs_offset;
+		bool range_contained;
+		int ret;
 		void **shdrs;
 		const void *img_shdrs;
 
@@ -528,9 +538,15 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 			*nlen = 0;
 			return *load_state;
 		}
-		shdrs_size = elf_shnum(*img_info) * elf_shentsize(*img_info);
-		if (offset > shdrs_offset ||
-		    offset + len < shdrs_offset + shdrs_size) {
+		ret = OPENAMP_MUL_SAFE(elf_shnum(*img_info),
+				       elf_shentsize(*img_info), &shdrs_size);
+		if (ret)
+			return -RPROC_EINVAL;
+		ret = OPENAMP_RANGE_CONTAINS(offset, len, shdrs_offset,
+					     shdrs_size, &range_contained);
+		if (ret)
+			return -RPROC_EINVAL;
+		if (!range_contained) {
 			*noffset = shdrs_offset;
 			*nlen = shdrs_size;
 			return *load_state;

--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -526,9 +526,13 @@ int remoteproc_load(struct remoteproc *rproc, const char *path,
 		} else if ((ret & RPROC_LOADER_READY_TO_LOAD) != 0) {
 			if (nlen == 0)
 				break;
-			else if ((noffset > (offset + len)) &&
+			else if ((noffset > offset && noffset - offset > len) &&
 				 (store_ops->features & SUPPORT_SEEK) == 0) {
-				/* Required data is not continued, however
+				/*
+				 * Use noffset - offset instead of offset + len
+				 * in the check above to avoid wrapping.
+				 *
+				 * Required data is not continued, however
 				 * seek is not supported, stop to load
 				 * headers such as ELF section headers which
 				 * is usually located to the end of image.


### PR DESCRIPTION
OpenAMP’s ELF loader should reject malformed firmware images before using ELF header metadata to size allocations, copy header tables, or look up section names.

  OpenAMP’s remoteproc ELF loader trusts several ELF header and section-header fields while parsing firmware images. These fields control program-header and section-header table sizes, table
  offsets, segment copy ranges, and section string-table lookups.

  The main issue is in the header-table loading path. The loader computes program and section table sizes from firmware-controlled values such as e_phnum * e_phentsize and e_shnum * e_shentsize.
  Those computed sizes are then used for allocation and memcpy(), while later code walks the copied buffers as native Elf32_Phdr, Elf64_Phdr, Elf32_Shdr, or Elf64_Shdr arrays. If the count, entry
  size, or offset metadata is malformed, the allocation/copy size can diverge from the way the loader later indexes the table.

  The range checks around these copies also rely on offset-plus-length arithmetic. With malformed offsets or sizes, unchecked addition can wrap and make an invalid range appear valid. Similar range
  assumptions apply when loading the section string table and when the loader asks the backing image store for the next chunk of firmware data.

  Section-name lookup has a separate parser-side read issue. The loader searches for sections such as .resource_table by using each section header’s sh_name as an offset into the loaded section
  string table. Because sh_name is firmware-controlled, the loader must not form or compare name_table + sh_name unless the offset is within the loaded string table and the referenced string is NUL-
  terminated before the end of that table.

  The fix makes the ELF loader fail closed on malformed metadata:

  - add portable checked arithmetic helpers for size_t multiplication, addition, and image-chunk range validation;
  - validate ELF header shape before loading tables, including ELF class, ELF header size, program-header entry size, section-header entry size, and section string-table index;
  - use checked multiplication for program-header and section-header table sizes;
  - replace wrapping offset-plus-length checks with overflow-safe range validation;
  - validate the section string-table range before copying it;
  - store the loaded section string-table size in the ELF image state;
  - bound section-name lookup by checking sh_name and comparing only within the loaded string table;
  - avoid wrapping arithmetic in the remoteproc caller’s non-seekable offset comparison.

  With these changes, valid firmware images continue to load normally, while malformed images with inconsistent table metadata, overflowing ranges, invalid entry sizes, or out-of-bounds section
  names are rejected before allocation, copy, or table lookup proceeds.