### PR TITLE
Harden untrusted input handling

### DIFF
--- a/lib/include/openamp/elf_loader.h
+++ b/lib/include/openamp/elf_loader.h
@@ -290,6 +290,7 @@ struct elf32_info {
 	Elf32_Phdr *phdrs;
 	Elf32_Shdr *shdrs;
 	void *shstrtab;
+	size_t shstrtab_size;
 };
 
 struct elf64_info {
@@ -298,6 +299,7 @@ struct elf64_info {
 	Elf64_Phdr *phdrs;
 	Elf64_Shdr *shdrs;
 	void *shstrtab;
+	size_t shstrtab_size;
 };
 
 #define ELF_STATE_INIT              0x0L

--- a/lib/include/openamp/remoteproc_virtio.h
+++ b/lib/include/openamp/remoteproc_virtio.h
@@ -24,6 +24,18 @@ extern "C" {
 /* maximum number of vring descriptors for a vdev limited by 16-bit data type */
 #define	RPROC_MAX_VRING_DESC	USHRT_MAX
 
+/**
+ * @brief Validate a remoteproc vring alignment.
+ *
+ * @param align	Vring alignment supplied by the resource table.
+ *
+ * @return true if the alignment is supported, otherwise false.
+ */
+static inline bool rproc_virtio_vring_align_valid(unsigned int align)
+{
+	return align != 0 && (align & (align - 1)) == 0;
+}
+
 /* cache invalidation helpers for resource table */
 #if defined(VIRTIO_USE_DCACHE)
 #define RSC_TABLE_FLUSH(x, s)		metal_cache_flush(x, s)
@@ -94,7 +106,7 @@ void rproc_virtio_remove_vdev(struct virtio_device *vdev);
  * @param va		vring virtual address
  * @param io		Pointer to vring I/O region
  * @param num_descs	Number of descriptors
- * @param align		vring alignment
+ * @param align		Nonzero power-of-two vring alignment
  *
  * @return 0 for success, negative value for failure.
  */

--- a/lib/include/openamp/rpmsg_rpc_client_server.h
+++ b/lib/include/openamp/rpmsg_rpc_client_server.h
@@ -176,7 +176,8 @@ int rpmsg_rpc_server_init(struct rpmsg_rpc_svr *rpcs, struct rpmsg_device *rdev,
  *				data
  * @param rpc_id		Function id
  * @param request_param		Pointer to request buffer
- * @param req_param_size	Length of the request data
+ * @param req_param_size	Length of the request data; must not exceed
+ *				MAX_BUF_LEN - MAX_FUNC_ID_LEN
  *
  * @return Length of the received response, negative value for failure.
  */

--- a/lib/include/openamp/virtio_mmio.h
+++ b/lib/include/openamp/virtio_mmio.h
@@ -170,14 +170,17 @@ struct virtio_mmio_device {
  * @param vdev		Pointer to device structure.
  * @param vq_num	Number of virtqueues the device uses.
  * @param vqs		Array of pointers to vthe virtqueues used by the device.
+ *
+ * @return 0 on success, negative error code on failure.
  */
-void virtio_mmio_register_device(struct virtio_device *vdev, int vq_num, struct virtqueue **vqs);
+int virtio_mmio_register_device(struct virtio_device *vdev, int vq_num, struct virtqueue **vqs);
 
 /**
  * @brief Setup a virtqueue structure.
  *
  * @param vdev		Pointer to device structure.
- * @param idx		Index of the virtqueue.
+ * @param idx		Index of the virtqueue; must be less than the vq_num
+ *			passed to virtio_mmio_register_device().
  * @param vq		Pointer to virtqueue structure.
  * @param cb		Pointer to virtqueue callback. Can be NULL.
  * @param cb_arg	Argument for the virtqueue callback.

--- a/lib/include/openamp/virtqueue.h
+++ b/lib/include/openamp/virtqueue.h
@@ -141,7 +141,10 @@ struct vring_alloc_info {
 	/** Vring address. */
 	void *vaddr;
 
-	/** Vring alignment. */
+	/**
+	 * Vring alignment; must be a nonzero power of two.
+	 * Zero makes vring_init() calculate a NULL used-ring pointer.
+	 */
 	uint32_t align;
 
 	/** Number of descriptors in the vring. */

--- a/lib/proxy/rpmsg_retarget.c
+++ b/lib/proxy/rpmsg_retarget.c
@@ -271,16 +271,20 @@ int _write(int fd, const char *ptr, int len)
 	int ret;
 	struct rpmsg_rpc_syscall *syscall;
 	struct rpmsg_rpc_syscall resp;
-	int payload_size = sizeof(*syscall) + len;
+	size_t payload_size;
 	struct rpmsg_rpc_data *rpc = rpmsg_default_rpc;
 	unsigned char tmpbuf[MAX_BUF_LEN];
 	unsigned char *tmpptr;
 	int null_term = 0;
 
-	if (!rpc)
+	if (!rpc || !ptr || len < 0)
 		return -EINVAL;
 	if (fd == 1)
 		null_term = 1;
+	/* Reserve space for the payload and stdout's trailing NUL byte. */
+	if ((size_t)len > MAX_BUF_LEN - sizeof(*syscall) - null_term)
+		return -EINVAL;
+	payload_size = sizeof(*syscall) + (size_t)len + null_term;
 
 	syscall = (void *)tmpbuf;
 	syscall->id = WRITE_SYSCALL_ID;
@@ -289,10 +293,8 @@ int _write(int fd, const char *ptr, int len)
 	syscall->args.data_len = len + null_term;
 	tmpptr = tmpbuf + sizeof(*syscall);
 	memcpy(tmpptr, ptr, len);
-	if (null_term == 1) {
-		*(char *)(tmpptr + len + null_term) = 0;
-		payload_size += 1;
-	}
+	if (null_term == 1)
+		tmpptr[len] = '\0';
 	resp.id = 0;
 	ret = rpmsg_rpc_send(rpc, tmpbuf, payload_size,
 			     (void *)&resp, sizeof(resp));

--- a/lib/proxy/rpmsg_retarget.c
+++ b/lib/proxy/rpmsg_retarget.c
@@ -220,7 +220,7 @@ int _read(int fd, char *buffer, int buflen)
 	unsigned char tmpbuf[MAX_BUF_LEN];
 	int ret;
 
-	if (!rpc || !buffer || buflen == 0)
+	if (!rpc || !buffer || buflen <= 0)
 		return -EINVAL;
 
 	/* Construct rpc payload */
@@ -238,12 +238,18 @@ int _read(int fd, char *buffer, int buflen)
 	if (ret >= 0) {
 		if (resp->id == READ_SYSCALL_ID) {
 			if (resp->args.int_field1 > 0) {
-				int tmplen = resp->args.data_len;
+				size_t tmplen = resp->args.data_len;
+				size_t payload_capacity;
 				unsigned char *tmpptr = tmpbuf;
 
 				tmpptr += sizeof(*resp);
-				if (tmplen > buflen)
-					tmplen = buflen;
+				payload_capacity = MAX_BUF_LEN - sizeof(*resp);
+				/* Clamp to the source capacity first. */
+				if (tmplen > payload_capacity)
+					tmplen = payload_capacity;
+				/* Only reduce the clamped length for the destination. */
+				if (tmplen > (size_t)buflen)
+					tmplen = (size_t)buflen;
 				memcpy(buffer, tmpptr, tmplen);
 			}
 			ret = resp->args.int_field1;

--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -132,22 +132,18 @@ static int elf_shstrndx(const void *elf_info)
 static int elf_validate_table_entry_sizes(const void *elf_info)
 {
 	if (elf_is_64(elf_info) == 0) {
-		const Elf32_Ehdr *ehdr = elf_info;
+		const struct elf32_info *einfo = elf_info;
 
-		if (ehdr->e_phnum != 0 &&
-		    ehdr->e_phentsize != sizeof(Elf32_Phdr))
+		if (einfo->ehdr.e_phnum != 0 && einfo->ehdr.e_phentsize != sizeof(*einfo->phdrs))
 			return -RPROC_EINVAL;
-		if (ehdr->e_shnum != 0 &&
-		    ehdr->e_shentsize != sizeof(Elf32_Shdr))
+		if (einfo->ehdr.e_shnum != 0 && einfo->ehdr.e_shentsize != sizeof(*einfo->shdrs))
 			return -RPROC_EINVAL;
 	} else {
-		const Elf64_Ehdr *ehdr = elf_info;
+		const struct elf64_info *einfo = elf_info;
 
-		if (ehdr->e_phnum != 0 &&
-		    ehdr->e_phentsize != sizeof(Elf64_Phdr))
+		if (einfo->ehdr.e_phnum != 0 && einfo->ehdr.e_phentsize != sizeof(*einfo->phdrs))
 			return -RPROC_EINVAL;
-		if (ehdr->e_shnum != 0 &&
-		    ehdr->e_shentsize != sizeof(Elf64_Shdr))
+		if (einfo->ehdr.e_shnum != 0 && einfo->ehdr.e_shentsize != sizeof(*einfo->shdrs))
 			return -RPROC_EINVAL;
 	}
 

--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -161,6 +161,25 @@ static void **elf_shstrtab_ptr(void *elf_info)
 	}
 }
 
+/**
+ * @brief Store the loaded ELF section string table size.
+ *
+ * @param elf_info	ELF information.
+ * @param size		Loaded section string table size.
+ */
+static void elf_set_shstrtab_size(void *elf_info, size_t size)
+{
+	if (elf_is_64(elf_info) == 0) {
+		struct elf32_info *einfo = elf_info;
+
+		einfo->shstrtab_size = size;
+	} else {
+		struct elf64_info *einfo = elf_info;
+
+		einfo->shstrtab_size = size;
+	}
+}
+
 static int *elf_load_state(void *elf_info)
 {
 	if (elf_is_64(elf_info) == 0) {
@@ -172,6 +191,33 @@ static int *elf_load_state(void *elf_info)
 
 		return &einfo->load_state;
 	}
+}
+
+/**
+ * @brief Compare a section name with a bounded string table entry.
+ *
+ * @param name			Section name to match.
+ * @param name_table		Loaded section string table.
+ * @param name_table_size	Size of the loaded section string table.
+ * @param sh_name		Offset of the candidate section name.
+ *
+ * @return true if the section name matches, otherwise false.
+ */
+static bool elf_section_name_matches(const char *name, const char *name_table,
+				     size_t name_table_size, size_t sh_name)
+{
+	size_t name_len;
+	size_t remaining;
+
+	if (sh_name >= name_table_size)
+		return false;
+
+	remaining = name_table_size - sh_name;
+	name_len = strlen(name);
+	if (name_len >= remaining)
+		return false;
+
+	return memcmp(name, name_table + sh_name, name_len + 1) == 0;
 }
 
 static void elf_parse_segment(void *elf_info, const void *elf_phdr,
@@ -242,6 +288,7 @@ static void *elf_get_section_from_name(void *elf_info, const char *name)
 {
 	unsigned int i;
 	const char *name_table;
+	size_t name_table_size;
 
 	if (elf_is_64(elf_info) == 0) {
 		struct elf32_info *einfo = elf_info;
@@ -249,10 +296,14 @@ static void *elf_get_section_from_name(void *elf_info, const char *name)
 		Elf32_Shdr *shdr = einfo->shdrs;
 
 		name_table = einfo->shstrtab;
+		name_table_size = einfo->shstrtab_size;
 		if (!shdr || !name_table)
 			return NULL;
 		for (i = 0; i < ehdr->e_shnum; i++, shdr++) {
-			if (strcmp(name, name_table + shdr->sh_name))
+			/* Validate the ELF32 name before comparing it. */
+			if (!elf_section_name_matches(name, name_table,
+						      name_table_size,
+						      shdr->sh_name))
 				continue;
 			else
 				return shdr;
@@ -263,10 +314,14 @@ static void *elf_get_section_from_name(void *elf_info, const char *name)
 		Elf64_Shdr *shdr = einfo->shdrs;
 
 		name_table = einfo->shstrtab;
+		name_table_size = einfo->shstrtab_size;
 		if (!shdr || !name_table)
 			return NULL;
 		for (i = 0; i < ehdr->e_shnum; i++, shdr++) {
-			if (strcmp(name, name_table + shdr->sh_name))
+			/* Validate the ELF64 name before comparing it. */
+			if (!elf_section_name_matches(name, name_table,
+						      name_table_size,
+						      shdr->sh_name))
 				continue;
 			else
 				return shdr;
@@ -520,6 +575,8 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 		*shstrtab = metal_allocate_memory(shstrtab_size);
 		if (!*shstrtab)
 			return -RPROC_ENOMEM;
+		/* Save the allocation size for bounded section name lookups. */
+		elf_set_shstrtab_size(*img_info, shstrtab_size);
 		memcpy(*shstrtab,
 		       (const char *)img_data + shstrtab_offset,
 		       shstrtab_size);

--- a/lib/remoteproc/elf_loader.c
+++ b/lib/remoteproc/elf_loader.c
@@ -122,6 +122,38 @@ static int elf_shstrndx(const void *elf_info)
 	}
 }
 
+/**
+ * @brief Validate ELF program and section header table entry sizes.
+ *
+ * @param elf_info	ELF information containing a complete ELF header.
+ *
+ * @return 0 on success, otherwise -RPROC_EINVAL.
+ */
+static int elf_validate_table_entry_sizes(const void *elf_info)
+{
+	if (elf_is_64(elf_info) == 0) {
+		const Elf32_Ehdr *ehdr = elf_info;
+
+		if (ehdr->e_phnum != 0 &&
+		    ehdr->e_phentsize != sizeof(Elf32_Phdr))
+			return -RPROC_EINVAL;
+		if (ehdr->e_shnum != 0 &&
+		    ehdr->e_shentsize != sizeof(Elf32_Shdr))
+			return -RPROC_EINVAL;
+	} else {
+		const Elf64_Ehdr *ehdr = elf_info;
+
+		if (ehdr->e_phnum != 0 &&
+		    ehdr->e_phentsize != sizeof(Elf64_Phdr))
+			return -RPROC_EINVAL;
+		if (ehdr->e_shnum != 0 &&
+		    ehdr->e_shentsize != sizeof(Elf64_Shdr))
+			return -RPROC_EINVAL;
+	}
+
+	return 0;
+}
+
 static void **elf_phtable_ptr(void *elf_info)
 {
 	if (elf_is_64(elf_info) == 0) {
@@ -467,6 +499,12 @@ int elf_load_header(const void *img_data, size_t offset, size_t len,
 			return ELF_STATE_INIT;
 		} else {
 			size_t infosize = elf_info_size(img_data);
+			int ret;
+
+			/* Validate table strides before loading either table. */
+			ret = elf_validate_table_entry_sizes(img_data);
+			if (ret < 0)
+				return ret;
 
 			if (!*img_info) {
 				*img_info = metal_allocate_memory(infosize);

--- a/lib/remoteproc/remoteproc.c
+++ b/lib/remoteproc/remoteproc.c
@@ -1013,6 +1013,9 @@ remoteproc_create_virtio(struct remoteproc *rproc,
 		da = vring_rsc->da;
 		num_descs = vring_rsc->num;
 		align = vring_rsc->align;
+		/* Validate the peer alignment before calculating the size. */
+		if (!rproc_virtio_vring_align_valid(align))
+			goto err1;
 		size = vring_size(num_descs, align);
 		va = remoteproc_mmap(rproc, NULL, &da, size, 0, &io);
 		if (!va)

--- a/lib/remoteproc/remoteproc_virtio.c
+++ b/lib/remoteproc/remoteproc_virtio.c
@@ -361,8 +361,12 @@ int rproc_virtio_init_vring(struct virtio_device *vdev, unsigned int index,
 	struct virtio_vring_info *vring_info;
 	unsigned int num_vrings;
 
+	if (!vdev)
+		return -RPROC_EINVAL;
 	num_vrings = vdev->vrings_num;
-	if ((index >= num_vrings) || (num_descs > RPROC_MAX_VRING_DESC))
+	/* Recheck the resource values before storing the vring metadata. */
+	if (index >= num_vrings || num_descs > RPROC_MAX_VRING_DESC ||
+	    !rproc_virtio_vring_align_valid(align))
 		return -RPROC_EINVAL;
 	vring_info = &vdev->vrings_info[index];
 	vring_info->io = io;

--- a/lib/remoteproc/rsc_table_parser.c
+++ b/lib/remoteproc/rsc_table_parser.c
@@ -155,21 +155,93 @@ static const rsc_handler rsc_handler_table[] = {
 	handle_vdev_rsc, /**< virtio resource */
 };
 
+/**
+ * @brief Validate the complete extent of a resource table entry.
+ *
+ * @param hdr		Resource entry header.
+ * @param available	Bytes remaining in the resource table.
+ *
+ * @return 0 on success, otherwise -RPROC_ERR_RSC_TAB_TRUNC.
+ */
+static int validate_rsc_entry(struct fw_rsc_hdr *hdr, size_t available)
+{
+	size_t entry_size;
+
+	if (available < sizeof(*hdr))
+		return -RPROC_ERR_RSC_TAB_TRUNC;
+
+	switch (hdr->type) {
+	case RSC_CARVEOUT:
+		entry_size = sizeof(struct fw_rsc_carveout);
+		break;
+	case RSC_DEVMEM:
+		entry_size = sizeof(struct fw_rsc_devmem);
+		break;
+	case RSC_TRACE:
+		entry_size = sizeof(struct fw_rsc_trace);
+		break;
+	case RSC_VDEV: {
+		struct fw_rsc_vdev *vdev_rsc = (void *)hdr;
+
+		entry_size = sizeof(*vdev_rsc);
+		if (entry_size > available)
+			return -RPROC_ERR_RSC_TAB_TRUNC;
+		if (vdev_rsc->num_of_vrings >
+		    (available - entry_size) /
+		    sizeof(struct fw_rsc_vdev_vring))
+			return -RPROC_ERR_RSC_TAB_TRUNC;
+		entry_size += vdev_rsc->num_of_vrings *
+			      sizeof(struct fw_rsc_vdev_vring);
+		if (vdev_rsc->config_len > available - entry_size)
+			return -RPROC_ERR_RSC_TAB_TRUNC;
+		entry_size += vdev_rsc->config_len;
+		break;
+	}
+	default:
+		if (hdr->type >= RSC_VENDOR_START &&
+		    hdr->type <= RSC_VENDOR_END) {
+			struct fw_rsc_vendor *vend_rsc = (void *)hdr;
+
+			if (available < sizeof(*vend_rsc))
+				return -RPROC_ERR_RSC_TAB_TRUNC;
+			entry_size = vend_rsc->len;
+			if (entry_size < sizeof(*vend_rsc))
+				return -RPROC_ERR_RSC_TAB_TRUNC;
+		} else {
+			entry_size = sizeof(*hdr);
+		}
+		break;
+	}
+
+	if (entry_size > available)
+		return -RPROC_ERR_RSC_TAB_TRUNC;
+
+	return 0;
+}
+
 int handle_rsc_table(struct remoteproc *rproc,
 		     struct resource_table *rsc_table, size_t size,
 		     struct metal_io_region *io)
 {
 	struct fw_rsc_hdr *hdr;
 	uint32_t rsc_type;
-	unsigned int idx, offset;
+	uint32_t num_entries;
+	unsigned int idx;
+	size_t offset;
+	size_t rsc_offset;
 	int status = 0;
 
 	/* Validate rsc table header fields */
 
 	/* Minimum rsc table size */
-	if (sizeof(struct resource_table) > size) {
+	if (!rsc_table || sizeof(struct resource_table) > size) {
 		return -RPROC_ERR_RSC_TAB_TRUNC;
 	}
+	if (io &&
+	    (metal_io_virt_to_offset(io, rsc_table) == METAL_BAD_OFFSET ||
+	     metal_io_virt_to_offset(io, (char *)rsc_table + size - 1) ==
+	     METAL_BAD_OFFSET))
+		return -RPROC_ERR_RSC_TAB_TRUNC;
 
 	/* Supported version */
 	if (rsc_table->ver != RSC_TAB_SUPPORTED_VERSION) {
@@ -177,12 +249,13 @@ int handle_rsc_table(struct remoteproc *rproc,
 	}
 
 	/* Offset array */
-	offset = sizeof(struct resource_table)
-		 + rsc_table->num * sizeof(rsc_table->offset[0]);
-
-	if (offset > size) {
+	num_entries = rsc_table->num;
+	if (num_entries > (size - sizeof(struct resource_table)) /
+			  sizeof(rsc_table->offset[0])) {
 		return -RPROC_ERR_RSC_TAB_TRUNC;
 	}
+	offset = sizeof(struct resource_table) +
+		 num_entries * sizeof(rsc_table->offset[0]);
 
 	/* Reserved fields - must be zero */
 	if (rsc_table->reserved[0] != 0 || rsc_table->reserved[1] != 0) {
@@ -190,10 +263,16 @@ int handle_rsc_table(struct remoteproc *rproc,
 	}
 
 	/* Loop through the offset array and parse each resource entry */
-	for (idx = 0; idx < rsc_table->num; idx++) {
-		hdr = (void *)((char *)rsc_table + rsc_table->offset[idx]);
-		if (io && metal_io_virt_to_offset(io, hdr) == METAL_BAD_OFFSET)
+	for (idx = 0; idx < num_entries; idx++) {
+		rsc_offset = rsc_table->offset[idx];
+		/* Keep writable resources outside the table metadata. */
+		if (rsc_offset < offset || rsc_offset > size ||
+		    size - rsc_offset < sizeof(*hdr))
 			return -RPROC_ERR_RSC_TAB_TRUNC;
+		hdr = (void *)((char *)rsc_table + rsc_offset);
+		status = validate_rsc_entry(hdr, size - rsc_offset);
+		if (status)
+			return status;
 		rsc_type = hdr->type;
 		if (rsc_type < RSC_LAST)
 			status = rsc_handler_table[rsc_type](rproc, hdr);

--- a/lib/rpmsg/rpmsg.c
+++ b/lib/rpmsg/rpmsg.c
@@ -137,7 +137,7 @@ int rpmsg_send_offchannel_raw(struct rpmsg_endpoint *ept, uint32_t src,
 
 int rpmsg_send_ns_message(struct rpmsg_endpoint *ept, unsigned long flags)
 {
-	struct rpmsg_ns_msg ns_msg;
+	struct rpmsg_ns_msg ns_msg = { 0 };
 	int ret;
 
 	ns_msg.flags = flags;

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -231,6 +231,8 @@ static void *rpmsg_virtio_get_rx_buffer(struct rpmsg_virtio_device *rvdev,
 
 	if (VIRTIO_ROLE_IS_DRIVER(rvdev->vdev)) {
 		data = virtqueue_get_buffer(rvdev->rvq, len, idx);
+		if (data && *len > rvdev->config.r2h_buf_size)
+			*len = rvdev->config.r2h_buf_size;
 	}
 
 	if (VIRTIO_ROLE_IS_DEVICE(rvdev->vdev)) {
@@ -576,6 +578,17 @@ static void rpmsg_virtio_rx_callback(struct virtqueue *vq)
 				virtqueue_kick(rvdev->rvq);
 			metal_mutex_release(&rdev->lock);
 			break;
+		}
+		if (len < sizeof(*rp_hdr) ||
+		    rp_hdr->len > len - sizeof(*rp_hdr)) {
+			len = virtqueue_get_buffer_length(rvdev->rvq, idx);
+			rpmsg_virtio_return_buffer(rvdev, rp_hdr, len, idx);
+			if (VIRTIO_ENABLED(VQ_RX_EMPTY_NOTIFY))
+				release = true;
+			else
+				virtqueue_kick(rvdev->rvq);
+			metal_mutex_release(&rdev->lock);
+			continue;
 		}
 
 		rp_hdr->reserved = idx;

--- a/lib/rpmsg/rpmsg_virtio.c
+++ b/lib/rpmsg/rpmsg_virtio.c
@@ -653,7 +653,12 @@ static int rpmsg_virtio_ns_callback(struct rpmsg_endpoint *ept, void *data,
 		return RPMSG_SUCCESS;
 	metal_io_block_read(io,
 			    metal_io_virt_to_offset(io, ns_msg->name),
-			    &name, sizeof(name));
+			    &name, sizeof(ns_msg->name));
+	/*
+	 * Don't trust the remote processor for null terminating the name.
+	 * Match upstream Linux RPMsg by terminating within the name field.
+	 */
+	name[RPMSG_NAME_SIZE - 1] = '\0';
 	dest = ns_msg->addr;
 
 	/* check if a Ept has been locally registered */

--- a/lib/service/rpmsg/rpc/rpmsg_rpc_client.c
+++ b/lib/service/rpmsg/rpc/rpmsg_rpc_client.c
@@ -53,12 +53,16 @@ int rpmsg_rpc_client_send(struct rpmsg_rpc_clt *rpc,
 {
 	unsigned char tmpbuf[MAX_BUF_LEN];
 
-	if (!rpc)
+	if (!rpc || (!request_param && req_param_size != 0))
+		return -EINVAL;
+	/* Reserve space for the function ID before copying parameters. */
+	if (req_param_size > MAX_BUF_LEN - MAX_FUNC_ID_LEN)
 		return -EINVAL;
 
 	/* to optimize with the zero copy API */
 	memcpy(tmpbuf, &rpc_id, MAX_FUNC_ID_LEN);
-	memcpy(&tmpbuf[MAX_FUNC_ID_LEN], request_param, req_param_size);
+	if (req_param_size != 0)
+		memcpy(&tmpbuf[MAX_FUNC_ID_LEN], request_param, req_param_size);
 	return rpmsg_send(&rpc->ept, tmpbuf, MAX_FUNC_ID_LEN + req_param_size);
 }
 

--- a/lib/service/rpmsg/rpc/rpmsg_rpc_client.c
+++ b/lib/service/rpmsg/rpc/rpmsg_rpc_client.c
@@ -93,6 +93,8 @@ static int rpmsg_endpoint_client_cb(struct rpmsg_endpoint *ept,
 	struct rpmsg_rpc_clt *rpc;
 	const struct rpmsg_rpc_client_services *service;
 	struct rpmsg_rpc_answer *msg;
+	size_t header_size;
+	size_t params_len;
 	(void)priv;
 	(void)src;
 
@@ -100,6 +102,11 @@ static int rpmsg_endpoint_client_cb(struct rpmsg_endpoint *ept,
 		return -EINVAL;
 
 	msg = (struct rpmsg_rpc_answer *)data;
+	header_size = sizeof(*msg) - sizeof(msg->params);
+	/* Validate the fixed header before reading its fields. */
+	if (len < header_size)
+		return -EINVAL;
+	params_len = len - header_size;
 
 	rpc = metal_container_of(ept,
 				 struct rpmsg_rpc_clt,
@@ -108,8 +115,8 @@ static int rpmsg_endpoint_client_cb(struct rpmsg_endpoint *ept,
 	if (!service)
 		return -EINVAL;
 
-	/* Invoke the callback function of the rpc */
-	service->cb(rpc, msg->status, msg->params, len);
+	/* Pass only bytes following the fixed reply header. */
+	service->cb(rpc, msg->status, msg->params, params_len);
 
 	return RPMSG_SUCCESS;
 }

--- a/lib/service/rpmsg/rpc/rpmsg_rpc_server.c
+++ b/lib/service/rpmsg/rpc/rpmsg_rpc_server.c
@@ -51,14 +51,14 @@ static int rpmsg_endpoint_server_cb(struct rpmsg_endpoint *ept, void *data,
 				    size_t len,
 				    uint32_t src, void *priv)
 {
-	unsigned char buf[MAX_BUF_LEN];
+	unsigned char buf[MAX_BUF_LEN] = { 0 };
 	unsigned int id;
 	const struct rpmsg_rpc_services *service;
 	struct rpmsg_rpc_svr *rpcs;
 	(void)priv;
 	(void)src;
 
-	if (len > MAX_BUF_LEN)
+	if (len < MAX_FUNC_ID_LEN || len > MAX_BUF_LEN)
 		return -EINVAL;
 
 	rpcs = metal_container_of(ept, struct rpmsg_rpc_svr, ept);

--- a/lib/utils/utilities.c
+++ b/lib/utils/utilities.c
@@ -27,7 +27,8 @@ size_t safe_strcpy(char *dst, size_t d_size, const char *src, size_t s_size)
 
 	/* Fill last characters with '\0' */
 	if (size < d_size)
-		memset(dst, '\0',  d_size - size + nleft);
+		/* Clear only bytes remaining after the copied data. */
+		memset(dst, '\0', d_size - (size_t)(dst - d));
 	else
 		d[d_size - 1] = '\0';
 

--- a/lib/virtio/virtqueue.c
+++ b/lib/virtio/virtqueue.c
@@ -51,6 +51,12 @@ int virtqueue_create(struct virtio_device *virt_dev, unsigned short id,
 	int status = VQUEUE_SUCCESS;
 
 	VQ_PARAM_CHK(ring == NULL, status, ERROR_VQUEUE_INVLD_PARAM);
+	if (!ring)
+		return ERROR_VQUEUE_INVLD_PARAM;
+	/* vring_init() requires a nonzero power-of-two alignment. */
+	if (ring->align == 0 || (ring->align & (ring->align - 1)) != 0)
+		return ERROR_VRING_ALIGN;
+
 	VQ_PARAM_CHK(ring->num_descs == 0, status, ERROR_VQUEUE_INVLD_PARAM);
 	VQ_PARAM_CHK(ring->num_descs & (ring->num_descs - 1), status,
 		     ERROR_VRING_ALIGN);

--- a/lib/virtio_mmio/virtio_mmio_drv.c
+++ b/lib/virtio_mmio/virtio_mmio_drv.c
@@ -213,16 +213,24 @@ int virtio_mmio_device_init(struct virtio_mmio_device *vmdev, uintptr_t virt_mem
 }
 
 /* Register preallocated virtqueues */
-void virtio_mmio_register_device(struct virtio_device *vdev, int vq_num, struct virtqueue **vqs)
+int virtio_mmio_register_device(struct virtio_device *vdev, int vq_num, struct virtqueue **vqs)
 {
+	struct virtio_vring_info *vrings_info;
 	int i;
 
-	vdev->vrings_info = metal_allocate_memory(sizeof(struct virtio_vring_info) * vq_num);
-	/* TODO: handle error case */
+	if (!vdev || !vqs || vq_num <= 0)
+		return -EINVAL;
+	vrings_info = metal_allocate_memory(sizeof(*vrings_info) * vq_num);
+	if (!vrings_info)
+		return -ENOMEM;
+
 	for (i = 0; i < vq_num; i++) {
-		vdev->vrings_info[i].vq = vqs[i];
+		vrings_info[i].vq = vqs[i];
 	}
+	vdev->vrings_info = vrings_info;
 	vdev->vrings_num = vq_num;
+
+	return 0;
 }
 
 struct virtqueue *virtio_mmio_setup_virtqueue(struct virtio_device *vdev,
@@ -236,8 +244,13 @@ struct virtqueue *virtio_mmio_setup_virtqueue(struct virtio_device *vdev,
 	struct virtio_vring_info _vring_info = {0};
 	struct virtio_vring_info *vring_info = &_vring_info;
 	struct vring_alloc_info *vring_alloc_info;
-	struct virtio_mmio_device *vmdev = metal_container_of(vdev,
-							      struct virtio_mmio_device, vdev);
+	struct virtio_mmio_device *vmdev;
+
+	if (!vdev || !vdev->vrings_info || idx >= vdev->vrings_num) {
+		metal_log(METAL_LOG_ERROR, "Invalid virtqueue index\n");
+		return NULL;
+	}
+	vmdev = metal_container_of(vdev, struct virtio_mmio_device, vdev);
 
 	if (vdev->role != (unsigned int)VIRTIO_DEV_DRIVER) {
 		metal_log(METAL_LOG_ERROR, "Only VIRTIO_DEV_DRIVER is currently supported\n");
@@ -300,8 +313,11 @@ struct virtqueue *virtio_mmio_setup_virtqueue(struct virtio_device *vdev,
 			    ((uintptr_t)metal_io_virt_to_phys(&vmdev->shm_io,
 			    (char *)vq->vq_ring.desc)) / 4096);
 
-	vdev->vrings_info[vdev->vrings_num].vq = vq;
-	vdev->vrings_num++;
+	/*
+	 * Registration already set vrings_num to the allocated slot count.
+	 * Configuring a slot does not increase that count.
+	 */
+	vdev->vrings_info[idx].vq = vq;
 	virtqueue_enable_cb(vq);
 
 	return vq;
@@ -341,7 +357,7 @@ static int virtio_mmio_create_virtqueues(struct virtio_device *vdev, unsigned in
 
 	(void)flags;
 
-	if (!vdev || !names || !vdev->vrings_info)
+	if (!vdev || !names || !vdev->vrings_info || nvqs > vdev->vrings_num)
 		return -EINVAL;
 
 	for (i = 0; i < nvqs; i++) {


### PR DESCRIPTION
This series hardens OpenAMP paths that consume firmware-controlled                 
data, messages from a remote processor, and caller-provided lengths.               
These inputs cross trust boundaries in AMP systems. They must be                   
validated before memory access, allocation, or callback dispatch.                  
                                                                                   
The remoteproc changes validate ELF section-name offsets and header                
table entry sizes. They bound each resource-table entry before its                 
handler runs and reject unsafe vring alignments before size or pointer             
calculations. The checks cover fixed resources and variable-length                 
VDEV vring and configuration data.                                                 
                                                                                   
The RPMsg RPC and proxy changes reject malformed message lengths.                  
They initialize omitted request bytes, report callback payload lengths             
without protocol headers, and bound retarget read and write copies to              
both source and destination capacities. Name-service strings are                   
terminated before being passed to application callbacks.                           
                                                                                   
The remaining changes correct the safe_strcpy() zero-fill off-by-one.              
They also make virtio MMIO queue setup honor its allocated capacity                
instead of appending beyond it.                                                    
                                                                                   
Validation performed:                                                              
                                                                                   
- git diff --check on every patch                                                  
- CMake Debug build against local Libmetal with -Wall -Wextra                      
- static and shared OpenAMP library targets built successfully                     
- CTest invoked; this configuration provides no tests 