### PR TITLE
virtio: fix NULL pointer dereference in virtqueue_notification

### DIFF
--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -620,7 +620,7 @@ static int vq_ring_enable_interrupt(struct virtqueue *vq, uint16_t ndesc)
 void virtqueue_notification(struct virtqueue *vq)
 {
 	atomic_thread_fence(memory_order_seq_cst);
-	if (vq->callback)
+	if (vq && vq->callback)
 		vq->callback(vq);
 }
 


### PR DESCRIPTION
Add a NULL check for the vq pointer before dereferencing it in virtqueue_notification(). Without this check, a NULL virtqueue pointer passed to the function would cause a crash when accessing vq->callback.