### PR TITLE
Use shell blocks for readme

### DIFF
--- a/.github/actions/build_ci/README.md
+++ b/.github/actions/build_ci/README.md
@@ -7,10 +7,12 @@ This action test builds for a specified target.
 ### `target`
 
 **Required** the build target. Default `"linux"`.
+
 The supported targets are:
-  linux
-  generic arm
-  zephyr
+
+* linux
+* generic arm
+* zephyr
 
 
 ## Example usage

--- a/.github/actions/build_ci/README.md
+++ b/.github/actions/build_ci/README.md
@@ -30,12 +30,12 @@ This should be cleaned up in a future PR.
 Desktop testing is possible but is likewise messy right now.
 
 One time setup, starting in open-amp directory:
-```
-$ git clone https://github.com/OpenAMP/libmetal.git
+```shell
+git clone https://github.com/OpenAMP/libmetal.git
 ```
 
 A sequence like below will work, change the "zephyr" at the end of the docker command line to "linux" or "generic" for the other working tests
-```
-$ docker build -t openamp-ci .github/actions/build_ci/ && docker run -it --rm -v$PWD:/prj -w /prj openamp-ci zephyr
-$ sudo rm -rf build* zephyr*
+```shell
+docker build -t openamp-ci .github/actions/build_ci/ && docker run -it --rm -v$PWD:/prj -w /prj openamp-ci zephyr
+sudo rm -rf build* zephyr*
 ```

--- a/README.md
+++ b/README.md
@@ -104,21 +104,21 @@ process.
 ### Example to compile OpenAMP for communication between Linux processes:
 * Install libsysfs devel and libhugetlbfs devel packages on your Linux host.
 * build libmetal library on your host as follows:
-  ```
-  $ mkdir -p build-libmetal
-  $ cd build-libmetal
-  $ cmake <libmetal_source>
-  $ make VERBOSE=1 DESTDIR=<libmetal_install> install
-  ```
+```shell
+mkdir -p build-libmetal
+cd build-libmetal
+cmake <libmetal_source>
+make VERBOSE=1 DESTDIR=<libmetal_install> install
+```
 
 * build OpenAMP library on your host as follows:
-   ```
-  $ mkdir -p build-openamp
-  $ cd build-openamp
-  $ cmake <openamp_source> -DCMAKE_INCLUDE_PATH=<libmetal_built_include_dir> \
-              -DCMAKE_LIBRARY_PATH=<libmetal_built_lib_dir>
-  $ make VERBOSE=1 DESTDIR=$(pwd) install
-  ```
+```shell
+mkdir -p build-openamp
+cd build-openamp
+cmake <openamp_source> -DCMAKE_INCLUDE_PATH=<libmetal_built_include_dir> \
+      -DCMAKE_LIBRARY_PATH=<libmetal_built_lib_dir>
+make VERBOSE=1 DESTDIR=$(pwd) install
+```
 The OpenAMP library will be generated to `build/usr/local/lib` directory,
 and the headers will be generated to `build/usr/local/include` directory.
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ instead of the full license text in the individual files:
 ### Signed-off-by
 Commit message must contain Signed-off-by: line and your email must match the change authorship
 information. Make sure your .gitconfig is set up correctly:
-  ```
+  ```shell
   git config --global user.name "first-name Last-Namer"
   git config --global user.email "yourmail@company.com"
   ```
@@ -175,7 +175,7 @@ Before you submit a pull request to the project, verify your commit messages mee
 The check can be  performed locally using the the gitlint command.
 
 Run gitlint locally in your tree and branch where your patches have been committed:
-  ```
+  ```shell
   gitlint
   ```
 Note, gitlint only checks HEAD (the most recent commit), so you should run it after each commit, or
@@ -191,7 +191,7 @@ The Linux kernel GPL-licensed tool checkpatch is used to check coding style conf
 available in the scripts directory.
 
 To check your \<n\> commits in your git branch:
-  ```
+  ```shell
   ./scripts/checkpatch.pl --strict  -g HEAD-<n>
   ```
 ### Send a pull request


### PR DESCRIPTION
To address documentation issues
https://github.com/OpenAMP/openamp-docs/issues/73
https://github.com/OpenAMP/openamp-docs/issues/84
Update code blocks to not use prompt ($) on command line so that github and IDE copy button provides exact command line.